### PR TITLE
add basic support for list and map

### DIFF
--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -192,7 +192,7 @@ public class SpanFormatter {
   private static Trace.KeyValue convertKVtoProto(String key, Object value) {
     Trace.KeyValue.Builder tagBuilder = Trace.KeyValue.newBuilder();
     tagBuilder.setKey(key);
-    if (value instanceof String) {
+    if (value instanceof String || value instanceof List || value instanceof Map) {
       tagBuilder.setFieldType(Schema.SchemaFieldType.KEYWORD);
       tagBuilder.setVStr(value.toString());
     } else if (value instanceof Boolean) {

--- a/astra/src/test/resources/opensearchRequest/bulk/index_nested_fields.ndjson
+++ b/astra/src/test/resources/opensearchRequest/bulk/index_nested_fields.ndjson
@@ -1,0 +1,4 @@
+{ "index" : { "_index" : "test", "_id" : "1" } }
+{ "list_field" : ["host1", "host2"], "map_field" : { "f1":  "v1"} }
+{ "index" : { "_index" : "test", "_id" : "2" } }
+{ "list_field" : "host3", "map_field" : "f1=v1" }


### PR DESCRIPTION
###  Summary

A start towards support lists and maps. This PR just deals with those two when a field does *not* have a schema field defined.

Before we'd just index them as Binary and then land up in scenarios like https://github.com/slackhq/astra/pull/870 where if one value was a list and the second value was a string then we index them as separate fields.

To support this in the schema we need to do a few things
1. Evolve trace.proto to take multiple values and perhaps even nested values so that we don't need to do toString and it can be multi-valued
2. schema.proto should support configs list multiValued, perhaps say it's a list or map even
