### PR TITLE
deal with muliple tags with the same key

### DIFF
--- a/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/kaldb/src/main/java/com/slack/kaldb/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -430,7 +430,9 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     Map<String, Trace.KeyValue> tags =
         message.getTagsList().stream()
             .map(keyValue -> Map.entry(keyValue.getKey(), keyValue))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey, Map.Entry::getValue, (firstKV, dupKV) -> firstKV));
 
     // This should just be top level Trace.Span fields. This is error prone - what if type is
     // not a string?

--- a/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/logstore/schema/RaiseErrorFieldValueTest.java
@@ -166,7 +166,7 @@ public class RaiseErrorFieldValueTest {
                         1, "Test message", Instant.now(), List.of(hostField, tagField))))
         .isInstanceOf(FieldDefMismatchException.class);
 
-    assertThat(docBuilder.getSchema().size()).isEqualTo(19);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
     assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.STRING);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();
@@ -206,7 +206,7 @@ public class RaiseErrorFieldValueTest {
                         1, "Test message", Instant.now(), List.of(hostField, tagField))))
         .isInstanceOf(FieldDefMismatchException.class);
 
-    assertThat(docBuilder.getSchema().size()).isEqualTo(18);
+    assertThat(docBuilder.getSchema().size()).isEqualTo(17);
     assertThat(docBuilder.getSchema().keySet()).contains(hostNameField);
     assertThat(docBuilder.getSchema().get(hostNameField).fieldType).isEqualTo(FieldType.STRING);
     assertThat(MetricsUtil.getCount(DROP_FIELDS_COUNTER, meterRegistry)).isZero();

--- a/kaldb/src/test/java/com/slack/kaldb/schema/SpanTagFormatterWithSchemaTest.java
+++ b/kaldb/src/test/java/com/slack/kaldb/schema/SpanTagFormatterWithSchemaTest.java
@@ -337,5 +337,27 @@ public class SpanTagFormatterWithSchemaTest {
 
     logStore.addMessage(span);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
+
+    // duplicate tags
+    span =
+        Trace.Span.newBuilder()
+            .setName("service1")
+            .setId(ByteString.copyFrom("123".getBytes()))
+            .addTags(
+                Trace.KeyValue.newBuilder()
+                    .setKey("tag1")
+                    .setVStr("value1")
+                    .setVType(Trace.ValueType.STRING)
+                    .setFieldType(Schema.SchemaFieldType.KEYWORD))
+            .addTags(
+                Trace.KeyValue.newBuilder()
+                    .setKey("tag1")
+                    .setVStr("value1")
+                    .setVType(Trace.ValueType.STRING)
+                    .setFieldType(Schema.SchemaFieldType.KEYWORD))
+            .build();
+
+    logStore.addMessage(span);
+    assertThat(getCount(MESSAGES_FAILED_COUNTER, meterRegistry)).isEqualTo(0);
   }
 }


### PR DESCRIPTION
###  Summary

deal with muliple tags with the same key

Without the fix, if there are multiple tags with the same key we throw this error
```
java.lang.IllegalStateException: Duplicate key tag1 (attempted merging values key: "tag1"
v_str: "value1"
 and key: "tag1"
v_str: "value1"
)

	at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:135)
	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:182)
...

```
