### PR TITLE
Add persistent ephemeral node support to metadata store

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunk/ReadOnlyChunkImpl.java
@@ -365,7 +365,7 @@ public class ReadOnlyChunkImpl<T> implements Chunk<T> {
       handleChunkEviction(cacheSlotMetadata);
     }
     cacheSlotMetadataStore.removeListener(cacheSlotListener);
-    cacheSlotMetadataStore.close();
+    // the cacheSlotMetadataStore is a passed param, and shouldn't be closed here
     LOG.debug("Closed chunk");
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/CachingChunkManager.java
@@ -58,10 +58,10 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting caching chunk manager");
 
-    replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, meterRegistry);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, false, meterRegistry);
+    cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework, meterRegistry);
 
     for (int i = 0; i < slotCountPerInstance; i++) {
       chunkList.add(

--- a/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
+++ b/kaldb/src/main/java/com/slack/kaldb/chunkManager/IndexingChunkManager.java
@@ -387,8 +387,8 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting indexing chunk manager");
 
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, false, meterRegistry);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
 
     stopIngestion = false;
   }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStore.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore;
 import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
@@ -15,12 +16,14 @@ public class CacheSlotMetadataStore extends KaldbPartitioningMetadataStore<Cache
    * Initializes a cache slot metadata store at the CACHE_SLOT_ZK_PATH. This should be used to
    * create/update the cache slots, and for listening to all cache slot events.
    */
-  public CacheSlotMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
+  public CacheSlotMetadataStore(AsyncCuratorFramework curatorFramework, MeterRegistry meterRegistry)
+      throws Exception {
     super(
         curatorFramework,
         CreateMode.EPHEMERAL,
         new CacheSlotMetadataSerializer().toModelSerializer(),
-        CACHE_SLOT_ZK_PATH);
+        CACHE_SLOT_ZK_PATH,
+        meterRegistry);
   }
 
   /** Update the cache slot state, if the slot is not FREE. */

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/CuratorBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/CuratorBuilder.java
@@ -81,7 +81,6 @@ public class CuratorBuilder {
             });
 
     curator.start();
-
     LOG.info(
         "Started curator server with the following config zkhost: {}, path prefix: {}, "
             + "connection timeout ms: {}, session timeout ms {} and retry policy {}",

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/CuratorBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/CuratorBuilder.java
@@ -73,9 +73,13 @@ public class CuratorBuilder {
                   && curatorEvent.getWatchedEvent().getState()
                       == Watcher.Event.KeeperState.Expired) {
                 LOG.warn("The ZK session has expired {}.", curatorEvent);
-                new RuntimeHalterImpl().handleFatal(new Throwable("ZK session expired."));
+
+                if (!KaldbMetadataStore.persistentEphemeralModeEnabled()) {
+                  new RuntimeHalterImpl().handleFatal(new Throwable("ZK session expired."));
+                }
               }
             });
+
     curator.start();
 
     LOG.info(

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/KaldbMetadataStore.java
@@ -3,16 +3,21 @@ package com.slack.kaldb.metadata.core;
 import static com.slack.kaldb.server.KaldbConfig.DEFAULT_ZK_TIMEOUT_SECS;
 
 import com.slack.kaldb.util.RuntimeHalterImpl;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.curator.framework.recipes.nodes.PersistentNode;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.api.CreateOption;
 import org.apache.curator.x.async.modeled.ModelSerializer;
@@ -23,17 +28,30 @@ import org.apache.curator.x.async.modeled.cached.CachedModeledFramework;
 import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * KaldbMetadataStore is a class which provides consistent ZK apis for all the metadata store class.
  *
  * <p>Every method provides an async and a sync API. In general, use the async API you are
  * performing batch operations and a sync if you are performing a synchronous operation on a node.
+ *
+ * <p><a href="https://curator.apache.org/docs/recipes-persistent-node">Persistent node recipie</a>
  */
 public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(KaldbMetadataStore.class);
+
+  public static String PERSISTENT_EPHEMERAL_PROPERTY = "kaldb.metadata.persistentEphemeral";
   protected final String storeFolder;
 
   private final ZPath zPath;
+
+  private final CreateMode createMode;
+
+  private final AsyncCuratorFramework curator;
+
+  private final ModelSpec<T> modelSpec;
 
   private final CountDownLatch cacheInitialized = new CountDownLatch(1);
 
@@ -44,17 +62,26 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   private final Map<KaldbMetadataStoreChangeListener<T>, ModeledCacheListener<T>> listenerMap =
       new ConcurrentHashMap<>();
 
+  private final Map<String, PersistentNode> persistentNodeMap = new ConcurrentHashMap<>();
+
+  public static final String PERSISTENT_NODE_RECREATED_COUNTER =
+      "metadata_persistent_node_recreated";
+  private final Counter persistentNodeRecreatedCounter;
+
   public KaldbMetadataStore(
       AsyncCuratorFramework curator,
       CreateMode createMode,
       boolean shouldCache,
       ModelSerializer<T> modelSerializer,
-      String storeFolder) {
+      String storeFolder,
+      MeterRegistry meterRegistry) {
 
+    this.createMode = createMode;
+    this.curator = curator;
     this.storeFolder = storeFolder;
     this.zPath = ZPath.parseWithIds(String.format("%s/{name}", storeFolder));
 
-    ModelSpec<T> modelSpec =
+    this.modelSpec =
         ModelSpec.builder(modelSerializer)
             .withPath(zPath)
             .withCreateOptions(
@@ -70,11 +97,54 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
     } else {
       cachedModeledFramework = null;
     }
+
+    persistentNodeRecreatedCounter = meterRegistry.counter(PERSISTENT_NODE_RECREATED_COUNTER);
+    LOG.info(
+        "Persistent ephemeral mode '{}' enabled - {}",
+        PERSISTENT_EPHEMERAL_PROPERTY,
+        persistentEphemeralModeEnabled());
+  }
+
+  public static boolean persistentEphemeralModeEnabled() {
+    return Boolean.parseBoolean(System.getProperty(PERSISTENT_EPHEMERAL_PROPERTY, "true"));
   }
 
   public CompletionStage<String> createAsync(T metadataNode) {
-    // by passing the version 0, this will throw if we attempt to create and it already exists
-    return modeledClient.set(metadataNode, 0);
+    if (createMode == CreateMode.EPHEMERAL && persistentEphemeralModeEnabled()) {
+      String nodePath = resolvePath(metadataNode);
+      // persistent node already implements NodeDataChanged
+      PersistentNode node =
+          new PersistentNode(
+              curator.unwrap(),
+              createMode,
+              false,
+              nodePath,
+              modelSpec.serializer().serialize(metadataNode));
+      persistentNodeMap.put(nodePath, node);
+      node.start();
+      // todo - what happens when attempting to create over existing?
+      return CompletableFuture.supplyAsync(
+          () -> {
+            try {
+              node.waitForInitialCreate(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+              node.getListenable().addListener(_ -> persistentNodeRecreatedCounter.increment());
+              return nodePath;
+            } catch (Exception e) {
+              throw new CompletionException(e);
+            }
+          });
+    } else {
+      // by passing the version 0, this will throw if we attempt to create and it already exists
+      return modeledClient.set(metadataNode, 0);
+    }
+  }
+
+  // resolveForSet
+  private String resolvePath(T model) {
+    if (modelSpec.path().isResolved()) {
+      return modelSpec.path().fullPath();
+    }
+    return modelSpec.path().resolved(model).fullPath();
   }
 
   public void createSync(T metadataNode) {
@@ -120,7 +190,18 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   }
 
   public CompletionStage<Stat> updateAsync(T metadataNode) {
-    return modeledClient.update(metadataNode);
+    PersistentNode node = getPersistentNodeIfExists(metadataNode);
+    if (node != null) {
+      try {
+        node.waitForInitialCreate(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+        node.setData(modelSpec.serializer().serialize(metadataNode));
+        return CompletableFuture.completedFuture(null);
+      } catch (Exception e) {
+        throw new CompletionException(e);
+      }
+    } else {
+      return modeledClient.update(metadataNode);
+    }
   }
 
   public void updateSync(T metadataNode) {
@@ -134,7 +215,18 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   }
 
   public CompletionStage<Void> deleteAsync(String path) {
-    return modeledClient.withPath(zPath.resolved(path)).delete();
+    PersistentNode node = removePersistentNodeIfExists(path);
+    if (node != null) {
+      try {
+        node.waitForInitialCreate(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+        node.close();
+        return CompletableFuture.completedFuture(null);
+      } catch (Exception e) {
+        throw new CompletionException(e);
+      }
+    } else {
+      return modeledClient.withPath(zPath.resolved(path)).delete();
+    }
   }
 
   public void deleteSync(String path) {
@@ -146,7 +238,18 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
   }
 
   public CompletionStage<Void> deleteAsync(T metadataNode) {
-    return modeledClient.withPath(zPath.resolved(metadataNode)).delete();
+    PersistentNode node = removePersistentNodeIfExists(metadataNode);
+    if (node != null) {
+      try {
+        node.waitForInitialCreate(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+        node.close();
+        return CompletableFuture.completedFuture(null);
+      } catch (Exception e) {
+        throw new CompletionException(e);
+      }
+    } else {
+      return modeledClient.withPath(zPath.resolved(metadataNode)).delete();
+    }
   }
 
   public void deleteSync(T metadataNode) {
@@ -210,6 +313,18 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
     }
   }
 
+  private PersistentNode getPersistentNodeIfExists(T metadataNode) {
+    return persistentNodeMap.getOrDefault(resolvePath(metadataNode), null);
+  }
+
+  private PersistentNode removePersistentNodeIfExists(T metadataNode) {
+    return persistentNodeMap.remove(resolvePath(metadataNode));
+  }
+
+  private PersistentNode removePersistentNodeIfExists(String path) {
+    return persistentNodeMap.remove(zPath.resolved(path).fullPath());
+  }
+
   private ModeledCacheListener<T> getCacheInitializedListener() {
     return new ModeledCacheListener<T>() {
       @Override
@@ -227,9 +342,17 @@ public class KaldbMetadataStore<T extends KaldbMetadata> implements Closeable {
 
   @Override
   public void close() {
+    persistentNodeMap.forEach(
+        (_, persistentNode) -> {
+          try {
+            persistentNode.close();
+          } catch (Exception ignored) {
+          }
+        });
+
     if (cachedModeledFramework != null) {
       listenerMap.forEach(
-          (kaldbMetadataStoreChangeListener, tModeledCacheListener) ->
+          (_, tModeledCacheListener) ->
               cachedModeledFramework.listenable().removeListener(tModeledCacheListener));
       cachedModeledFramework.close();
     }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/core/PersistentWatchedNode.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/core/PersistentWatchedNode.java
@@ -1,0 +1,97 @@
+package com.slack.kaldb.metadata.core;
+
+import com.slack.kaldb.util.RuntimeHalterImpl;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.nodes.PersistentNode;
+import org.apache.curator.framework.recipes.watch.PersistentWatcher;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PersistentWatchedNode implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PersistentWatchedNode.class);
+  private final PersistentNode node;
+  private PersistentWatcher watcher;
+
+  public static final String PERSISTENT_NODE_RECREATED_COUNTER =
+      "metadata_persistent_node_recreated";
+  private final Counter persistentNodeRecreatedCounter;
+
+  private final CuratorFramework givenClient;
+
+  public PersistentWatchedNode(
+      CuratorFramework givenClient,
+      final CreateMode mode,
+      boolean useProtection,
+      final String basePath,
+      byte[] initData,
+      MeterRegistry meterRegistry) {
+    this.givenClient = givenClient;
+    persistentNodeRecreatedCounter = meterRegistry.counter(PERSISTENT_NODE_RECREATED_COUNTER);
+    node = new PersistentNode(givenClient, mode, useProtection, basePath, initData);
+    node.getListenable().addListener(_ -> persistentNodeRecreatedCounter.increment());
+  }
+
+  private Watcher nodeWatcher() {
+    return event -> {
+      try {
+        if (event.getType() == Watcher.Event.EventType.NodeDataChanged) {
+          // get data
+          givenClient
+              .getData()
+              .inBackground(
+                  (_, event1) -> {
+                    if (node.getActualPath() != null) {
+                      byte[] updatedBytes = event1.getData();
+                      if (!Arrays.equals(node.getData(), updatedBytes)) {
+                        // only trigger a setData if something actually
+                        // changed, otherwise we end up in a deathloop
+                        node.setData(updatedBytes);
+                      }
+                    }
+                  })
+              .forPath(event.getPath());
+        }
+      } catch (Exception e) {
+        LOG.info("Error", e);
+        new RuntimeHalterImpl().handleFatal(e);
+      }
+    };
+  }
+
+  public void start() {
+    node.start();
+    try {
+      node.waitForInitialCreate(30, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    watcher = new PersistentWatcher(givenClient, node.getActualPath(), false);
+    watcher.start();
+    watcher.getListenable().addListener(nodeWatcher());
+  }
+
+  public void setData(byte[] data) throws Exception {
+    node.setData(data);
+  }
+
+  public byte[] getData() {
+    return node.getData();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
+    node.close();
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/dataset/DatasetMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.metadata.dataset;
 
 import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -8,12 +9,15 @@ public class DatasetMetadataStore extends KaldbMetadataStore<DatasetMetadata> {
   // TODO: The path should be dataset, but leaving it as /service for backwards compatibility.
   public static final String DATASET_METADATA_STORE_ZK_PATH = "/service";
 
-  public DatasetMetadataStore(AsyncCuratorFramework curator, boolean shouldCache) throws Exception {
+  public DatasetMetadataStore(
+      AsyncCuratorFramework curator, boolean shouldCache, MeterRegistry meterRegistry)
+      throws Exception {
     super(
         curator,
         CreateMode.PERSISTENT,
         shouldCache,
         new DatasetMetadataSerializer().toModelSerializer(),
-        DATASET_METADATA_STORE_ZK_PATH);
+        DATASET_METADATA_STORE_ZK_PATH,
+        meterRegistry);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/hpa/HpaMetricMetadataStore.java
@@ -1,18 +1,21 @@
 package com.slack.kaldb.metadata.hpa;
 
 import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class HpaMetricMetadataStore extends KaldbMetadataStore<HpaMetricMetadata> {
   public static final String AUTOSCALER_METADATA_STORE_ZK_PATH = "/hpa_metrics";
 
-  public HpaMetricMetadataStore(AsyncCuratorFramework curator, boolean shouldCache) {
+  public HpaMetricMetadataStore(
+      AsyncCuratorFramework curator, boolean shouldCache, MeterRegistry meterRegistry) {
     super(
         curator,
         CreateMode.EPHEMERAL,
         shouldCache,
         new HpaMetricMetadataSerializer().toModelSerializer(),
-        AUTOSCALER_METADATA_STORE_ZK_PATH);
+        AUTOSCALER_METADATA_STORE_ZK_PATH,
+        meterRegistry);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.metadata.recovery;
 
 import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -11,13 +12,15 @@ public class RecoveryNodeMetadataStore extends KaldbMetadataStore<RecoveryNodeMe
    * Initializes a recovery node metadata store at the RECOVERY_NODE_ZK_PATH. This should be used to
    * create/update the recovery nodes, and for listening to all recovery node events.
    */
-  public RecoveryNodeMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache) {
+  public RecoveryNodeMetadataStore(
+      AsyncCuratorFramework curatorFramework, boolean shouldCache, MeterRegistry meterRegistry) {
     super(
         curatorFramework,
         CreateMode.EPHEMERAL,
         shouldCache,
         new RecoveryNodeMetadataSerializer().toModelSerializer(),
-        RECOVERY_NODE_ZK_PATH);
+        RECOVERY_NODE_ZK_PATH,
+        meterRegistry);
   }
 
   /**
@@ -26,12 +29,16 @@ public class RecoveryNodeMetadataStore extends KaldbMetadataStore<RecoveryNodeMe
    * mutating any nodes.
    */
   public RecoveryNodeMetadataStore(
-      AsyncCuratorFramework curatorFramework, String recoveryNodeName, boolean shouldCache) {
+      AsyncCuratorFramework curatorFramework,
+      String recoveryNodeName,
+      boolean shouldCache,
+      MeterRegistry meterRegistry) {
     super(
         curatorFramework,
         CreateMode.EPHEMERAL,
         shouldCache,
         new RecoveryNodeMetadataSerializer().toModelSerializer(),
-        String.format("%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName));
+        String.format("%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName),
+        meterRegistry);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/recovery/RecoveryTaskMetadataStore.java
@@ -1,19 +1,22 @@
 package com.slack.kaldb.metadata.recovery;
 
 import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class RecoveryTaskMetadataStore extends KaldbMetadataStore<RecoveryTaskMetadata> {
   public static final String RECOVERY_TASK_ZK_PATH = "/recoveryTask";
 
-  public RecoveryTaskMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache)
+  public RecoveryTaskMetadataStore(
+      AsyncCuratorFramework curatorFramework, boolean shouldCache, MeterRegistry meterRegistry)
       throws Exception {
     super(
         curatorFramework,
         CreateMode.PERSISTENT,
         shouldCache,
         new RecoveryTaskMetadataSerializer().toModelSerializer(),
-        RECOVERY_TASK_ZK_PATH);
+        RECOVERY_TASK_ZK_PATH,
+        meterRegistry);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/replica/ReplicaMetadataStore.java
@@ -1,17 +1,20 @@
 package com.slack.kaldb.metadata.replica;
 
 import com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class ReplicaMetadataStore extends KaldbPartitioningMetadataStore<ReplicaMetadata> {
   public static final String REPLICA_STORE_ZK_PATH = "/partitioned_replica";
 
-  public ReplicaMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
+  public ReplicaMetadataStore(AsyncCuratorFramework curatorFramework, MeterRegistry meterRegistry)
+      throws Exception {
     super(
         curatorFramework,
         CreateMode.PERSISTENT,
         new ReplicaMetadataSerializer().toModelSerializer(),
-        REPLICA_STORE_ZK_PATH);
+        REPLICA_STORE_ZK_PATH,
+        meterRegistry);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/search/SearchMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.metadata.search;
 
 import com.slack.kaldb.metadata.core.KaldbMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.zookeeper.CreateMode;
@@ -9,14 +10,16 @@ import org.apache.zookeeper.data.Stat;
 public class SearchMetadataStore extends KaldbMetadataStore<SearchMetadata> {
   public static final String SEARCH_METADATA_STORE_ZK_PATH = "/search";
 
-  public SearchMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache)
+  public SearchMetadataStore(
+      AsyncCuratorFramework curatorFramework, boolean shouldCache, MeterRegistry meterRegistry)
       throws Exception {
     super(
         curatorFramework,
         CreateMode.EPHEMERAL,
         shouldCache,
         new SearchMetadataSerializer().toModelSerializer(),
-        SEARCH_METADATA_STORE_ZK_PATH);
+        SEARCH_METADATA_STORE_ZK_PATH,
+        meterRegistry);
   }
 
   @Override

--- a/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStore.java
+++ b/kaldb/src/main/java/com/slack/kaldb/metadata/snapshot/SnapshotMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.kaldb.metadata.snapshot;
 
 import com.slack.kaldb.metadata.core.KaldbPartitioningMetadataStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -9,11 +10,13 @@ public class SnapshotMetadataStore extends KaldbPartitioningMetadataStore<Snapsh
 
   // TODO: Consider restricting the update methods to only update live nodes only?
 
-  public SnapshotMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
+  public SnapshotMetadataStore(AsyncCuratorFramework curatorFramework, MeterRegistry meterRegistry)
+      throws Exception {
     super(
         curatorFramework,
         CreateMode.PERSISTENT,
         new SnapshotMetadataSerializer().toModelSerializer(),
-        SNAPSHOT_METADATA_STORE_ZK_PATH);
+        SNAPSHOT_METADATA_STORE_ZK_PATH,
+        meterRegistry);
   }
 }

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -137,10 +137,12 @@ public class RecoveryService extends AbstractIdleService {
   protected void startUp() throws Exception {
     LOG.info("Starting recovery service");
 
-    recoveryNodeMetadataStore = new RecoveryNodeMetadataStore(curatorFramework, false);
-    recoveryTaskMetadataStore = new RecoveryTaskMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    recoveryNodeMetadataStore =
+        new RecoveryNodeMetadataStore(curatorFramework, false, meterRegistry);
+    recoveryTaskMetadataStore =
+        new RecoveryTaskMetadataStore(curatorFramework, false, meterRegistry);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, false, meterRegistry);
 
     recoveryNodeMetadataStore.createSync(
         new RecoveryNodeMetadata(
@@ -151,7 +153,8 @@ public class RecoveryService extends AbstractIdleService {
     recoveryNodeLastKnownState = Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
 
     recoveryNodeListenerMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, searchContext.hostname, true);
+        new RecoveryNodeMetadataStore(
+            curatorFramework, searchContext.hostname, true, meterRegistry);
     recoveryNodeListenerMetadataStore.addListener(recoveryNodeListener);
   }
 

--- a/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/recovery/RecoveryService.java
@@ -179,6 +179,13 @@ public class RecoveryService extends AbstractIdleService {
   private void recoveryNodeListener(RecoveryNodeMetadata recoveryNodeMetadata) {
     Metadata.RecoveryNodeMetadata.RecoveryNodeState newRecoveryNodeState =
         recoveryNodeMetadata.recoveryNodeState;
+    if (recoveryNodeLastKnownState.equals(recoveryNodeMetadata.recoveryNodeState)) {
+      // todo - consider moving this to a model where it deduplicates with a scheduled executor,
+      // similar to the manager
+      // This can fire duplicate events if the ephemeral node is re-created
+      LOG.info("Recovery node - listener fired with no state change, skipping event");
+      return;
+    }
 
     if (newRecoveryNodeState.equals(Metadata.RecoveryNodeMetadata.RecoveryNodeState.ASSIGNED)) {
       LOG.info("Recovery node - ASSIGNED received");

--- a/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/Kaldb.java
@@ -192,9 +192,12 @@ public class Kaldb {
     }
 
     if (roles.contains(KaldbConfigs.NodeRole.QUERY)) {
-      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+      SearchMetadataStore searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, true, meterRegistry);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      DatasetMetadataStore datasetMetadataStore =
+          new DatasetMetadataStore(curatorFramework, true, meterRegistry);
 
       services.add(
           new CloseableLifecycleManager(
@@ -237,7 +240,7 @@ public class Kaldb {
       services.add(chunkManager);
 
       HpaMetricMetadataStore hpaMetricMetadataStore =
-          new HpaMetricMetadataStore(curatorFramework, true);
+          new HpaMetricMetadataStore(curatorFramework, true, meterRegistry);
       services.add(
           new CloseableLifecycleManager(
               KaldbConfigs.NodeRole.CACHE, List.of(hpaMetricMetadataStore)));
@@ -266,16 +269,20 @@ public class Kaldb {
       final KaldbConfigs.ManagerConfig managerConfig = kaldbConfig.getManagerConfig();
       final int serverPort = managerConfig.getServerConfig().getServerPort();
 
-      ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      ReplicaMetadataStore replicaMetadataStore =
+          new ReplicaMetadataStore(curatorFramework, meterRegistry);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, meterRegistry);
       RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-          new RecoveryTaskMetadataStore(curatorFramework, true);
+          new RecoveryTaskMetadataStore(curatorFramework, true, meterRegistry);
       RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-          new RecoveryNodeMetadataStore(curatorFramework, true);
-      CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
-      DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+          new RecoveryNodeMetadataStore(curatorFramework, true, meterRegistry);
+      CacheSlotMetadataStore cacheSlotMetadataStore =
+          new CacheSlotMetadataStore(curatorFramework, meterRegistry);
+      DatasetMetadataStore datasetMetadataStore =
+          new DatasetMetadataStore(curatorFramework, true, meterRegistry);
       HpaMetricMetadataStore hpaMetricMetadataStore =
-          new HpaMetricMetadataStore(curatorFramework, true);
+          new HpaMetricMetadataStore(curatorFramework, true, meterRegistry);
 
       Duration requestTimeout =
           Duration.ofMillis(kaldbConfig.getManagerConfig().getServerConfig().getRequestTimeoutMs());
@@ -372,7 +379,8 @@ public class Kaldb {
     }
 
     if (roles.contains(KaldbConfigs.NodeRole.PREPROCESSOR)) {
-      DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+      DatasetMetadataStore datasetMetadataStore =
+          new DatasetMetadataStore(curatorFramework, true, meterRegistry);
 
       final KaldbConfigs.PreprocessorConfig preprocessorConfig =
           kaldbConfig.getPreprocessorConfig();

--- a/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
+++ b/kaldb/src/main/java/com/slack/kaldb/server/KaldbIndexer.java
@@ -93,9 +93,10 @@ public class KaldbIndexer extends AbstractExecutionThreadService {
    */
   private long indexerPreStart() throws Exception {
     LOG.info("Starting Kaldb indexer pre start.");
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, true);
+        new RecoveryTaskMetadataStore(curatorFramework, true, meterRegistry);
 
     String partitionId = kafkaConfig.getKafkaTopicPartition();
     long maxOffsetDelay = indexerConfig.getMaxOffsetDelayMessages();

--- a/kaldb/src/test/java/com/slack/kaldb/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -90,7 +90,7 @@ class BulkIngestKafkaProducerTest {
             .setRateLimiterMaxBurstSeconds(1)
             .build();
 
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true, meterRegistry);
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
             INDEX_NAME,

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/IndexingChunkImplTest.java
@@ -70,6 +70,8 @@ public class IndexingChunkImplTest {
   private static final Duration COMMIT_INTERVAL = Duration.ofSeconds(5 * 60);
   private static final Duration REFRESH_INTERVAL = Duration.ofSeconds(5 * 60);
 
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
   private static void testBeforeSnapshotState(
       SnapshotMetadataStore snapshotMetadataStore,
       SearchMetadataStore searchMetadataStore,
@@ -112,8 +114,10 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      SearchMetadataStore searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, true, meterRegistry);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -456,8 +460,10 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      SearchMetadataStore searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, true, meterRegistry);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -540,8 +546,8 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, true, meterRegistry);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -154,8 +154,11 @@ public class ReadOnlyChunkImplTest {
 
     // ensure that the chunk was marked LIVE
     await().until(() -> KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore).size() == 1);
-    assertThat(readOnlyChunk.getChunkMetadataState())
-        .isEqualTo(Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getChunkMetadataState()
+                    == Metadata.CacheSlotMetadata.CacheSlotState.LIVE);
 
     SearchResult<LogMessage> logMessageSearchResult =
         readOnlyChunk.query(
@@ -230,6 +233,10 @@ public class ReadOnlyChunkImplTest {
     assertThat(meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful", "false").timer().count())
         .isEqualTo(0);
 
+    cacheSlotMetadataStore.close();
+    searchMetadataStore.close();
+    snapshotMetadataStore.close();
+    replicaMetadataStore.close();
     curatorFramework.unwrap().close();
   }
 
@@ -300,6 +307,10 @@ public class ReadOnlyChunkImplTest {
     assertThat(meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful", "false").timer().count())
         .isEqualTo(1);
 
+    cacheSlotMetadataStore.close();
+    searchMetadataStore.close();
+    snapshotMetadataStore.close();
+    replicaMetadataStore.close();
     curatorFramework.unwrap().close();
   }
 
@@ -370,6 +381,10 @@ public class ReadOnlyChunkImplTest {
     assertThat(meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful", "false").timer().count())
         .isEqualTo(1);
 
+    cacheSlotMetadataStore.close();
+    searchMetadataStore.close();
+    snapshotMetadataStore.close();
+    replicaMetadataStore.close();
     curatorFramework.unwrap().close();
   }
 
@@ -473,6 +488,10 @@ public class ReadOnlyChunkImplTest {
       assertThat(files.findFirst().isPresent()).isFalse();
     }
 
+    cacheSlotMetadataStore.close();
+    searchMetadataStore.close();
+    snapshotMetadataStore.close();
+    replicaMetadataStore.close();
     curatorFramework.unwrap().close();
   }
 

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/ReadOnlyChunkImplTest.java
@@ -110,10 +110,14 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, meterRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, true, meterRegistry);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -242,10 +246,14 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, meterRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, true, meterRegistry);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -308,10 +316,14 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, meterRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, true, meterRegistry);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -374,10 +386,14 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, meterRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, true, meterRegistry);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -500,7 +516,8 @@ public class ReadOnlyChunkImplTest {
 
   private void initializeZkSnapshot(AsyncCuratorFramework curatorFramework, String snapshotId)
       throws Exception {
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     snapshotMetadataStore.createSync(
         new SnapshotMetadata(
             snapshotId,
@@ -515,7 +532,8 @@ public class ReadOnlyChunkImplTest {
   private void initializeZkReplica(
       AsyncCuratorFramework curatorFramework, String replicaId, String snapshotId)
       throws Exception {
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, meterRegistry);
     replicaMetadataStore.createSync(
         new ReplicaMetadata(
             replicaId,

--- a/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunk/RecoveryChunkImplTest.java
@@ -64,6 +64,8 @@ public class RecoveryChunkImplTest {
   private static final Duration COMMIT_INTERVAL = Duration.ofSeconds(5 * 60);
   private static final Duration REFRESH_INTERVAL = Duration.ofSeconds(5 * 60);
 
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
   @Nested
   public class BasicTests {
     @TempDir private Path tmpPath;
@@ -92,8 +94,8 @@ public class RecoveryChunkImplTest {
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, false, meterRegistry);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -445,8 +447,8 @@ public class RecoveryChunkImplTest {
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, false, meterRegistry);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -531,8 +533,8 @@ public class RecoveryChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, meterRegistry);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, true, meterRegistry);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/IndexingChunkManagerTest.java
@@ -136,8 +136,8 @@ public class IndexingChunkManagerTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, metricsRegistry);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, false, metricsRegistry);
   }
 
   @AfterEach
@@ -1260,8 +1260,10 @@ public class IndexingChunkManagerTest {
     assertThat(rollOverFuture.isDone()).isTrue();
 
     // The stores are closed so temporarily re-create them so we can query the data in ZK.
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, false, metricsRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, metricsRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
     List<SnapshotMetadata> snapshots =
         KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
@@ -1313,8 +1315,10 @@ public class IndexingChunkManagerTest {
 
     // The stores are closed so temporarily re-create them so we can query the data in ZK.
     // All ephemeral data is ZK is deleted and no data or metadata is persisted.
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, false, metricsRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, metricsRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
     searchMetadataStore.close();

--- a/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/chunkManager/RecoveryChunkManagerTest.java
@@ -108,8 +108,8 @@ public class RecoveryChunkManagerTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, false, metricsRegistry);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, metricsRegistry);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ClusterHpaMetricServiceTest.java
@@ -56,9 +56,9 @@ class ClusterHpaMetricServiceTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, meterRegistry));
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true, meterRegistry));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -63,8 +63,10 @@ public class RecoveryTaskAssignmentServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    recoveryTaskMetadataStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
-    recoveryNodeMetadataStore = spy(new RecoveryNodeMetadataStore(curatorFramework, true));
+    recoveryTaskMetadataStore =
+        spy(new RecoveryTaskMetadataStore(curatorFramework, true, meterRegistry));
+    recoveryNodeMetadataStore =
+        spy(new RecoveryNodeMetadataStore(curatorFramework, true, meterRegistry));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaAssignmentServiceTest.java
@@ -71,8 +71,8 @@ public class ReplicaAssignmentServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, meterRegistry));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaCreationServiceTest.java
@@ -68,8 +68,8 @@ public class ReplicaCreationServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, meterRegistry));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
   }
 
   @AfterEach
@@ -84,8 +84,10 @@ public class ReplicaCreationServiceTest {
 
   @Test
   public void shouldDoNothingIfReplicasAlreadyExist() throws Exception {
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, meterRegistry);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
 
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaDeletionServiceTest.java
@@ -66,8 +66,8 @@ public class ReplicaDeletionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, meterRegistry));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaEvictionServiceTest.java
@@ -67,8 +67,8 @@ public class ReplicaEvictionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, meterRegistry));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/ReplicaRestoreServiceTest.java
@@ -70,7 +70,7 @@ public class ReplicaRestoreServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/clusterManager/SnapshotDeletionServiceTest.java
@@ -87,8 +87,8 @@ public class SnapshotDeletionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, meterRegistry));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
 
     s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
     s3CrtBlobFs = spy(new S3CrtBlobFs(s3AsyncClient));

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -88,9 +88,9 @@ public class KaldbDistributedQueryServiceTest {
 
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
 
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, true));
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, metricsRegistry));
+    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, true, metricsRegistry));
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true, metricsRegistry);
 
     indexer1SearchContext = new SearchContext("indexer_host1", 10000);
     indexer2SearchContext = new SearchContext("indexer_host2", 10001);

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -47,7 +47,7 @@ public class CacheSlotMetadataStoreTest {
             .setSleepBetweenRetriesMs(500)
             .build();
     this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
-    this.store = new CacheSlotMetadataStore(curatorFramework);
+    this.store = new CacheSlotMetadataStore(curatorFramework, meterRegistry);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -52,6 +52,7 @@ public class CacheSlotMetadataStoreTest {
 
   @AfterEach
   public void tearDown() throws IOException {
+    store.close();
     curatorFramework.unwrap().close();
     testingServer.close();
     meterRegistry.close();

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -200,6 +200,8 @@ class KaldbPartitioningMetadataStoreTest {
     curatorFramework.unwrap().close();
     testingServer.close();
     meterRegistry.close();
+    // clear any overrides
+    System.clearProperty(KaldbMetadataStore.PERSISTENT_EPHEMERAL_PROPERTY);
   }
 
   @Test
@@ -441,6 +443,7 @@ class KaldbPartitioningMetadataStoreTest {
 
   @Test
   void testListenersWithZkReconnect() throws Exception {
+    System.setProperty(KaldbMetadataStore.PERSISTENT_EPHEMERAL_PROPERTY, "true");
     class TestMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
       public TestMetadataStore() {
         super(

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/core/KaldbPartitioningMetadataStoreTest.java
@@ -26,7 +26,6 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.server.EphemeralType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,7 +209,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_znodes")) {
+            "/partitioned_znodes",
+            meterRegistry)) {
 
       int size = 50_000;
 
@@ -243,7 +243,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_create")) {
+            "/partitioned_create",
+            meterRegistry)) {
 
       ExampleMetadata exampleMetadata = new ExampleMetadata("id");
       partitionedMetadataStore.createSync(exampleMetadata);
@@ -266,7 +267,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_update")) {
+            "/partitioned_update",
+            meterRegistry)) {
 
       ExampleMetadata exampleMetadata = new ExampleMetadata("id");
       partitionedMetadataStore.createAsync(exampleMetadata);
@@ -298,7 +300,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_delete")) {
+            "/partitioned_delete",
+            meterRegistry)) {
 
       ExampleMetadata exampleMetadata = new ExampleMetadata("id");
       partitionedMetadataStore.createSync(exampleMetadata);
@@ -324,7 +327,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_find")) {
+            "/partitioned_find",
+            meterRegistry)) {
 
       String nodeName = "findme";
       ExampleMetadata exampleMetadataToFindLater = new ExampleMetadata(nodeName);
@@ -346,7 +350,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_find_missing")) {
+            "/partitioned_find_missing",
+            meterRegistry)) {
 
       assertThatExceptionOfType(InternalMetadataStoreException.class)
           .isThrownBy(() -> partitionedMetadataStore.findSync("missing"));
@@ -360,7 +365,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_snapshot_duplicate_create")) {
+            "/partitioned_snapshot_duplicate_create",
+            meterRegistry)) {
       ExampleMetadata exampleMetadata = new ExampleMetadata("name", "field");
       partitionedMetadataStore.createSync(exampleMetadata);
       await().until(() -> partitionedMetadataStore.listSync().size() == 1);
@@ -378,7 +384,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_persistent");
+            "/partitioned_persistent",
+            meterRegistry);
       }
     }
 
@@ -388,7 +395,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.EPHEMERAL,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_ephemeral");
+            "/partitioned_ephemeral",
+            meterRegistry);
       }
     }
 
@@ -432,7 +440,6 @@ class KaldbPartitioningMetadataStoreTest {
   }
 
   @Test
-  @Disabled("ZK reconnect support currently disabled")
   void testListenersWithZkReconnect() throws Exception {
     class TestMetadataStore extends KaldbPartitioningMetadataStore<ExampleMetadata> {
       public TestMetadataStore() {
@@ -440,7 +447,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_zk_reconnect");
+            "/partitioned_zk_reconnect",
+            meterRegistry);
       }
     }
 
@@ -478,7 +486,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_snapshot_listeners")) {
+            "/partitioned_snapshot_listeners",
+            meterRegistry)) {
 
       AtomicInteger counter = new AtomicInteger(0);
       partitionedMetadataStore.addListener(
@@ -581,7 +590,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
-            "/partitioned_add_remove_listeners");
+            "/partitioned_add_remove_listeners",
+            meterRegistry);
       }
     }
 
@@ -625,7 +635,8 @@ class KaldbPartitioningMetadataStoreTest {
             curatorFramework,
             CreateMode.PERSISTENT,
             new FixedPartitionMetadataSerializer().toModelSerializer(),
-            "/partitioned_duplicate_listeners");
+            "/partitioned_duplicate_listeners",
+            meterRegistry);
       }
     }
 

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -45,7 +45,7 @@ public class DatasetPartitionMetadataTest {
             .build();
 
     this.curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    this.datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    this.datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true, metricsRegistry);
   }
 
   @AfterEach

--- a/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/metadata/search/SearchMetadataStoreTest.java
@@ -45,7 +45,7 @@ public class SearchMetadataStoreTest {
 
   @Test
   public void testSearchMetadataStoreIsNotUpdatable() throws Exception {
-    store = new SearchMetadataStore(curatorFramework, true);
+    store = new SearchMetadataStore(curatorFramework, true, meterRegistry);
     SearchMetadata searchMetadata = new SearchMetadata("test", "snapshot", "http");
     Throwable exAsync = catchThrowable(() -> store.updateAsync(searchMetadata));
     assertThat(exAsync).isInstanceOf(UnsupportedOperationException.class);

--- a/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/preprocessor/PreprocessorServiceIntegrationTest.java
@@ -66,7 +66,8 @@ public class PreprocessorServiceIntegrationTest {
             .setSleepBetweenRetriesMs(100)
             .build();
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    DatasetMetadataStore datasetMetadataStore =
+        new DatasetMetadataStore(curatorFramework, true, meterRegistry);
 
     KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
         KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
@@ -132,7 +133,8 @@ public class PreprocessorServiceIntegrationTest {
             .setSleepBetweenRetriesMs(30000)
             .build();
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    DatasetMetadataStore datasetMetadataStore =
+        new DatasetMetadataStore(curatorFramework, true, meterRegistry);
 
     KaldbConfigs.PreprocessorConfig.KafkaStreamConfig kafkaStreamConfig =
         KaldbConfigs.PreprocessorConfig.KafkaStreamConfig.newBuilder()
@@ -192,7 +194,8 @@ public class PreprocessorServiceIntegrationTest {
             .setSleepBetweenRetriesMs(30000)
             .build();
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    DatasetMetadataStore datasetMetadataStore =
+        new DatasetMetadataStore(curatorFramework, true, meterRegistry);
 
     // initialize the downstream topic
     String downstreamTopic = "test-topic-out";

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -165,7 +165,8 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
@@ -238,7 +239,8 @@ public class RecoveryServiceTest {
     await()
         .until(() -> localTestConsumer.getEndOffSetForPartition() == msgsToProduce + msgsToProduce);
 
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery service
@@ -321,7 +323,8 @@ public class RecoveryServiceTest {
     await()
         .until(() -> localTestConsumer.getEndOffSetForPartition() == msgsToProduce + msgsToProduce);
 
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery service
@@ -376,7 +379,8 @@ public class RecoveryServiceTest {
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name())
         .isNotEqualTo(fakeS3Bucket);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery
@@ -413,13 +417,14 @@ public class RecoveryServiceTest {
 
     assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(curatorFramework, false, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -431,7 +436,7 @@ public class RecoveryServiceTest {
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, false);
+        new RecoveryNodeMetadataStore(curatorFramework, false, meterRegistry);
     List<RecoveryNodeMetadata> recoveryNodes =
         KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);
@@ -498,13 +503,14 @@ public class RecoveryServiceTest {
     // fakeS3Bucket is not present.
     assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     assertThat(KaldbMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(curatorFramework, false, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -516,7 +522,7 @@ public class RecoveryServiceTest {
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, false);
+        new RecoveryNodeMetadataStore(curatorFramework, false, meterRegistry);
     List<RecoveryNodeMetadata> recoveryNodes =
         KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);
@@ -668,7 +674,7 @@ public class RecoveryServiceTest {
 
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(curatorFramework, false, meterRegistry);
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 0, 0, Instant.now().toEpochMilli());
@@ -680,7 +686,7 @@ public class RecoveryServiceTest {
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, false);
+        new RecoveryNodeMetadataStore(curatorFramework, false, meterRegistry);
     List<RecoveryNodeMetadata> recoveryNodes =
         KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);

--- a/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/recovery/RecoveryServiceTest.java
@@ -184,6 +184,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(ROLLOVERS_INITIATED, meterRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_COMPLETED, meterRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_FAILED, meterRegistry)).isEqualTo(0);
+
+    snapshotMetadataStore.close();
   }
 
   @Test
@@ -269,6 +271,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(ROLLOVERS_INITIATED, meterRegistry)).isEqualTo(0);
     assertThat(getCount(ROLLOVERS_COMPLETED, meterRegistry)).isEqualTo(0);
     assertThat(getCount(ROLLOVERS_FAILED, meterRegistry)).isEqualTo(0);
+
+    snapshotMetadataStore.close();
   }
 
   @Test
@@ -357,6 +361,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(ROLLOVERS_INITIATED, meterRegistry)).isEqualTo(0);
     assertThat(getCount(ROLLOVERS_COMPLETED, meterRegistry)).isEqualTo(0);
     assertThat(getCount(ROLLOVERS_FAILED, meterRegistry)).isEqualTo(0);
+
+    snapshotMetadataStore.close();
   }
 
   @Test
@@ -398,6 +404,8 @@ public class RecoveryServiceTest {
     assertThat(getCount(ROLLOVERS_INITIATED, meterRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_COMPLETED, meterRegistry)).isEqualTo(0);
     assertThat(getCount(ROLLOVERS_FAILED, meterRegistry)).isEqualTo(1);
+
+    snapshotMetadataStore.close();
   }
 
   @Test
@@ -482,6 +490,10 @@ public class RecoveryServiceTest {
     assertThat(getCount(ROLLOVERS_INITIATED, meterRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_COMPLETED, meterRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_FAILED, meterRegistry)).isEqualTo(0);
+
+    snapshotMetadataStore.close();
+    recoveryTaskMetadataStore.close();
+    recoveryNodeMetadataStore.close();
   }
 
   @Test
@@ -571,6 +583,10 @@ public class RecoveryServiceTest {
     assertThat(getCount(ROLLOVERS_INITIATED, meterRegistry)).isEqualTo(1);
     assertThat(getCount(ROLLOVERS_COMPLETED, meterRegistry)).isEqualTo(0);
     assertThat(getCount(ROLLOVERS_FAILED, meterRegistry)).isEqualTo(1);
+
+    snapshotMetadataStore.close();
+    recoveryTaskMetadataStore.close();
+    recoveryNodeMetadataStore.close();
   }
 
   @Test
@@ -709,11 +725,17 @@ public class RecoveryServiceTest {
     // Post recovery checks
     assertThat(KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore).size())
         .isEqualTo(1);
-    assertThat(
-            KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore)
-                .get(0)
-                .recoveryNodeState)
-        .isEqualTo(Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
+
+    await()
+        .until(
+            () ->
+                KaldbMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore)
+                        .get(0)
+                        .recoveryNodeState
+                    == Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE);
+
+    recoveryNodeMetadataStore.close();
+    recoveryTaskMetadataStore.close();
   }
 
   // returns startOffset or endOffset based on the supplied OffsetSpec

--- a/kaldb/src/test/java/com/slack/kaldb/server/BulkIngestApiTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/BulkIngestApiTest.java
@@ -103,7 +103,7 @@ public class BulkIngestApiTest {
             .setRateLimiterMaxBurstSeconds(1)
             .build();
 
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true, meterRegistry);
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
             INDEX_NAME,

--- a/kaldb/src/test/java/com/slack/kaldb/server/HpaMetricPublisherServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/HpaMetricPublisherServiceTest.java
@@ -1,6 +1,5 @@
 package com.slack.kaldb.server;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.spy;
 
@@ -10,9 +9,11 @@ import com.slack.kaldb.metadata.hpa.HpaMetricMetadata;
 import com.slack.kaldb.metadata.hpa.HpaMetricMetadataStore;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.proto.metadata.Metadata;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.util.List;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.junit.jupiter.api.AfterEach;
@@ -42,7 +43,7 @@ class HpaMetricPublisherServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(new SimpleMeterRegistry(), zkConfig);
-    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true));
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true, meterRegistry));
   }
 
   @AfterEach
@@ -61,24 +62,24 @@ class HpaMetricPublisherServiceTest {
             hpaMetricMetadataStore, meterRegistry, Metadata.HpaMetricMetadata.NodeRole.CACHE);
     hpaMetricPublisherService.startUp();
 
-    assertThat(meterRegistry.getMeters()).isEmpty();
+    List<Meter> initialMeters = meterRegistry.getMeters();
 
     hpaMetricMetadataStore.createSync(
         new HpaMetricMetadata("foo", Metadata.HpaMetricMetadata.NodeRole.CACHE, 1.0));
 
     await().until(() -> hpaMetricMetadataStore.listSync().size() == 1);
-    await().until(() -> meterRegistry.getMeters().size() == 1);
+    await().until(() -> meterRegistry.getMeters().size() == 1 + initialMeters.size());
 
     hpaMetricMetadataStore.createSync(
         new HpaMetricMetadata("bar", Metadata.HpaMetricMetadata.NodeRole.INDEX, 1.0));
 
     await().until(() -> hpaMetricMetadataStore.listSync().size() == 2);
-    await().until(() -> meterRegistry.getMeters().size() == 1);
+    await().until(() -> meterRegistry.getMeters().size() == 1 + initialMeters.size());
 
     hpaMetricMetadataStore.createSync(
         new HpaMetricMetadata("baz", Metadata.HpaMetricMetadata.NodeRole.CACHE, 0.0));
 
     await().until(() -> hpaMetricMetadataStore.listSync().size() == 3);
-    await().until(() -> meterRegistry.getMeters().size() == 2);
+    await().until(() -> meterRegistry.getMeters().size() == 2 + initialMeters.size());
   }
 }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbIndexerTest.java
@@ -119,9 +119,10 @@ public class KaldbIndexerTest {
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, false));
-    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, false));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, metricsRegistry));
+    recoveryTaskStore =
+        spy(new RecoveryTaskMetadataStore(curatorFramework, false, metricsRegistry));
+    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, false, metricsRegistry));
 
     kafkaServer = new TestKafkaServer();
   }

--- a/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/KaldbTest.java
@@ -125,7 +125,7 @@ public class KaldbTest {
             .setSleepBetweenRetriesMs(1000)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true, meterRegistry);
     final DatasetPartitionMetadata partition =
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);

--- a/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/ManagerApiGrpcTest.java
@@ -77,9 +77,9 @@ public class ManagerApiGrpcTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    datasetMetadataStore = spy(new DatasetMetadataStore(curatorFramework, true));
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    datasetMetadataStore = spy(new DatasetMetadataStore(curatorFramework, true, meterRegistry));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, meterRegistry));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, meterRegistry));
 
     KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         KaldbConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()

--- a/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/server/RecoveryTaskCreatorTest.java
@@ -83,8 +83,8 @@ public class RecoveryTaskCreatorTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, meterRegistry));
+    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true, meterRegistry));
   }
 
   @AfterEach


### PR DESCRIPTION
###  Summary

This adds an optional **opt-in** mode to run the `KaldbMetadataStore` using a combination of `PersistentNode` and `PersistentWatcher` for ephemeral nodes. This system property flag will be removed once the logic is validated, at which point this will no longer be able to be opt-out.

The goal of this PR is to support using ephemeral nodes across ZK session disconnects (https://github.com/slackhq/kaldb/pull/644#discussion_r1295013333), and uses the Curator `PersistentNode` in order to recreate nodes when they disappear, and `PersistentWatcher` to subscribe to updates to ephemeral nodes by other instances (ie - manager updating cache/recovery ephemerals). 

https://curator.apache.org/docs/recipes-persistent-node
https://curator.apache.org/docs/recipes-persistent-watcher

This PR also includes:
* Passing the meter registry into the metadata stores - in part for testing of this PR, but it will also enable us to start adding meters where appropriate to this class.
* Fixes to both unclosed metadata stores when they should have been closed (mostly tests), and fixes to closing metadata stores when they shouldn't have been (ie, passed as a param)
* Deduplication of events on the recovery service. This should probably have a further refactor to match the approach used by the manager, with an eventAggregationWindow given that ZK is _eventually consistent_.
