### PR TITLE
Add all contributors information

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "astra",
+  "projectOwner": "slackhq"
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![release version](https://img.shields.io/github/v/release/slackhq/astra?include_prereleases)](https://github.com/slackhq/astra/releases)
 [![release pipeline](https://img.shields.io/github/actions/workflow/status/slackhq/astra/maven.yml?branch=master)](https://github.com/slackhq/astra/actions/workflows/maven.yml)
 [![license](https://img.shields.io/github/license/slackhq/astra)](https://github.com/slackhq/astra/blob/master/LICENSE)
+[![All Contributors](https://img.shields.io/github/all-contributors/slackhq/astra?color=ee8449)](#contributors)
+
 
 Astra is a cloud-native search and analytics engine for log, trace, and audit data. It is designed to be easy to operate, 
 cost-effective, and scale to petabytes of data.
@@ -31,8 +33,16 @@ https://slackhq.github.io/astra/
 - Support for JVM versions other than the current LTS.
 - Supporting multiple Lucene versions.
 
-## Contributing
-If you are interested in reporting/fixing issues and contributing directly to the code base, please see [CONTRIBUTING](.github/CONTRIBUTING.md) for more information on what we're looking for and how to get started.
-
 ## Licensing
 Licensed under [MIT](LICENSE). Copyright (c) 2024 Slack.
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
###  Summary

Adds https://allcontributors.org/ to the project for recognizing folks that have contributed, via code or other contributions.