### PR TITLE
make conversions more robust

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -262,7 +262,8 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         indexTypedField(doc, key, convertedValue, registeredField);
       } else {
         LOG.warn(
-            "No mapping found to convert value from={} to={}",
+            "No mapping found to convert key={} value from={} to={}",
+            key,
             valueType.name,
             registeredField.fieldType.name);
         convertErrorCounter.increment();

--- a/astra/src/main/java/com/slack/astra/metadata/schema/FieldType.java
+++ b/astra/src/main/java/com/slack/astra/metadata/schema/FieldType.java
@@ -404,6 +404,9 @@ public enum FieldType {
       if (toType == FieldType.BOOLEAN) {
         return ((String) value).equals("1") || ((String) value).equalsIgnoreCase("true");
       }
+      if (toType == FieldType.BINARY) {
+        return ByteString.copyFromUtf8((String) value);
+      }
     }
 
     // Int type
@@ -497,6 +500,11 @@ public enum FieldType {
       }
       if (toType == FieldType.DOUBLE) {
         return (Boolean) value ? 1d : 0d;
+      }
+    }
+    if (fromType == FieldType.BINARY) {
+      if (isTexty(toType)) {
+        return ((ByteString) value).toStringUtf8();
       }
     }
     return null;

--- a/astra/src/test/java/com/slack/astra/metadata/schema/FieldTypeTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/schema/FieldTypeTest.java
@@ -3,6 +3,7 @@ package com.slack.astra.metadata.schema;
 import static com.slack.astra.metadata.schema.FieldType.convertFieldValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
 
 public class FieldTypeTest {
@@ -14,6 +15,8 @@ public class FieldTypeTest {
     assertThat(convertFieldValue("3", FieldType.TEXT, FieldType.DOUBLE)).isEqualTo(3.0d);
     assertThat(convertFieldValue("4", FieldType.TEXT, FieldType.STRING)).isEqualTo("4");
     assertThat(convertFieldValue("4", FieldType.STRING, FieldType.TEXT)).isEqualTo("4");
+    assertThat(convertFieldValue("[1,2,3]", FieldType.KEYWORD, FieldType.BINARY))
+        .isEqualTo(ByteString.copyFromUtf8("[1,2,3]"));
     assertThat(convertFieldValue("1", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(true);
     assertThat(convertFieldValue("0", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(false);
     assertThat(convertFieldValue("true", FieldType.STRING, FieldType.BOOLEAN)).isEqualTo(true);
@@ -132,5 +135,10 @@ public class FieldTypeTest {
     assertThat(convertFieldValue(1L, FieldType.LONG, FieldType.LONG)).isEqualTo(1L);
     assertThat(convertFieldValue(2.0f, FieldType.FLOAT, FieldType.FLOAT)).isEqualTo(2.0f);
     assertThat(convertFieldValue(3.0d, FieldType.DOUBLE, FieldType.DOUBLE)).isEqualTo(3.0d);
+
+    assertThat(
+            convertFieldValue(
+                ByteString.copyFromUtf8("[1,2,3]"), FieldType.BINARY, FieldType.KEYWORD))
+        .isEqualTo("[1,2,3]");
   }
 }


### PR DESCRIPTION
###  Summary

Let's assume there is a key called `primary_keys` . The values I've seen can be `C014A143GG` , `<not logged on bootstrap>` and `ABC, XYZ` etc.


The SpanFormatter#convertKVtoProto (preprocessor) for `ABC,XYZ` is getting indexed as a BINARY. My understanding is the `value` is a list and the toString is what leads to `ABC, XYZ`

So now `primary_keys` ends up being defined as binary. Next time `C014A143GG` comes in it's a Keyword

Then in the indexer we don't have a type conversion b/w keyword->binary and vice versa

This PR just adds that. The whole field detection logic and how it then interacts with the field conversion in the indexer is janky. This is just a tactical fix b/w keyword->binary and vice versa