### PR TITLE
standardize one field type

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/SearchResultUtils.java
@@ -24,6 +24,7 @@ import com.slack.kaldb.logstore.search.aggregations.SumAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.TermsAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.UniqueCountAggBuilder;
 import com.slack.kaldb.metadata.schema.FieldType;
+import com.slack.kaldb.proto.schema.Schema;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.util.JsonUtil;
 import java.io.IOException;
@@ -641,21 +642,21 @@ public class SearchResultUtils {
 
   public static FieldType fromSchemaDefinitionProto(
       KaldbSearch.SchemaDefinition protoSchemaDefinition) {
-    if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.TEXT)) {
+    if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.TEXT)) {
       return FieldType.TEXT;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.STRING)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.STRING)) {
       return FieldType.STRING;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.INTEGER)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.INTEGER)) {
       return FieldType.INTEGER;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.LONG)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.LONG)) {
       return FieldType.LONG;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.FLOAT)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.FLOAT)) {
       return FieldType.FLOAT;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.BOOLEAN)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.BOOLEAN)) {
       return FieldType.BOOLEAN;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.DOUBLE)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.DOUBLE)) {
       return FieldType.DOUBLE;
-    } else if (protoSchemaDefinition.getType().equals(KaldbSearch.FieldType.ID)) {
+    } else if (protoSchemaDefinition.getType().equals(Schema.SchemaFieldType.ID)) {
       return FieldType.ID;
     } else {
       throw new IllegalArgumentException(
@@ -667,21 +668,21 @@ public class SearchResultUtils {
     KaldbSearch.SchemaDefinition.Builder schemaBuilder = KaldbSearch.SchemaDefinition.newBuilder();
 
     if (fieldType.equals(FieldType.TEXT)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.TEXT);
+      schemaBuilder.setType(Schema.SchemaFieldType.TEXT);
     } else if (fieldType.equals(FieldType.STRING)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.STRING);
+      schemaBuilder.setType(Schema.SchemaFieldType.STRING);
     } else if (fieldType.equals(FieldType.INTEGER)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.INTEGER);
+      schemaBuilder.setType(Schema.SchemaFieldType.INTEGER);
     } else if (fieldType.equals(FieldType.LONG)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.LONG);
+      schemaBuilder.setType(Schema.SchemaFieldType.LONG);
     } else if (fieldType.equals(FieldType.FLOAT)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.FLOAT);
+      schemaBuilder.setType(Schema.SchemaFieldType.FLOAT);
     } else if (fieldType.equals(FieldType.BOOLEAN)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.BOOLEAN);
+      schemaBuilder.setType(Schema.SchemaFieldType.BOOLEAN);
     } else if (fieldType.equals(FieldType.DOUBLE)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.DOUBLE);
+      schemaBuilder.setType(Schema.SchemaFieldType.DOUBLE);
     } else if (fieldType.equals(FieldType.ID)) {
-      schemaBuilder.setType(KaldbSearch.FieldType.ID);
+      schemaBuilder.setType(Schema.SchemaFieldType.ID);
     } else {
       throw new IllegalArgumentException(
           String.format("Field type %s is not a supported type", fieldType));

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -4,6 +4,8 @@ package slack.proto.kaldb;
 
 option java_package = "com.slack.kaldb.proto.service";
 
+import "schema.proto";
+
 message SearchRequest {
   // Data sets or chunk_ids to be searched
   string dataset = 1;
@@ -238,21 +240,9 @@ message SchemaResult {
   // Map of field name, to field definition
   map<string, SchemaDefinition> field_definition = 1;
 }
-
-enum FieldType {
-  TEXT = 0;
-  STRING = 1;
-  INTEGER = 2;
-  LONG = 3;
-  FLOAT = 4;
-  BOOLEAN = 5;
-  DOUBLE = 6;
-  ID = 7;
-}
-
 message SchemaDefinition {
   // Field type as defined by KalDB
-  FieldType type = 1;
+  slack.proto.kaldb.schema.SchemaFieldType type = 1;
   // Any field-specific metadata to be included
   // map<string, Value> metadata = 2;
 }

--- a/kaldb/src/main/proto/schema.proto
+++ b/kaldb/src/main/proto/schema.proto
@@ -35,4 +35,9 @@ enum SchemaFieldType {
   SHORT = 11;
   BYTE = 12;
   BINARY = 13;
+  // we may get rid of this in the future
+  ID = 14;
+  // to help with backward compatibility
+  // move to KEYWORD in the future
+  STRING = 15;
 };

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/KaldbDistributedQueryServiceTest.java
@@ -32,6 +32,7 @@ import com.slack.kaldb.metadata.snapshot.SnapshotMetadata;
 import com.slack.kaldb.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.kaldb.proto.config.KaldbConfigs;
 import com.slack.kaldb.proto.metadata.Metadata;
+import com.slack.kaldb.proto.schema.Schema;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import com.slack.kaldb.proto.service.KaldbServiceGrpc;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -877,7 +878,7 @@ public class KaldbDistributedQueryServiceTest {
                     .putFieldDefinition(
                         "foo",
                         KaldbSearch.SchemaDefinition.newBuilder()
-                            .setType(KaldbSearch.FieldType.TEXT)
+                            .setType(Schema.SchemaFieldType.TEXT)
                             .build())
                     .build()));
 
@@ -895,7 +896,7 @@ public class KaldbDistributedQueryServiceTest {
             Map.of(
                 "foo",
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.TEXT)
+                    .setType(Schema.SchemaFieldType.TEXT)
                     .build()));
 
     // Exact dataset query should return a result
@@ -912,7 +913,7 @@ public class KaldbDistributedQueryServiceTest {
             Map.of(
                 "foo",
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.TEXT)
+                    .setType(Schema.SchemaFieldType.TEXT)
                     .build()));
 
     // query window that returns no results should have no schema

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -21,6 +21,7 @@ import com.slack.kaldb.logstore.search.aggregations.SumAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.TermsAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.UniqueCountAggBuilder;
 import com.slack.kaldb.metadata.schema.FieldType;
+import com.slack.kaldb.proto.schema.Schema;
 import com.slack.kaldb.proto.service.KaldbSearch;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -330,90 +331,92 @@ public class SearchResultUtilsTest {
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.BOOLEAN)
+                    .setType(Schema.SchemaFieldType.BOOLEAN)
                     .build()))
         .isEqualTo(FieldType.BOOLEAN);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.BOOLEAN))
         .isEqualTo(
             KaldbSearch.SchemaDefinition.newBuilder()
-                .setType(KaldbSearch.FieldType.BOOLEAN)
+                .setType(Schema.SchemaFieldType.BOOLEAN)
                 .build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.DOUBLE)
+                    .setType(Schema.SchemaFieldType.DOUBLE)
                     .build()))
         .isEqualTo(FieldType.DOUBLE);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.DOUBLE))
         .isEqualTo(
             KaldbSearch.SchemaDefinition.newBuilder()
-                .setType(KaldbSearch.FieldType.DOUBLE)
+                .setType(Schema.SchemaFieldType.DOUBLE)
                 .build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.STRING)
+                    .setType(Schema.SchemaFieldType.STRING)
                     .build()))
         .isEqualTo(FieldType.STRING);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.STRING))
         .isEqualTo(
             KaldbSearch.SchemaDefinition.newBuilder()
-                .setType(KaldbSearch.FieldType.STRING)
+                .setType(Schema.SchemaFieldType.STRING)
                 .build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.FLOAT)
+                    .setType(Schema.SchemaFieldType.FLOAT)
                     .build()))
         .isEqualTo(FieldType.FLOAT);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.FLOAT))
         .isEqualTo(
-            KaldbSearch.SchemaDefinition.newBuilder().setType(KaldbSearch.FieldType.FLOAT).build());
+            KaldbSearch.SchemaDefinition.newBuilder()
+                .setType(Schema.SchemaFieldType.FLOAT)
+                .build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.LONG)
+                    .setType(Schema.SchemaFieldType.LONG)
                     .build()))
         .isEqualTo(FieldType.LONG);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.LONG))
         .isEqualTo(
-            KaldbSearch.SchemaDefinition.newBuilder().setType(KaldbSearch.FieldType.LONG).build());
+            KaldbSearch.SchemaDefinition.newBuilder().setType(Schema.SchemaFieldType.LONG).build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.TEXT)
+                    .setType(Schema.SchemaFieldType.TEXT)
                     .build()))
         .isEqualTo(FieldType.TEXT);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.TEXT))
         .isEqualTo(
-            KaldbSearch.SchemaDefinition.newBuilder().setType(KaldbSearch.FieldType.TEXT).build());
+            KaldbSearch.SchemaDefinition.newBuilder().setType(Schema.SchemaFieldType.TEXT).build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.INTEGER)
+                    .setType(Schema.SchemaFieldType.INTEGER)
                     .build()))
         .isEqualTo(FieldType.INTEGER);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.INTEGER))
         .isEqualTo(
             KaldbSearch.SchemaDefinition.newBuilder()
-                .setType(KaldbSearch.FieldType.INTEGER)
+                .setType(Schema.SchemaFieldType.INTEGER)
                 .build());
 
     assertThat(
             SearchResultUtils.fromSchemaDefinitionProto(
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.ID)
+                    .setType(Schema.SchemaFieldType.ID)
                     .build()))
         .isEqualTo(FieldType.ID);
     assertThat(SearchResultUtils.toSchemaDefinitionProto(FieldType.ID))
         .isEqualTo(
-            KaldbSearch.SchemaDefinition.newBuilder().setType(KaldbSearch.FieldType.ID).build());
+            KaldbSearch.SchemaDefinition.newBuilder().setType(Schema.SchemaFieldType.ID).build());
   }
 
   @Test
@@ -423,7 +426,7 @@ public class SearchResultUtilsTest {
             .putFieldDefinition(
                 "foo",
                 KaldbSearch.SchemaDefinition.newBuilder()
-                    .setType(KaldbSearch.FieldType.TEXT)
+                    .setType(Schema.SchemaFieldType.TEXT)
                     .build())
             .build();
 


### PR DESCRIPTION
###  Summary

remove the field type definition in `kaldb_search.proto` . We use that to convert the internal `FieldType` enum class and we can swap it for the new schema field type.

This will cause less confusion and ambiguity when working around the schema work. I think the change should be backwards compatible but I'll test internally and confim
