### PR TITLE
We should enforce these required inputs by returning a useful error and 400 response. right now it is 500

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequest.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/OpenSearchRequest.java
@@ -85,14 +85,20 @@ public class OpenSearchRequest {
     return queryString;
   }
 
+  // This is required. consider returning a more useful error to the user than 500
+  // or setting a reasonable default (default seems a good option here)
   private static int getHowMany(JsonNode body) {
     return body.get("size").asInt();
   }
 
+  // This is required. consider returning a more useful error to the user than 500
+  // or setting a reasonable default (not sure what that would be)
   private static long getStartTimeEpochMs(JsonNode body) {
     return body.get("query").findValue("gte").asLong();
   }
 
+  // This is required. consider returning a more useful error to the user than 500
+  // or setting a reasonable default (not sure what that would be)
   private static long getEndTimeEpochMs(JsonNode body) {
     return body.get("query").findValue("lte").asLong();
   }


### PR DESCRIPTION
###  Summary
I think we should set a reasonable default for when size is missing (10? - i think that is what ES uses when missing). Opening a draft PR as a discussion before going further in this direction.  There may be a better way to more closely follow the ES API spec. ([_msearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-multi-search.html), [range query docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html))

For `lte` and `gte` I think if they are missing, we should return a 400 (Bad Request) and a helpful error string.

Right now, if any of these are missing, we get a 500 (Internal Server Error) response.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
