### PR TITLE
Add true date field support and also index "@timestamp" as a date

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -9,10 +9,6 @@ import com.slack.astra.writer.SpanFormatter;
 import com.slack.service.murron.trace.Trace;
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -55,15 +51,12 @@ public class BulkApiRequestParser {
     try {
       if (sourceAndMetadata.containsKey(ReservedFields.TIMESTAMP)) {
         String dateString = (String) sourceAndMetadata.get(ReservedFields.TIMESTAMP);
-        LocalDateTime localDateTime =
-            LocalDateTime.parse(dateString, DateTimeFormatter.ISO_DATE_TIME);
-        Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+        Instant instant = Instant.parse(dateString);
         return instant.toEpochMilli();
       }
 
       // assumption that the provided timestamp is in millis
-      // at some point both th unit and field need to be configurable
-      // when we do that, remember to change the called to appropriately remove the field
+      // at some point both the unit and field need to be configurable
       if (sourceAndMetadata.containsKey("timestamp")) {
         return (long) sourceAndMetadata.get("timestamp");
       }
@@ -76,10 +69,8 @@ public class BulkApiRequestParser {
           "Unable to parse timestamp from ingest document. Using current time as timestamp", e);
     }
 
-    return ((ZonedDateTime)
-            sourceAndMetadata.getOrDefault("timestamp", ZonedDateTime.now(ZoneOffset.UTC)))
-        .toInstant()
-        .toEpochMilli();
+    // We tried parsing 3 timestamp fields and failed. Use the current time
+    return Instant.now().toEpochMilli();
   }
 
   @VisibleForTesting

--- a/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
@@ -1,0 +1,6 @@
+package com.slack.astra.logstore.schema;
+
+public class ReservedFields {
+
+  public static final String TIMESTAMP = "@timestamp";
+}

--- a/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
@@ -1,6 +1,17 @@
 package com.slack.astra.logstore.schema;
 
+import com.slack.astra.proto.schema.Schema;
+
 public class ReservedFields {
 
   public static final String TIMESTAMP = "@timestamp";
+
+  public static Schema.IngestSchema addPredefinedFields(Schema.IngestSchema currentSchema) {
+    Schema.SchemaField timestampField =
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.DATE).build();
+    return Schema.IngestSchema.newBuilder()
+        .putAllFields(currentSchema.getFieldsMap())
+        .putFields(TIMESTAMP, timestampField)
+        .build();
+  }
 }

--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -19,8 +19,6 @@ import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -490,9 +488,8 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
       } else if (schemaFieldType == Schema.SchemaFieldType.DATE) {
         Instant instant =
             Instant.ofEpochSecond(keyValue.getVDate().getSeconds(), keyValue.getVDate().getNanos());
-        LocalDateTime date = LocalDateTime.ofInstant(instant, ZoneId.of("UTC"));
-        addField(doc, keyValue.getKey(), date, Schema.SchemaFieldType.DATE, "", 0);
-        jsonMap.put(keyValue.getKey(), date.toString());
+        addField(doc, keyValue.getKey(), instant, Schema.SchemaFieldType.DATE, "", 0);
+        jsonMap.put(keyValue.getKey(), instant.toString());
       } else if (schemaFieldType == Schema.SchemaFieldType.BOOLEAN) {
         addField(
             doc, keyValue.getKey(), keyValue.getVBool(), Schema.SchemaFieldType.BOOLEAN, "", 0);

--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -19,6 +19,8 @@ import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -486,8 +488,11 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         addField(doc, keyValue.getKey(), keyValue.getVStr(), Schema.SchemaFieldType.IP, "", 0);
         jsonMap.put(keyValue.getKey(), keyValue.getVStr());
       } else if (schemaFieldType == Schema.SchemaFieldType.DATE) {
-        addField(doc, keyValue.getKey(), keyValue.getVInt64(), Schema.SchemaFieldType.DATE, "", 0);
-        jsonMap.put(keyValue.getKey(), keyValue.getVInt64());
+        Instant instant =
+            Instant.ofEpochSecond(keyValue.getVDate().getSeconds(), keyValue.getVDate().getNanos());
+        LocalDateTime date = LocalDateTime.ofInstant(instant, ZoneId.of("UTC"));
+        addField(doc, keyValue.getKey(), date, Schema.SchemaFieldType.DATE, "", 0);
+        jsonMap.put(keyValue.getKey(), date.toString());
       } else if (schemaFieldType == Schema.SchemaFieldType.BOOLEAN) {
         addField(
             doc, keyValue.getKey(), keyValue.getVBool(), Schema.SchemaFieldType.BOOLEAN, "", 0);

--- a/astra/src/main/java/com/slack/astra/metadata/schema/FieldType.java
+++ b/astra/src/main/java/com/slack/astra/metadata/schema/FieldType.java
@@ -7,8 +7,6 @@ import com.google.protobuf.ByteString;
 import com.slack.astra.proto.schema.Schema;
 import java.net.InetAddress;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 import org.apache.lucene.document.Document;
@@ -136,14 +134,13 @@ public enum FieldType {
   DATE("date") {
     @Override
     public void addField(Document doc, String name, Object value, LuceneFieldDef fieldDef) {
-      if (value instanceof LocalDateTime localDateTime) {
-        Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+      if (value instanceof Instant instant) {
         long timeSinceEpoch = instant.toEpochMilli();
         if (fieldDef.isIndexed) {
           doc.add(new LongPoint(name, timeSinceEpoch));
         }
         if (fieldDef.isStored) {
-          doc.add(new StoredField(name, localDateTime.toString()));
+          doc.add(new StoredField(name, instant.toString()));
         }
         if (fieldDef.storeDocValue) {
           doc.add(new NumericDocValuesField(name, timeSinceEpoch));

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -21,6 +21,7 @@ import com.slack.astra.clusterManager.ReplicaRestoreService;
 import com.slack.astra.clusterManager.SnapshotDeletionService;
 import com.slack.astra.elasticsearchApi.ElasticsearchApiService;
 import com.slack.astra.logstore.LogMessage;
+import com.slack.astra.logstore.schema.ReservedFields;
 import com.slack.astra.logstore.search.AstraDistributedQueryService;
 import com.slack.astra.logstore.search.AstraLocalQueryService;
 import com.slack.astra.metadata.cache.CacheSlotMetadataStore;
@@ -407,6 +408,12 @@ public class Astra {
           LOG.info("Loaded schema with total fields: {}", schema.getFieldsCount());
         } else {
           LOG.info("No schema file provided, using default schema");
+          Schema.SchemaField timestampField =
+              Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.DATE).build();
+          schema =
+              Schema.IngestSchema.newBuilder()
+                  .putFields(ReservedFields.TIMESTAMP, timestampField)
+                  .build();
         }
         BulkIngestApi openSearchBulkApiService =
             new BulkIngestApi(

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -408,13 +408,8 @@ public class Astra {
           LOG.info("Loaded schema with total fields: {}", schema.getFieldsCount());
         } else {
           LOG.info("No schema file provided, using default schema");
-          Schema.SchemaField timestampField =
-              Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.DATE).build();
-          schema =
-              Schema.IngestSchema.newBuilder()
-                  .putFields(ReservedFields.TIMESTAMP, timestampField)
-                  .build();
         }
+        schema = ReservedFields.addPredefinedFields(schema);
         BulkIngestApi openSearchBulkApiService =
             new BulkIngestApi(
                 bulkIngestKafkaProducer,

--- a/astra/src/main/proto/trace.proto
+++ b/astra/src/main/proto/trace.proto
@@ -8,6 +8,8 @@ option java_package = "com.slack.service.murron.trace";
 option go_package = "com.slack/astra/gen/proto/tracepb";
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
 import "schema.proto";
 
 message KeyValue {
@@ -19,6 +21,7 @@ message KeyValue {
   bytes     v_binary  = 7;
   int32     v_int32   = 8;
   float     v_float32 = 9;
+  google.protobuf.Timestamp v_date = 11;
   slack.proto.astra.schema.SchemaFieldType fieldType = 10;
 }
 

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
@@ -45,7 +45,7 @@ public class BulkApiRequestParserTest {
     assertThat(indexDocs.get("test").size()).isEqualTo(1);
 
     assertThat(indexDocs.get("test").get(0).getId().toStringUtf8()).isEqualTo("1");
-    assertThat(indexDocs.get("test").get(0).getTagsList().size()).isEqualTo(5);
+    assertThat(indexDocs.get("test").get(0).getTagsList().size()).isEqualTo(4);
     assertThat(
             indexDocs.get("test").get(0).getTagsList().stream()
                 .filter(

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
@@ -272,7 +272,8 @@ public class BulkApiRequestParserTest {
   public void testTimestampParsingFromIngestDocument() {
     IngestDocument ingestDocument =
         new IngestDocument("index", "1", "routing", 1L, VersionType.INTERNAL, Map.of());
-    long timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    long timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     Instant ingestDocumentTime = Instant.ofEpochMilli(timeInMillis);
 
     // this tests that the parser inserted a timestamp close to the current time
@@ -287,7 +288,8 @@ public class BulkApiRequestParserTest {
     ingestDocument =
         new IngestDocument(
             "index", "1", "routing", 1L, VersionType.INTERNAL, Map.of("@timestamp", ts));
-    timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     assertThat(timeInMillis).isEqualTo(providedTimeStamp.toEpochMilli());
 
     // we put a long in the @timestamp field, which today we don't parse
@@ -300,7 +302,8 @@ public class BulkApiRequestParserTest {
             1L,
             VersionType.INTERNAL,
             Map.of("@timestamp", providedTimeStamp.toEpochMilli()));
-    timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     ingestDocumentTime = Instant.ofEpochMilli(timeInMillis);
     assertThat(oneMinuteBefore.isBefore(ingestDocumentTime)).isTrue();
     assertThat(ingestDocumentTime.isBefore(oneMinuteAfter)).isTrue();
@@ -310,7 +313,8 @@ public class BulkApiRequestParserTest {
     ingestDocument =
         new IngestDocument(
             "index", "1", "routing", 1L, VersionType.INTERNAL, Map.of("_timestamp", ts));
-    timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     ingestDocumentTime = Instant.ofEpochMilli(timeInMillis);
     assertThat(oneMinuteBefore.isBefore(ingestDocumentTime)).isTrue();
     assertThat(ingestDocumentTime.isBefore(oneMinuteAfter)).isTrue();
@@ -320,7 +324,8 @@ public class BulkApiRequestParserTest {
     ingestDocument =
         new IngestDocument(
             "index", "1", "routing", 1L, VersionType.INTERNAL, Map.of("timestamp", ts));
-    timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     ingestDocumentTime = Instant.ofEpochMilli(timeInMillis);
     assertThat(oneMinuteBefore.isBefore(ingestDocumentTime)).isTrue();
     assertThat(ingestDocumentTime.isBefore(oneMinuteAfter)).isTrue();
@@ -333,7 +338,8 @@ public class BulkApiRequestParserTest {
             1L,
             VersionType.INTERNAL,
             Map.of("timestamp", providedTimeStamp.toEpochMilli()));
-    timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     assertThat(timeInMillis).isEqualTo(providedTimeStamp.toEpochMilli());
 
     ingestDocument =
@@ -344,7 +350,8 @@ public class BulkApiRequestParserTest {
             1L,
             VersionType.INTERNAL,
             Map.of("_timestamp", providedTimeStamp.toEpochMilli()));
-    timeInMillis = BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument);
+    timeInMillis =
+        BulkApiRequestParser.getTimestampFromIngestDocument(ingestDocument.getSourceAndMetadata());
     assertThat(timeInMillis).isEqualTo(providedTimeStamp.toEpochMilli());
   }
 }

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParserTest.java
@@ -45,7 +45,7 @@ public class BulkApiRequestParserTest {
     assertThat(indexDocs.get("test").size()).isEqualTo(1);
 
     assertThat(indexDocs.get("test").get(0).getId().toStringUtf8()).isEqualTo("1");
-    assertThat(indexDocs.get("test").get(0).getTagsList().size()).isEqualTo(4);
+    assertThat(indexDocs.get("test").get(0).getTagsList().size()).isEqualTo(5);
     assertThat(
             indexDocs.get("test").get(0).getTagsList().stream()
                 .filter(


### PR DESCRIPTION
###  Summary


PR does two things.

1. Add true date field support  - which means any schema defined date field will get stored as a date and the indexer will use it appropriately. i.e you can do date range queries but the values will show up a a string an not a long since epoch like it was previously.
2. Index "@timestamp" as a date field if the document contains it. For now just treat this as an additional field and then later solidify our plan our reserved fields.
