### PR TITLE
Add extra config docs, multisearch api expanded

### DIFF
--- a/docs/api/query_api.yaml
+++ b/docs/api/query_api.yaml
@@ -9,7 +9,7 @@ paths:
       summary: Cluster metadata
       responses:
         '200':
-          description: A JSON object of cluster metadata
+          description: Cluster metadata
           content:
             application/json:
               schema:
@@ -19,7 +19,7 @@ paths:
                     type: object
                     properties:
                       distribution:
-                        description: "Astra"
+                        description: "'astra'"
                         type: string
                       number:
                         description: "Release version of cluster"
@@ -33,21 +33,134 @@ paths:
                     #  lucene_version: 9.7.0
   /_msearch:
     post:
-      summary: Multisearch
       requestBody:
-        description: NDJSON
+        description: Bulk search
         required: true
         content:
           application/ndjson:
             schema:
               type: object
+              properties:
+                '{header}':
+                  type: object
+                  description: "Newline delineated JSON header"
+                  required: true
+                  properties:
+                    index:
+                      description: "Index name to search"
+                      type: string
+                      required: true
+                '{body}':
+                  type: object
+                  description: "Newline delineated JSON body"
+                  required: true
+                  properties:
+                    size:
+                      description: "Amount of results to return"
+                      type: integer
+                      required: true
+                      minimum: 0
+                    query:
+                      description: "Query object"
+                      type: object
+                      properties:
+                        bool:
+                          type: object
+                          properties:
+                            filter:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  range:
+                                    type: object
+                                    properties:
+                                      '{timefield}':
+                                        properties:
+                                          gte:
+                                            type: number
+                                            required: true
+                                          lte:
+                                            type: number
+                                            required: true
+                                  query_string:
+                                    type: object
+                                    properties:
+                                      query:
+                                        type: string
+                    aggs:
+                      type: object
+                      description: "Requested search aggregations"
+                      properties:
+                        '{name}':
+                          type: object
+                          description: "Keyed by name of requested aggregation"
+                          properties:
+                            aggs:
+                              type: object
+                              description: "Nested aggregations"
+                            date_histogram:
+                              type: object
+                            terms:
+                              type: object
+
       responses:
         '200':
-          description: A JSON response
+          description: Bulk search results
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  took:
+                    type: integer
+                  responses:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        took:
+                          type: integer
+                        timed_out:
+                          type: boolean
+                        _shards:
+                          type: object
+                          properties:
+                            failed:
+                              type: number
+                            total:
+                              type: number
+                        _debug:
+                          type: object
+                        hits:
+                          type: object
+                          properties:
+                            total:
+                              type: object
+                              properties:
+                                value:
+                                  type: number
+                                relation:
+                                  type: string
+                            max_score:
+                              type: object
+                            hits:
+                              type: array
+                              items:
+                                type: object
+                        aggregations:
+                          type: object
+                          properties:
+                            '{name}':
+                              type: object
+                        status:
+                          type: number
+                  _debug:
+                    type: object
+                    properties:
+                      traceId:
+                        type: string
+                        description: "Trace ID for the returned result"
 
 
   /{indexName}/_mapping:
@@ -60,13 +173,30 @@ paths:
             type: string
           required: true
           description: Index name as stored by cluster
-          examples:
-            all:
-              value: _all
-              summary: Query all indexes
-            index:
-              value: foo
-              summary: Query specific index "foo"
       responses:
         '200':
-          description: A JSON object of field mapping
+          description: Index field mappings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  '{indexName}':
+                    type: object
+                    properties:
+                      mappings:
+                        type: object
+                        properties:
+                          type: object
+                          properties:
+                            type: object
+                            properties:
+                              type: object
+                              '{fieldName}':
+                                properties:
+                                  'type':
+                                    type: string
+                                    description: "One of valid schema types"
+                                    enum: [ keyword, text, ip, date, boolean, double, float, half_float, integer, long, scaled_long, short, byte, binary]
+
+

--- a/docs/cfg/glossary.xml
+++ b/docs/cfg/glossary.xml
@@ -2,4 +2,8 @@
 <!DOCTYPE terms SYSTEM "https://resources.jetbrains.com/writerside/1.0/glossary.dtd">
 <terms>
     <term name="mmap">Method for mapping file I/O to memory</term>
+    <term name="snapshot">A representation of a chunk stored in Zookeeper</term>
+    <term name="chunk">A object describing a Lucene index and its associated metadata</term>
+    <term name="replica">An assignable request to serve a snapshot, stored in Zookeeper</term>
+    <term name="dataset">A representation of an index and its metadata, stored in Zookeeper</term>
 </terms>

--- a/docs/topics/API-opensearch.md
+++ b/docs/topics/API-opensearch.md
@@ -16,13 +16,134 @@ Definitions for the OpenSearch compatible API, queryable via the Grafana and end
             </sample>
         </response>
     </api-endpoint>
-    <api-endpoint endpoint="_msearch" method="POST">
+    <api-endpoint endpoint="/_msearch" method="POST"> 
         <request>
             <sample lang="JSON">
+                {
+                    "index": "_all" 
+                }
+                {
+                    "size": 0,
+                    "query":
+                    {
+                        "bool": 
+                        { 
+                            "filter":
+                            [ 
+                                { 
+                                    "range": 
+                                    {
+                                        "_timesinceepoch":   
+                                        {
+                                            "gte": 1713287603983, 
+                                            "lte": 1713291203983,
+                                        }
+                                    }
+                                },
+                                {
+                                    "query_string":
+                                    {
+                                        "query": "*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggs":
+                    { 
+                        "2":  
+                        {
+                            "date_histogram":
+                            {  
+                                "interval": "10m", 
+                                "field": "_timesinceepoch",
+                                "min_doc_count": 0,
+                                "extended_bounds": 
+                                {  
+                                    "min": 1713287603983, 
+                                    "max": 1713291203983  
+                                }, 
+                                "format": "epoch_millis" 
+                            },
+                            "aggs": 
+                            {}
+                        }
+                    }
+                }
             </sample>
         </request>
         <response type="200">
             <sample lang="JSON">
+                {
+                    "took": 0,
+                    "responses":
+                    [
+                        { 
+                            "took": 52,  
+                            "timed_out": false, 
+                            "_shards": 
+                            {
+                                "failed": 0,
+                                "total": 3
+                            },
+                            "_debug":
+                            {},
+                            "hits":
+                            {
+                                "total":
+                                {
+                                    "value": 0,
+                                    "relation": "eq"
+                                },
+                                "max_score": null,
+                                "hits":
+                                []
+                            },
+                            "aggregations":
+                            {
+                                "2":
+                                {
+                                    "buckets":
+                                    [
+                                        {
+                                            "key": 1713287400000,
+                                            "doc_count": 343718
+                                        },
+                                        { 
+                                            "key": 1713288000000,
+                                            "doc_count": 591515
+                                        },   
+                                        {
+                                            "key": 1713288600000, 
+                                            "doc_count": 547228
+                                        }, 
+                                        {
+                                            "key": 1713289200000,
+                                            "doc_count": 467128 
+                                        }, 
+                                        { 
+                                            "key": 1713289800000, 
+                                            "doc_count": 539753    
+                                        }, 
+                                        { 
+                                            "key": 1713290400000,  
+                                            "doc_count": 481929
+                                        },
+                                        {
+                                            "key": 1713291000000,
+                                            "doc_count": 170998
+                                        }
+                                    ]
+                                }
+                            },
+                            "status": 200
+                        }
+                    ],
+                    "_debug":
+                    {
+                        "traceId": "d691f1b383052b8d" 
+                    }
+                }
             </sample>
         </response>
     </api-endpoint>
@@ -30,11 +151,11 @@ Definitions for the OpenSearch compatible API, queryable via the Grafana and end
         <response type="200">
             <sample lang="JSON">
                 {
-                    "_all": {
+                    "_all": { 
                         "mappings": {
                             "properties": {
                                 "_timesinceepoch": {
-                                    "type": "date"
+                                    "type": "date" 
                                 }
                                 "@version": {
                                     "type": "keyword"
@@ -51,7 +172,7 @@ Definitions for the OpenSearch compatible API, queryable via the Grafana and end
                             }
                         }
                     }
-                }
+                } 
             </sample>
         </response>
     </api-endpoint>


### PR DESCRIPTION
###  Summary

Adds the remaining config definitions and expands the multisearch api docs. The current state of the OpenApi spec support within Writerside is limited, and these definitions attempt to work within what is currently supported there.