### PR TITLE
Increase max operations per run for stale workflow (default of 30)

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -24,3 +24,4 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
           days-before-pr-stale: 30
           days-before-pr-close: 3
+          operations-per-run: 200


### PR DESCRIPTION
###  Summary

Fixes an issue where we run out of operation "tokens" before completing the work required. 