### PR TITLE
updates to dockerfile to run astra and dependencies locally

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -139,5 +139,5 @@ preprocessorConfig:
   dataTransformer: ${PREPROCESSOR_TRANSFORMER:-json}
   rateLimiterMaxBurstSeconds: ${PREPROCESSOR_RATE_LIMITER_MAX_BURST_SECONDS:-1}
   kafkaPartitionStickyTimeoutMs: ${KAFKA_PARTITION_STICKY_TIMEOUT_MS:-0}
-  useBulkApi: ${KALDB_PREPROCESSOR_USE_BULK_API:-true}
+  useBulkApi: ${KALDB_PREPROCESSOR_USE_BULK_API:-false}
   rateLimitExceededErrorCode: ${KALDB_PREPROCESSOR_RATE_LIMIT_EXCEEDED_ERROR_CODE:-400}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -139,5 +139,5 @@ preprocessorConfig:
   dataTransformer: ${PREPROCESSOR_TRANSFORMER:-json}
   rateLimiterMaxBurstSeconds: ${PREPROCESSOR_RATE_LIMITER_MAX_BURST_SECONDS:-1}
   kafkaPartitionStickyTimeoutMs: ${KAFKA_PARTITION_STICKY_TIMEOUT_MS:-0}
-  useBulkApi: ${KALDB_PREPROCESSOR_USE_BULK_API:-false}
+  useBulkApi: ${KALDB_PREPROCESSOR_USE_BULK_API:-true}
   rateLimitExceededErrorCode: ${KALDB_PREPROCESSOR_RATE_LIMIT_EXCEEDED_ERROR_CODE:-400}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   zookeeper:
     image: 'bitnami/zookeeper:3.6.3'
-    container_name: kaldb_zookeeper
+    container_name: dep_zookeeper
     ports:
       - '2181:2181'
     environment:
@@ -10,7 +10,7 @@ services:
 
   kafka:
     image: 'bitnami/kafka:3.2.3'
-    container_name: kaldb_kafka
+    container_name: dep_kafka
     ports:
       - '9092:9092'
       - '29092:29092'
@@ -29,7 +29,7 @@ services:
 
   grafana:
     image: 'grafana/grafana:8.0.3'
-    container_name: kaldb_grafana
+    container_name: dep_grafana
     ports:
       - '3000:3000'
     volumes:
@@ -46,7 +46,7 @@ services:
 
   s3:
     image: 'adobe/s3mock:2.1.29'
-    container_name: kaldb_s3
+    container_name: dep_s3
     ports:
       - 9090:9090
     environment:
@@ -54,28 +54,136 @@ services:
 
   openzipkin:
     image: 'openzipkin/zipkin-slim'
-    container_name: openzipkin
+    container_name: dep_openzipkin
     ports:
       - 9411:9411
 
-  #to build this image run 'docker build -t slackhq/kaldb .'
-  kaldb:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_kaldb
-    profiles:
-      - kaldb
+  #to build this image run 'docker build -t aubreyt/kaldb .'
+  kaldb_preprocessor:
+    image: 'aubreyt/kaldb'
+    container_name: kaldb_preprocessor
     ports:
-      - 8080:8080
-      - 8081:8081
-      - 8082:8082
-      - 8083:8083
-      - 8085:8085
       - 8086:8086
     environment:
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - NODE_ROLES=PREPROCESSOR
+      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - S3_ENDPOINT=http://dep_s3:9090
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
     depends_on:
       - zookeeper
       - kafka
       - s3
       - openzipkin
+
+  kaldb_index:
+    image: 'aubreyt/kaldb'
+    container_name: kaldb_index
+    ports:
+      - 8080:8080
+    environment:
+      - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - NODE_ROLES=INDEX
+      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - S3_ENDPOINT=http://dep_s3:9090
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+    depends_on:
+      - kaldb_preprocessor
+
+  kaldb_manager:
+    image: 'aubreyt/kaldb'
+    container_name: kaldb_manager
+    ports:
+      - 8083:8083
+    environment:
+      - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - NODE_ROLES=MANAGER
+      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - S3_ENDPOINT=http://dep_s3:9090
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+    depends_on:
+      - kaldb_preprocessor
+
+  kaldb_query:
+    image: 'aubreyt/kaldb'
+    container_name: kaldb_query
+    ports:
+      - 8081:8081
+    environment:
+      - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - NODE_ROLES=QUERY
+      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - S3_ENDPOINT=http://dep_s3:9090
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+    depends_on:
+      - kaldb_preprocessor
+
+  kaldb_cache:
+    image: 'aubreyt/kaldb'
+    container_name: kaldb_cache
+    ports:
+      - 8082:8082
+    environment:
+      - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - NODE_ROLES=CACHE
+      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - S3_ENDPOINT=http://dep_s3:9090
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+    depends_on:
+      - kaldb_preprocessor
+
+  kaldb_recovery:
+    image: 'aubreyt/kaldb'
+    container_name: kaldb_recovery
+    ports:
+      - 8085:8085
+    environment:
+      - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - NODE_ROLES=RECOVERY
+      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - S3_ENDPOINT=http://dep_s3:9090
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+    depends_on:
+      - kaldb_preprocessor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
       - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
       - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+      - KALDB_PREPROCESSOR_USE_BULK_API=true
     depends_on:
       - zookeeper
       - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,17 +58,17 @@ services:
     ports:
       - 9411:9411
 
-  #to build this image run 'docker build -t slackhq/kaldb .'
-  kaldb_preprocessor:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_preprocessor
+  #to build this image run 'docker build -t slackhq/astra .'
+  astra_preprocessor:
+    image: 'slackhq/astra'
+    container_name: astra_preprocessor
     ports:
       - 8086:8086
     environment:
       # Node specific settings
       - NODE_ROLES=PREPROCESSOR
       - KALDB_PREPROCESSOR_USE_BULK_API=true
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=astra_preprocessor
       # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
@@ -80,88 +80,88 @@ services:
       - s3
       - openzipkin
 
-  kaldb_index:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_index
+  astra_index:
+    image: 'slackhq/astra'
+    container_name: astra_index
     ports:
       - 8080:8080
     environment:
       # Node specific settings
       - NODE_ROLES=INDEX
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      - KALDB_INDEX_SERVER_ADDRESS=astra_index
       # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
-      - kaldb_preprocessor
+      - astra_preprocessor
 
-  kaldb_manager:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_manager
+  astra_manager:
+    image: 'slackhq/astra'
+    container_name: astra_manager
     ports:
       - 8083:8083
     environment:
       # Node specific settings
       - NODE_ROLES=MANAGER
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      - KALDB_MANAGER_SERVER_ADDRESS=astra_manager
       # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
-      - kaldb_preprocessor
+      - astra_preprocessor
 
-  kaldb_query:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_query
+  astra_query:
+    image: 'slackhq/astra'
+    container_name: astra_query
     ports:
       - 8081:8081
     environment:
       # Node specific settings
       - NODE_ROLES=QUERY
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      - KALDB_QUERY_SERVER_ADDRESS=astra_query
+      - KALDB_MANAGER_CONNECTION_STRING=astra_manager:8083
       # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
-      - kaldb_preprocessor
+      - astra_preprocessor
 
-  kaldb_cache:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_cache
+  astra_cache:
+    image: 'slackhq/astra'
+    container_name: astra_cache
     ports:
       - 8082:8082
     environment:
       # Node specific settings
       - NODE_ROLES=CACHE
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      - KALDB_CACHE_SERVER_ADDRESS=astra_cache
       # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
-      - kaldb_preprocessor
+      - astra_preprocessor
 
-  kaldb_recovery:
-    image: 'slackhq/kaldb'
-    container_name: kaldb_recovery
+  astra_recovery:
+    image: 'slackhq/astra'
+    container_name: astra_recovery
     ports:
       - 8085:8085
     environment:
       # Node specific settings
       - NODE_ROLES=RECOVERY
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      - KALDB_RECOVERY_SERVER_ADDRESS=astra_recovery
       # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
-      - kaldb_preprocessor
+      - astra_preprocessor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,19 +65,15 @@ services:
     ports:
       - 8086:8086
     environment:
+      # Node specific settings
+      - NODE_ROLES=PREPROCESSOR
+      - KALDB_PREPROCESSOR_USE_BULK_API=true
+      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
+      # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - NODE_ROLES=PREPROCESSOR
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
       - S3_ENDPOINT=http://dep_s3:9090
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
-      - KALDB_PREPROCESSOR_USE_BULK_API=true
     depends_on:
       - zookeeper
       - kafka
@@ -90,18 +86,14 @@ services:
     ports:
       - 8080:8080
     environment:
+      # Node specific settings
+      - NODE_ROLES=INDEX
+      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
+      # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - NODE_ROLES=INDEX
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
       - S3_ENDPOINT=http://dep_s3:9090
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
     depends_on:
       - kaldb_preprocessor
 
@@ -111,18 +103,14 @@ services:
     ports:
       - 8083:8083
     environment:
+      # Node specific settings
+      - NODE_ROLES=MANAGER
+      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
+      # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - NODE_ROLES=MANAGER
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
       - S3_ENDPOINT=http://dep_s3:9090
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
     depends_on:
       - kaldb_preprocessor
 
@@ -132,18 +120,15 @@ services:
     ports:
       - 8081:8081
     environment:
+      # Node specific settings
+      - NODE_ROLES=QUERY
+      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
+      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
+      # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - NODE_ROLES=QUERY
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
       - S3_ENDPOINT=http://dep_s3:9090
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
     depends_on:
       - kaldb_preprocessor
 
@@ -153,18 +138,14 @@ services:
     ports:
       - 8082:8082
     environment:
+      # Node specific settings
+      - NODE_ROLES=CACHE
+      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
+      # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - NODE_ROLES=CACHE
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
       - S3_ENDPOINT=http://dep_s3:9090
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
     depends_on:
       - kaldb_preprocessor
 
@@ -174,17 +155,13 @@ services:
     ports:
       - 8085:8085
     environment:
+      # Node specific settings
+      - NODE_ROLES=RECOVERY
+      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
+      # Shared settings
       - KALDB_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - NODE_ROLES=RECOVERY
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - KALDB_MANAGER_CONNECTION_STRING=kaldb_manager:8083
       - S3_ENDPOINT=http://dep_s3:9090
-      - KALDB_INDEX_SERVER_ADDRESS=kaldb_index
-      - KALDB_QUERY_SERVER_ADDRESS=kaldb_query
-      - KALDB_CACHE_SERVER_ADDRESS=kaldb_cache
-      - KALDB_MANAGER_SERVER_ADDRESS=kaldb_manager
-      - KALDB_RECOVERY_SERVER_ADDRESS=kaldb_recovery
-      - KALDB_PREPROCESSOR_SERVER_ADDRESS=kaldb_preprocessor
     depends_on:
       - kaldb_preprocessor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,9 @@ services:
     ports:
       - 9411:9411
 
-  #to build this image run 'docker build -t aubreyt/kaldb .'
+  #to build this image run 'docker build -t slackhq/kaldb .'
   kaldb_preprocessor:
-    image: 'aubreyt/kaldb'
+    image: 'slackhq/kaldb'
     container_name: kaldb_preprocessor
     ports:
       - 8086:8086
@@ -81,7 +81,7 @@ services:
       - openzipkin
 
   kaldb_index:
-    image: 'aubreyt/kaldb'
+    image: 'slackhq/kaldb'
     container_name: kaldb_index
     ports:
       - 8080:8080
@@ -98,7 +98,7 @@ services:
       - kaldb_preprocessor
 
   kaldb_manager:
-    image: 'aubreyt/kaldb'
+    image: 'slackhq/kaldb'
     container_name: kaldb_manager
     ports:
       - 8083:8083
@@ -115,7 +115,7 @@ services:
       - kaldb_preprocessor
 
   kaldb_query:
-    image: 'aubreyt/kaldb'
+    image: 'slackhq/kaldb'
     container_name: kaldb_query
     ports:
       - 8081:8081
@@ -133,7 +133,7 @@ services:
       - kaldb_preprocessor
 
   kaldb_cache:
-    image: 'aubreyt/kaldb'
+    image: 'slackhq/kaldb'
     container_name: kaldb_cache
     ports:
       - 8082:8082
@@ -150,7 +150,7 @@ services:
       - kaldb_preprocessor
 
   kaldb_recovery:
-    image: 'aubreyt/kaldb'
+    image: 'slackhq/kaldb'
     container_name: kaldb_recovery
     ports:
       - 8085:8085


### PR DESCRIPTION
###  Summary
Opening a draft PR to start a discussion about onboarding / local development. I am still working on validating some flows. This is loosely based on the onboarding docs here:
https://github.com/slackhq/kaldb/wiki/Onboarding

This PR updates the dockerfile to:

1. renames dependencies `dep_` to make it easier to differentiate the containers when printed alphabetically.
2. makes one service per kaldb node type with necessary flags changes so kaldb nodes can communicate with each other.

Note: I've also tested the flow of bringing up the dependencies in docker and running kaldb via the run configs in IntelliJ. I think both scenarios are useful. e.g. 1) clear way to bring up everything locally via docker and 2) bring up deps via docker and kaldb via IntelliJ or maven in command line.

The flows I've tested with this PR are ingestion via bulk ingest and read via _msearch on the query node. So the following flow:
```
/_bulk -> preprocessor -> internal kafka topic -> indexer -> query node _msearch
```
input kafka topic, S3, recovery nodes, and cache nodes were not confirmed to work yet.

More work is needed to fully test and setup locally. But here are the current instructions that work for this PR:


**NOTE: I copied these instructions to an issue here https://github.com/slackhq/astra/discussions/799**

### Instructions for local development.
Putting these in the PR description for now, but potentially this should be added to the Onboarding docs or a new local development doc.
#### 1. in terminal, build and run compose to bring up dependencies and kaldb nodes
```
docker build -t slackhq/kaldb .

docker compose up
```

#### 2. in kafka container terminal, create input topic (preprocessor crashes if it does not exist before configuring manager in next step) 
```
kafka-topics.sh --create --topic test-topic-in --bootstrap-server localhost:9092
```

#### 3. run 2 curl commands to configure 1 partition
```
curl -XPOST -H 'content-type: application/json; charset=utf-8; protocol=gRPC' http://localhost:8083'/slack.proto.kaldb.ManagerApiService/CreateDatasetMetadata' -d '{
  "name": "test",
  "owner": "test@email.com",
  "serviceNamePattern": "_all"
}'

curl -XPOST -H 'content-type: application/json; charset=utf-8; protocol=gRPC' http://localhost:8083'/slack.proto.kaldb.ManagerApiService/UpdatePartitionAssignment' -d '{
  "name": "test",
  "throughputBytes": "1000000",
  "partitionIds": ["0"]
}'
```

#### 4. Add some logs via bulk ingest
```
curl --location 'http://localhost:8086/_bulk' \
--header 'Content-type: application/x-ndjson' \
--data '{ "index" : { "_index" : "test", "_id" : "100" } }
{ "@timestamp": "2024-03-07T12:00:00.000Z", "level": "INFO", "message": "This is a log message", "service-name": "test" }
'
```

#### 5. Example curl to read data
Note: This is similar to [ES _msearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-multi-search.html) but `size`, `lte`, and `gte` are all required or else a 500 error occurs. In follow-up work, I will clean up those endpoints to return a 400 (bad request) with detail about the missing required argument. PR around follow-up: https://github.com/slackhq/kaldb/pull/780
```
curl --location 'http://localhost:8081/_msearch' \
--header 'Content-type: application/x-ndjson' \
--data '{ "index": "test"}
{"query" : {"match_all" : {}, "gte":1625156649889,"lte":2708540790265}, "size": 500}
'
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
