### PR TITLE
Improve ES query compatibility for Grafana 10

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/kaldb/src/main/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -111,9 +111,6 @@ public class BulkApiRequestParser {
     // these fields don't need to be tags as they have been explicitly set already
     sourceAndMetadata.remove(IngestDocument.Metadata.ID.getFieldName());
     sourceAndMetadata.remove(IngestDocument.Metadata.INDEX.getFieldName());
-    sourceAndMetadata.remove("timestamp");
-    sourceAndMetadata.remove("_timestamp");
-    sourceAndMetadata.remove("@timestamp");
 
     sourceAndMetadata.forEach(
         (key, value) -> spanBuilder.addTags(SpanFormatter.convertKVtoProto(key, value, schema)));

--- a/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
+++ b/kaldb/src/main/java/com/slack/kaldb/elasticsearchApi/ElasticsearchApiService.java
@@ -61,6 +61,27 @@ public class ElasticsearchApiService {
     this.searcher = searcher;
   }
 
+  /** Returns metadata about the cluster */
+  @Get
+  @Path("/")
+  public HttpResponse clusterMetadata() {
+    // todo - expand this to automatically pull in build info
+    // example - https://opensearch.org/docs/2.3/quickstart/
+    // number must validate with npm semver validate for grafana compatibility due to
+    // https://github.com/grafana/grafana/blob/f74d5ff93ebe61e090994162be9b08bafcd5b7f0/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/MetricEditor.tsx#L54
+    return HttpResponse.of(
+        """
+        {
+            "version":
+            {
+                "distribution": "astra",
+                "number": "0.0.1",
+                "lucene_version": "9.7.0"
+            }
+        }
+        """);
+  }
+
   /**
    * Multisearch API
    *

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregation.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregation.java
@@ -18,8 +18,10 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.filter.InternalFilters;
+import org.opensearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.InternalAutoDateHistogram;
 import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogram;
 import org.opensearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
@@ -78,6 +80,14 @@ public class OpenSearchInternalAggregation {
                   InternalAggregation.class,
                   DateHistogramAggregationBuilder.NAME,
                   InternalDateHistogram::new),
+              new NamedWriteableRegistry.Entry(
+                  AggregationBuilder.class,
+                  AutoDateHistogramAggregationBuilder.NAME,
+                  AutoDateHistogramAggregationBuilder::new),
+              new NamedWriteableRegistry.Entry(
+                  InternalAggregation.class,
+                  AutoDateHistogramAggregationBuilder.NAME,
+                  InternalAutoDateHistogram::new),
               new NamedWriteableRegistry.Entry(
                   AggregationBuilder.class,
                   FiltersAggregationBuilder.NAME,

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -420,8 +420,12 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
       jsonMap.put(
           LogMessage.ReservedField.KALDB_INVALID_TIMESTAMP.fieldName, message.getTimestamp());
     }
+
     addField(
         doc, LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, timestamp.toEpochMilli(), "", 0);
+    // todo - this should be removed once we simplify the time handling
+    // this will be overridden below if a user provided value exists
+    jsonMap.put(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, timestamp.toString());
 
     Map<String, Trace.KeyValue> tags =
         message.getTagsList().stream()
@@ -459,7 +463,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     tags.remove(LogMessage.ReservedField.NAME.fieldName);
     tags.remove(LogMessage.ReservedField.DURATION_MS.fieldName);
     tags.remove(LogMessage.SystemField.ID.fieldName);
-    tags.remove(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName);
 
     for (Trace.KeyValue keyValue : tags.values()) {
       if (keyValue.getVType() == Trace.ValueType.STRING) {

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/AutoDateHistogramAggBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/AutoDateHistogramAggBuilder.java
@@ -1,0 +1,82 @@
+package com.slack.kaldb.logstore.search.aggregations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Aggregation request type to form an automatic histogram bucketed by a timestamp */
+public class AutoDateHistogramAggBuilder extends ValueSourceAggBuilder {
+  public static final String TYPE = "auto_date_histogram";
+  private final String minInterval;
+  private final Integer numBuckets;
+
+  public AutoDateHistogramAggBuilder(
+      String name,
+      String fieldName,
+      String minInterval,
+      Integer numBuckets,
+      List<AggBuilder> subAggregations) {
+    // todo - metadata?
+    super(name, Map.of(), subAggregations, fieldName);
+
+    this.minInterval = minInterval;
+    this.numBuckets = numBuckets;
+  }
+
+  public String getMinInterval() {
+    return minInterval;
+  }
+
+  public Integer getNumBuckets() {
+    return numBuckets;
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof AutoDateHistogramAggBuilder that)) return false;
+    if (!super.equals(o)) return false;
+
+    if (!Objects.equals(minInterval, that.minInterval)) return false;
+    return Objects.equals(numBuckets, that.numBuckets);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (minInterval != null ? minInterval.hashCode() : 0);
+    result = 31 * result + (numBuckets != null ? numBuckets.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "AutoDateHistogramAggBuilder{"
+        + "minInterval='"
+        + minInterval
+        + '\''
+        + ", numBuckets="
+        + numBuckets
+        + ", field='"
+        + field
+        + '\''
+        + ", missing="
+        + missing
+        + ", script='"
+        + script
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", metadata="
+        + metadata
+        + ", subAggregations="
+        + subAggregations
+        + '}';
+  }
+}

--- a/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/DateHistogramAggBuilder.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/search/aggregations/DateHistogramAggBuilder.java
@@ -9,6 +9,7 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
   public static final String TYPE = "date_histogram";
   private final String interval;
   private final String offset;
+  private final String zoneId;
   private final long minDocCount;
 
   private final String format;
@@ -20,6 +21,7 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
 
     this.interval = interval;
     this.offset = "";
+    this.zoneId = null;
     this.minDocCount = 1;
     this.format = null;
     this.extendedBounds = Map.of();
@@ -30,6 +32,7 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
       String fieldName,
       String interval,
       String offset,
+      String zoneId,
       long minDocCount,
       String format,
       Map<String, Long> extendedBounds,
@@ -39,6 +42,7 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
 
     this.interval = interval;
     this.offset = offset;
+    this.zoneId = zoneId;
     this.minDocCount = minDocCount;
     this.format = format;
     this.extendedBounds = extendedBounds;
@@ -46,6 +50,10 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
 
   public String getInterval() {
     return interval;
+  }
+
+  public String getZoneId() {
+    return zoneId;
   }
 
   public String getOffset() {
@@ -72,14 +80,13 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof DateHistogramAggBuilder)) return false;
+    if (!(o instanceof DateHistogramAggBuilder that)) return false;
     if (!super.equals(o)) return false;
-
-    DateHistogramAggBuilder that = (DateHistogramAggBuilder) o;
 
     if (minDocCount != that.minDocCount) return false;
     if (!interval.equals(that.interval)) return false;
     if (!Objects.equals(offset, that.offset)) return false;
+    if (!Objects.equals(zoneId, that.zoneId)) return false;
     if (!Objects.equals(format, that.format)) return false;
     return Objects.equals(extendedBounds, that.extendedBounds);
   }
@@ -89,6 +96,7 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
     int result = super.hashCode();
     result = 31 * result + interval.hashCode();
     result = 31 * result + (offset != null ? offset.hashCode() : 0);
+    result = 31 * result + (zoneId != null ? zoneId.hashCode() : 0);
     result = 31 * result + (int) (minDocCount ^ (minDocCount >>> 32));
     result = 31 * result + (format != null ? format.hashCode() : 0);
     result = 31 * result + (extendedBounds != null ? extendedBounds.hashCode() : 0);
@@ -104,6 +112,9 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
         + ", offset='"
         + offset
         + '\''
+        + ", zoneId='"
+        + zoneId
+        + '\''
         + ", minDocCount="
         + minDocCount
         + ", format='"
@@ -113,6 +124,11 @@ public class DateHistogramAggBuilder extends ValueSourceAggBuilder {
         + extendedBounds
         + ", field='"
         + field
+        + '\''
+        + ", missing="
+        + missing
+        + ", script='"
+        + script
         + '\''
         + ", name='"
         + name

--- a/kaldb/src/main/proto/kaldb_search.proto
+++ b/kaldb/src/main/proto/kaldb_search.proto
@@ -67,6 +67,7 @@ message SearchRequest {
         DateHistogramAggregation date_histogram = 11;
         TermsAggregation terms = 12;
         HistogramAggregation histogram = 13;
+        AutoDateHistogramAggregation auto_date_histogram = 14;
         ExtendedStatsAggregation extended_stats = 15;
         UniqueCountAggregation unique_count = 16;
         PercentilesAggregation percentiles = 17;
@@ -93,6 +94,16 @@ message SearchRequest {
         map<string, int64> extended_bounds = 4;
         // Format for the resulting buckets timestamps
         string format = 5;
+        // Date zoneId if requesting with timezone option
+        Value zoneId = 6;
+      }
+
+      // Unique fields specific to the auto date histogram aggregation request
+      message AutoDateHistogramAggregation {
+        // Value representing the minimum interval of the bucket size (ie, day, hour)
+        Value min_interval = 1;
+        // Exact number of buckets required
+        Value num_buckets = 2;
       }
 
       // Unique fields specific to the terms aggregation request

--- a/kaldb/src/test/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
@@ -45,7 +45,7 @@ public class BulkApiRequestParserTest {
     assertThat(indexDocs.get("test").size()).isEqualTo(1);
 
     assertThat(indexDocs.get("test").get(0).getId().toStringUtf8()).isEqualTo("1");
-    assertThat(indexDocs.get("test").get(0).getTagsList().size()).isEqualTo(3);
+    assertThat(indexDocs.get("test").get(0).getTagsList().size()).isEqualTo(4);
     assertThat(
             indexDocs.get("test").get(0).getTagsList().stream()
                 .filter(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapterTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchAdapterTest.java
@@ -7,6 +7,7 @@ import com.slack.kaldb.logstore.LogMessage;
 import com.slack.kaldb.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
 import com.slack.kaldb.logstore.search.aggregations.AggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.AggBuilderBase;
+import com.slack.kaldb.logstore.search.aggregations.AutoDateHistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.AvgAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.CumulativeSumAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
@@ -37,6 +38,7 @@ import org.opensearch.index.mapper.Uid;
 import org.opensearch.search.aggregations.AbstractAggregationBuilder;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.bucket.histogram.InternalAutoDateHistogram;
 import org.opensearch.search.aggregations.bucket.histogram.InternalDateHistogram;
 import org.opensearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.opensearch.search.aggregations.metrics.InternalAvg;
@@ -236,6 +238,7 @@ public class OpenSearchAdapterTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             100,
             "epoch_ms",
             Map.of(),
@@ -258,6 +261,29 @@ public class OpenSearchAdapterTest {
   }
 
   @Test
+  public void canBuildValidAutoDateHistogram() throws IOException {
+    AutoDateHistogramAggBuilder autoDateHistogramAggBuilder =
+        new AutoDateHistogramAggBuilder(
+            "foo", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, null, null, List.of());
+
+    CollectorManager<Aggregator, InternalAggregation> collectorManager =
+        openSearchAdapter.getCollectorManager(
+            autoDateHistogramAggBuilder,
+            logStoreAndSearcherRule.logStore.getSearcherManager().acquire(),
+            null);
+
+    try (Aggregator autoDateHistogramAggregator = collectorManager.newCollector()) {
+      InternalAutoDateHistogram internalDateHistogram =
+          (InternalAutoDateHistogram) autoDateHistogramAggregator.buildTopLevel();
+
+      assertThat(internalDateHistogram.getName()).isEqualTo("foo");
+
+      // todo - we don't have access to the package local methods for extra asserts - use
+      // reflection?
+    }
+  }
+
+  @Test
   public void canBuildValidCumulativeSumPipelineAggregator() {
     DateHistogramAggBuilder dateHistogramWithCumulativeSum =
         new DateHistogramAggBuilder(
@@ -265,6 +291,7 @@ public class OpenSearchAdapterTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             100,
             "epoch_ms",
             Map.of(),
@@ -292,6 +319,7 @@ public class OpenSearchAdapterTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             100,
             "epoch_ms",
             Map.of(),
@@ -319,6 +347,7 @@ public class OpenSearchAdapterTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             100,
             "epoch_ms",
             Map.of(),
@@ -346,6 +375,7 @@ public class OpenSearchAdapterTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             100,
             "epoch_ms",
             Map.of(),
@@ -392,6 +422,7 @@ public class OpenSearchAdapterTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             0,
             "epoch_ms",
             Map.of(),

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregationTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/opensearch/OpenSearchInternalAggregationTest.java
@@ -3,6 +3,7 @@ package com.slack.kaldb.logstore.opensearch;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.logstore.search.aggregations.AutoDateHistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.AvgAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.HistogramAggBuilder;
@@ -37,10 +38,36 @@ public class OpenSearchInternalAggregationTest {
         new AvgAggBuilder("foo", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "3", null);
     DateHistogramAggBuilder dateHistogramAggBuilder =
         new DateHistogramAggBuilder(
-            "foo", "epoch_ms", "10s", "5s", 10, "epoch_ms", Map.of(), List.of(avgAggBuilder));
+            "foo", "epoch_ms", "10s", "5s", null, 10, "epoch_ms", Map.of(), List.of(avgAggBuilder));
     CollectorManager<Aggregator, InternalAggregation> collectorManager =
         openSearchAdapter.getCollectorManager(
             dateHistogramAggBuilder,
+            logStoreAndSearcherRule.logStore.getSearcherManager().acquire(),
+            null);
+    InternalAggregation internalAggregation1 =
+        collectorManager.reduce(Collections.singleton(collectorManager.newCollector()));
+
+    byte[] serialize = OpenSearchInternalAggregation.toByteArray(internalAggregation1);
+    InternalAggregation internalAggregation2 =
+        OpenSearchInternalAggregation.fromByteArray(serialize);
+
+    // todo - this is pending a PR to OpenSearch to address specific to histograms
+    // https://github.com/opensearch-project/OpenSearch/pull/6357
+    // this is because DocValueFormat.DateTime in OpenSearch does not implement a proper equals
+    // method
+    // As such the DocValueFormat.parser are never equal to each other
+    assertThat(internalAggregation1.toString()).isEqualTo(internalAggregation2.toString());
+  }
+
+  @Test
+  public void canSerializeDeserializeInternalAutoDateHistogramAggregation() throws IOException {
+    AvgAggBuilder avgAggBuilder =
+        new AvgAggBuilder("foo", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "3", null);
+    AutoDateHistogramAggBuilder autoDateHistogramAggBuilder =
+        new AutoDateHistogramAggBuilder("foo", "epoch_ms", "day", 5, List.of(avgAggBuilder));
+    CollectorManager<Aggregator, InternalAggregation> collectorManager =
+        openSearchAdapter.getCollectorManager(
+            autoDateHistogramAggBuilder,
             logStoreAndSearcherRule.logStore.getSearcherManager().acquire(),
             null);
     InternalAggregation internalAggregation1 =

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/LogIndexSearcherImplTest.java
@@ -947,6 +947,7 @@ public class LogIndexSearcherImplTest {
                 LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
                 "1s",
                 null,
+                null,
                 0,
                 "epoch_ms",
                 Map.of("min", 1593365471000L, "max", 1593365471000L + 5000L),

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultAggregatorImplTest.java
@@ -552,6 +552,7 @@ public class SearchResultAggregatorImplTest {
                 LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
                 interval,
                 "0",
+                null,
                 0,
                 "",
                 Map.of("min", histogramStartMs, "max", histogramEndMs),

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/SearchResultUtilsTest.java
@@ -5,6 +5,7 @@ import static com.slack.kaldb.logstore.search.SearchResultUtils.toValueProto;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.slack.kaldb.logstore.LogMessage;
+import com.slack.kaldb.logstore.search.aggregations.AutoDateHistogramAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.AvgAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.CumulativeSumAggBuilder;
 import com.slack.kaldb.logstore.search.aggregations.DateHistogramAggBuilder;
@@ -122,6 +123,7 @@ public class SearchResultUtilsTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             10000,
             "epoch_ms",
             Map.of(
@@ -135,6 +137,31 @@ public class SearchResultUtilsTest {
         (DateHistogramAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation);
 
     assertThat(dateHistogramAggBuilder1).isEqualTo(dateHistogramAggBuilder2);
+  }
+
+  @Test
+  public void shouldConvertAutoDateHistogramAggToFromProto() {
+    AutoDateHistogramAggBuilder autoDateHistogramAggBuilder1 =
+        new AutoDateHistogramAggBuilder(
+            "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "day", 10, List.of());
+
+    KaldbSearch.SearchRequest.SearchAggregation searchAggregation =
+        SearchResultUtils.toSearchAggregationProto(autoDateHistogramAggBuilder1);
+    AutoDateHistogramAggBuilder autoDateHistogramAggBuilder2 =
+        (AutoDateHistogramAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation);
+
+    assertThat(autoDateHistogramAggBuilder1).isEqualTo(autoDateHistogramAggBuilder2);
+
+    AutoDateHistogramAggBuilder autoDateHistogramAggBuilder3 =
+        new AutoDateHistogramAggBuilder(
+            "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, null, null, List.of());
+
+    KaldbSearch.SearchRequest.SearchAggregation searchAggregation2 =
+        SearchResultUtils.toSearchAggregationProto(autoDateHistogramAggBuilder3);
+    AutoDateHistogramAggBuilder autoDateHistogramAggBuilder4 =
+        (AutoDateHistogramAggBuilder) SearchResultUtils.fromSearchAggregations(searchAggregation2);
+
+    assertThat(autoDateHistogramAggBuilder3).isEqualTo(autoDateHistogramAggBuilder4);
   }
 
   @Test
@@ -282,6 +309,7 @@ public class SearchResultUtilsTest {
             LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
             "5s",
             "2s",
+            null,
             10000,
             "epoch_ms",
             Map.of(
@@ -295,6 +323,7 @@ public class SearchResultUtilsTest {
             "duration_ms",
             "10s",
             "7s",
+            null,
             1000,
             "epoch_ms",
             Map.of(

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/AutoDateHistogramAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/AutoDateHistogramAggBuilderTest.java
@@ -1,0 +1,68 @@
+package com.slack.kaldb.logstore.search.aggregations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class AutoDateHistogramAggBuilderTest {
+
+  @Test
+  public void testEqualsAndHashCode() {
+    assertThat(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                "day",
+                10,
+                List.of(new AvgAggBuilder("name", "field", null, null))))
+        .isEqualTo(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                "day",
+                10,
+                List.of(new AvgAggBuilder("name", "field", null, null))));
+
+    assertThat(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                null,
+                null,
+                List.of(new AvgAggBuilder("name", "field", null, null))))
+        .isEqualTo(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                null,
+                null,
+                List.of(new AvgAggBuilder("name", "field", null, null))));
+
+    assertThat(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                "day",
+                null,
+                List.of(new AvgAggBuilder("name", "field", null, null))))
+        .isNotEqualTo(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                null,
+                null,
+                List.of(new AvgAggBuilder("name", "field", null, null))));
+
+    assertThat(
+            new AutoDateHistogramAggBuilder(
+                "name", "field", null, 10, List.of(new AvgAggBuilder("name", "field", null, null))))
+        .isNotEqualTo(
+            new AutoDateHistogramAggBuilder(
+                "name",
+                "field",
+                null,
+                null,
+                List.of(new AvgAggBuilder("name", "field", null, null))));
+  }
+}

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/DateHistogramAggBuilderTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/search/aggregations/DateHistogramAggBuilderTest.java
@@ -16,6 +16,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 0,
                 "epoch_ms",
                 Map.of("max", 1L, "min", 0L),
@@ -26,6 +27,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 0,
                 "epoch_ms",
                 Map.of("max", 1L, "min", 0L),
@@ -36,6 +38,7 @@ public class DateHistogramAggBuilderTest {
                     "field",
                     "1d",
                     "10s",
+                    "-01:00",
                     0,
                     "epoch_ms",
                     Map.of("max", 1L, "min", 0L),
@@ -47,6 +50,7 @@ public class DateHistogramAggBuilderTest {
                     "field",
                     "1d",
                     "10s",
+                    "-01:00",
                     0,
                     "epoch_ms",
                     Map.of("max", 1L, "min", 0L),
@@ -59,6 +63,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 1,
                 "epoch_ms",
                 Map.of(),
@@ -69,6 +74,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 1,
                 "epoch_ms",
                 Map.of(),
@@ -80,6 +86,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "1d",
+                "-01:00",
                 1,
                 "epoch_ms",
                 Map.of(),
@@ -90,6 +97,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 1,
                 "epoch_ms",
                 Map.of(),
@@ -97,10 +105,10 @@ public class DateHistogramAggBuilderTest {
 
     assertThat(
             new DateHistogramAggBuilder(
-                "name", "field", "12d", "10s", 1, "epoch_ms", Map.of(), List.of()))
+                "name", "field", "12d", "10s", "-01:00", 1, "epoch_ms", Map.of(), List.of()))
         .isNotEqualTo(
             new DateHistogramAggBuilder(
-                "name", "field", "1d", "10s", 1, "epoch_ms", Map.of(), List.of()));
+                "name", "field", "1d", "10s", "-01:00", 1, "epoch_ms", Map.of(), List.of()));
 
     assertThat(
             new DateHistogramAggBuilder(
@@ -108,6 +116,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 0,
                 "epoch_ms",
                 Map.of("max", 1L, "min", 0L),
@@ -118,6 +127,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 0,
                 "epoch_ms",
                 Map.of("max", 1L, "min", 1L),
@@ -129,6 +139,7 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 1,
                 "epoch_ms",
                 Map.of(),
@@ -139,9 +150,33 @@ public class DateHistogramAggBuilderTest {
                 "field",
                 "1d",
                 "10s",
+                "-01:00",
                 1,
                 "epoch_ms",
                 Map.of(),
                 List.of(new AvgAggBuilder("name", "field2", null, null))));
+
+    assertThat(
+            new DateHistogramAggBuilder(
+                "name",
+                "field",
+                "1d",
+                "10s",
+                null,
+                1,
+                "epoch_ms",
+                Map.of(),
+                List.of(new AvgAggBuilder("name", "field1", null, null))))
+        .isNotEqualTo(
+            new DateHistogramAggBuilder(
+                "name",
+                "field",
+                "1d",
+                "10s",
+                "-01:00",
+                1,
+                "epoch_ms",
+                Map.of(),
+                List.of(new AvgAggBuilder("name", "field1", null, null))));
   }
 }


### PR DESCRIPTION
###  Summary

Improves ES query support for Grafana 10. This is to enable easier datasource migrations from ES to Astra.

This improves the current state of #798, but a greater rework of query parsing is still needed.