### PR TITLE
Improve flaky test execution

### DIFF
--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -28,7 +28,7 @@
         <opensearch.version>2.11.1</opensearch.version>
         <curator.version>5.6.0</curator.version>
         <log4j.version>2.23.1</log4j.version>
-        <aws.sdk.version>2.25.31</aws.sdk.version>
+        <aws.sdk.version>2.25.36</aws.sdk.version>
         <error.prone.version>2.23.0</error.prone.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
     </properties>
@@ -332,7 +332,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.29.14</version>
+            <version>0.29.18</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,6 +170,7 @@ class BulkIngestKafkaProducerTest {
   }
 
   @Test
+  @Disabled("Flaky test")
   public void testDocumentInKafkaTransactionError() throws Exception {
     KafkaConsumer kafkaConsumer = getTestKafkaConsumer();
 
@@ -205,6 +207,7 @@ class BulkIngestKafkaProducerTest {
     assertThat(responseObj.failedDocs()).isEqualTo(5);
     assertThat(responseObj.errorMsg()).isNotNull();
 
+    // todo - this pretty consistently times out waiting to evaluate true
     await()
         .until(
             () -> {


### PR DESCRIPTION
##  Summary

This PR attempts to improve a few flaky test executions. Reviewing the most recent 12 failures (both in outstanding PRs and against master) they seem to broadly land into two root causes.

### BulkIngestKafkaProducerTest
* `BulkIngestKafkaProducerTest.testDocumentInKafkaTransactionError:209`
This appears to regularly fail due to the Kafka offsets not meeting the expected criteria. This test was disabled.

### S3 CRT related
There were several tests that fell under this category:
* `LuceneIndexStoreImplTest$SnapshotTester.testS3SnapshotWithPrefix:344->testS3Snapshot`
* `S3CrtBlobFsTest.testDeleteFolder:227`
* `S3CrtBlobFsTest.testExists:285`

These all appear to be related to a `s3metaRequest` NPE within the AWS sdk. 

https://www.github.com/aws/aws-sdk-java-v2/issues/3658