### PR TITLE
Update docker compose to work with astra grafana plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,13 @@ services:
       - zookeeper
 
   grafana:
-    image: 'grafana/grafana:8.0.3'
+    image: 'grafana/grafana:10.3.1'
     container_name: dep_grafana
     ports:
       - '3000:3000'
     volumes:
       - ./config/grafana/provisioning:/etc/grafana/provisioning
-      - ../slack-kaldb-app:/var/lib/grafana/plugins
+      - ../slack-astra-app:/var/lib/grafana/plugins
     environment:
       GF_LOG_MODE: "console file"
       GF_LOG_LEVEL: "info"
@@ -42,7 +42,7 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
       GF_PATHS_PLUGINS: "/var/lib/grafana/plugins"
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-kaldb-app,slack-kaldb-app-backend-datasource"
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-astra-app,slack-astra-app-backend-datasource"
 
   s3:
     image: 'adobe/s3mock:2.1.29'


### PR DESCRIPTION
###  Summary
Updates docker compose to allow the astra grafana plugin to work. (note, the [slack-astra-app](https://github.com/slackhq/slack-astra-app) repo must be cloned in the same directory where the astra project is cloned. Also the build instructions need to be followed as well.

TODO: fix other flags. current `HEAD` renamed some flags since this update. 

TODO: provision the datasource. Configuration that works:
![image](https://github.com/slackhq/astra/assets/24304518/c6948d17-1286-41cd-b127-d7a122f2db3e)


### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
