### PR TITLE
Switch bulk ingest as config default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -140,5 +140,5 @@ preprocessorConfig:
   dataTransformer: ${PREPROCESSOR_TRANSFORMER:-json}
   rateLimiterMaxBurstSeconds: ${PREPROCESSOR_RATE_LIMITER_MAX_BURST_SECONDS:-1}
   kafkaPartitionStickyTimeoutMs: ${KAFKA_PARTITION_STICKY_TIMEOUT_MS:-0}
-  useBulkApi: ${ASTRA_PREPROCESSOR_USE_BULK_API:-false}
+  useBulkApi: ${ASTRA_PREPROCESSOR_USE_BULK_API:-true}
   rateLimitExceededErrorCode: ${ASTRA_PREPROCESSOR_RATE_LIMIT_EXCEEDED_ERROR_CODE:-400}


### PR DESCRIPTION
###  Summary

Switches the bulk ingest to the default config, as this is a deprecated config option.