### PR TITLE
Fix docs sitemap urls

### DIFF
--- a/docs/cfg/buildprofiles.xml
+++ b/docs/cfg/buildprofiles.xml
@@ -17,6 +17,7 @@
             <include-in-head>include_head.html</include-in-head>
             <enable-browser-edits>true</enable-browser-edits>
             <browser-edits-url>https://github.com/slackhq/astra/edit/master/docs/</browser-edits-url>
+            <generate-sitemap-url-prefix>https://slackhq.github.io/astra/</generate-sitemap-url-prefix>
             <web-root>https://slackhq.github.io/astra/</web-root>
         </variables>
         <sitemap priority="0.35" change-frequency="monthly"/>


### PR DESCRIPTION
###  Summary

Fixes a sitemap issue where the urls were automatically getting an extra `/astra` inserted into the path (see https://slackhq.github.io/astra/sitemap.xml for example).

```xml
<url>
<loc>
https://slackhq.github.io/astra/astra/api-manager.html
</loc>
<lastmod>2024-04-19</lastmod>
<changefreq>monthly</changefreq>
<priority>0.35</priority>
</url>
```