### PR TITLE
Increase dependabot frequency, max PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,10 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"    
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
###  Summary

Increases the frequency and max amount of Dependabot PRs allowed