### PR TITLE
remove top level fields from tags(if present)

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -453,6 +453,14 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     tags.remove(LogMessage.ReservedField.SERVICE_NAME.fieldName);
     tags.remove(LogMessage.ReservedField.TYPE.fieldName);
 
+    // if any top level fields are in the tags, we should remove them
+    tags.remove(LogMessage.ReservedField.PARENT_ID.fieldName);
+    tags.remove(LogMessage.ReservedField.TRACE_ID.fieldName);
+    tags.remove(LogMessage.ReservedField.NAME.fieldName);
+    tags.remove(LogMessage.ReservedField.DURATION_MS.fieldName);
+    tags.remove(LogMessage.SystemField.ID.fieldName);
+    tags.remove(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName);
+
     for (Trace.KeyValue keyValue : tags.values()) {
       if (keyValue.getVType() == Trace.ValueType.STRING) {
         addField(doc, keyValue.getKey(), keyValue.getVStr(), "", 0);


### PR DESCRIPTION
###  Summary

Tags is a list, and if any top level trace.proto fields ends up existing as tags we'll try to recreate the field twice in the lucene document leading to an error ( cannot index same field twice )

This is a quick and dirty way to fix it. We need to evolve trace.proto to be a better fit for our internal data transport so we'll revisit this again 