### PR TITLE
protect against empty or null tag values

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -139,7 +139,11 @@ public class BulkApiRequestParser {
       if (!tagsContainServiceName && kv.getKey().equals(SERVICE_NAME_KEY)) {
         tagsContainServiceName = true;
       }
-      spanBuilder.addAllTags(SpanFormatter.convertKVtoProto(kv.getKey(), kv.getValue(), schema));
+      List<Trace.KeyValue> tags =
+          SpanFormatter.convertKVtoProto(kv.getKey(), kv.getValue(), schema);
+      if (tags != null) {
+        spanBuilder.addAllTags(tags);
+      }
     }
     if (!tagsContainServiceName) {
       spanBuilder.addTags(

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -160,6 +160,10 @@ public class SpanFormatter {
 
   public static List<Trace.KeyValue> convertKVtoProto(
       String key, Object value, Schema.IngestSchema schema) {
+    if (value == null || value.toString().isEmpty()) {
+      return null;
+    }
+
     if (schema.containsFields(key)) {
       List<Trace.KeyValue> tags = new ArrayList<>();
       Schema.SchemaField schemaFieldDef = schema.getFieldsMap().get(key);
@@ -185,7 +189,7 @@ public class SpanFormatter {
     }
   }
 
-  public static Trace.KeyValue convertKVtoProto(String key, Object value) {
+  private static Trace.KeyValue convertKVtoProto(String key, Object value) {
     Trace.KeyValue.Builder tagBuilder = Trace.KeyValue.newBuilder();
     tagBuilder.setKey(key);
     if (value instanceof String) {

--- a/astra/src/test/resources/opensearchRequest/bulk/index_all_schema_fields.ndjson
+++ b/astra/src/test/resources/opensearchRequest/bulk/index_all_schema_fields.ndjson
@@ -1,6 +1,6 @@
 { "index" : { "_index" : "test", "_id" : "1" } }
 { "host" : "host1", "message" : "foo bar", "ip" : "192.168.1.1", "my_date" : "2014-09-01T12:00:00Z", "success" : true, "cost": 4.0, "amount" : 1.1, "amount_half_float" : 1.2, "value" : 42, "count" : 3, "count_scaled_long" : 80, "count_short" : 10, "bucket" : "20" }
 { "index" : { "_index" : "test", "_id" : "2" } }
-{ "parent_id" : "1", "trace_id" : "2", "name": "check", "ip" :  "::afff:4567:890a", "duration" : 20000, "username": "me" }
+{ "parent_id" : "1", "trace_id" : "2", "name": "check", "ip" :  "::afff:4567:890a", "duration" : 20000, "username": "me", "bucket": null }
 
 

--- a/astra/src/test/resources/opensearchRequest/bulk/index_with_null_values.ndjson
+++ b/astra/src/test/resources/opensearchRequest/bulk/index_with_null_values.ndjson
@@ -1,0 +1,2 @@
+{ "index" : { "_index" : "test", "_id" : "1" } }
+{ "parent_id" : "1", "username": "me", "bucket": null }


### PR DESCRIPTION
###  Summary

```
Cannot invoke \"Object.toString()\" because \"value\" is null","error_stack_trace":"java.lang.NullPointerException: Cannot invoke \"Object.toString()\" because \"value\" is null com.slack.astra.writer.SpanFormatter.convertKVtoProto(SpanFormatter.java:158)
 com.slack.astra.bulkIngestApi.opensearch.BulkApiRequestParser.fromIngestDocument(BulkApiRequestParser.java:142)
 com.slack.astra.bulkIngestApi.opensearch.BulkApiRequestParser.convertIndexRequestToTraceFormat(BulkApiRequestParser.java:168)
 com.slack.astra.bulkIngestApi.opensearch.BulkApiRequestParser.parseRequest(BulkApiRequestParser.java:43)
 com.slack.astra.bulkIngestApi.BulkIngestApi.addDocument(BulkIngestApi.java:73)
 com.linecorp.armeria.internal.server.annotation.AnnotatedService.invoke(AnnotatedService.java:382)
 com.linecorp.armeria.internal.server.annotation.AnnotatedService.lambda$serve1$4(AnnotatedService.java:334)
```

I saw this stack trace. I believe this can happen if the schema is defined for a field and the value is explicitly sent as null ( which I guess is possible )

Added test case which would fail without the fix
