### PR TITLE
Make java build step conditional

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -8,7 +8,6 @@
   "commitConvention": "angular",
   "contributorsPerLine": 7,
   "linkToUsage": false,
-  "skipCi": true,
   "contributors": [
     {
       "login": "vthacker",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,29 @@ permissions:
 env:
   INSTANCE: docs/astra
   ARTIFACT: webHelpASTRA2-all.zip
-  DOCKER_VERSION: 233.14938
+  DOCKER_VERSION: 241.15989
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+
   build:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
 
     steps:
       - name: Checkout repository
@@ -41,8 +59,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
+    needs: [changes, build]
     runs-on: ubuntu-latest
+    if: ${{ needs.changes.outputs.docs == 'true' }}
 
     steps:
       - name: Download artifact

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,13 +13,22 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          java:
+            - 'astra/**'
+            - 'benchmarks/**'
+            - 'config/**'
+            - 'pom.xml'
     - name: Set up JDK 21
+      if: steps.filter.outputs.java == 'true'
       uses: actions/setup-java@v3
       with:
         java-version: '21'
@@ -28,8 +37,11 @@ jobs:
         distribution: 'corretto'
         cache: 'maven'
     - name: Ensure code is formatted
+      if: steps.filter.outputs.java == 'true'
       run: mvn -B -Dstyle.color=always com.spotify.fmt:fmt-maven-plugin:check --file astra/pom.xml
     - name: Ensure jmh benchmark code is formatted
+      if: steps.filter.outputs.java == 'true'
       run: mvn -B -Dstyle.color=always com.spotify.fmt:fmt-maven-plugin:check --file benchmarks/pom.xml
     - name: Build with Maven
+      if: steps.filter.outputs.java == 'true'
       run: mvn -B -Dstyle.color=always package --file pom.xml


### PR DESCRIPTION
###  Summary

Makes Java build step conditional based on path (should still "pass" as a required check immediately). Removes the skipci from allcontributors since the build step is still required, and skip ci causes it not to run.