### PR TITLE
remove special handling for "type" and remove some reserved fields that were not being used

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -216,8 +216,6 @@ public class OpenSearchAdapter {
    * and if not attempt to register it with the mapper service
    */
   public void reloadSchema() {
-    // todo - see SchemaAwareLogDocumentBuilderImpl.getDefaultLuceneFieldDefinitions
-    //  this needs to be adapted to include other field types once we have support
     // TreeMap here ensures the schema is sorted by natural order - to ensure multifields are
     // registered by their parent first, and then fields added second
     for (Map.Entry<String, LuceneFieldDef> entry : new TreeMap<>(chunkSchema).entrySet()) {

--- a/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
@@ -1,5 +1,6 @@
 package com.slack.astra.logstore.schema;
 
+import com.slack.astra.logstore.LogMessage;
 import com.slack.astra.proto.schema.Schema;
 
 public class ReservedFields {
@@ -9,9 +10,25 @@ public class ReservedFields {
   public static Schema.IngestSchema addPredefinedFields(Schema.IngestSchema currentSchema) {
     Schema.SchemaField timestampField =
         Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.DATE).build();
+    Schema.SchemaField messageField =
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.TEXT).build();
+    Schema.SchemaField allField =
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.TEXT).build();
+    Schema.SchemaField timeSinceEpoch =
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.LONG).build();
+    Schema.SchemaField idField =
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.ID).build();
+
     return Schema.IngestSchema.newBuilder()
         .putAllFields(currentSchema.getFieldsMap())
         .putFields(TIMESTAMP, timestampField)
+        .putFields(LogMessage.ReservedField.MESSAGE.fieldName, messageField)
+        .putFields(LogMessage.SystemField.ALL.fieldName, allField)
+        .putFields(LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, timeSinceEpoch)
+        .putFields(LogMessage.SystemField.ID.fieldName, idField)
         .build();
   }
+
+  public static Schema.IngestSchema START_SCHEMA =
+      addPredefinedFields(Schema.IngestSchema.getDefaultInstance());
 }

--- a/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/SchemaAwareLogDocumentBuilderImpl.java
@@ -6,7 +6,6 @@ import static com.slack.astra.writer.SpanFormatter.DEFAULT_LOG_MESSAGE_TYPE;
 import static com.slack.astra.writer.SpanFormatter.isValidTimestamp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableMap;
 import com.slack.astra.logstore.DocumentBuilder;
 import com.slack.astra.logstore.FieldDefMismatchException;
 import com.slack.astra.logstore.LogMessage;
@@ -48,66 +47,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
 
   // TODO: In future, make this value configurable.
   private static final int MAX_NESTING_DEPTH = 3;
-
-  private static void addTextField(
-      ImmutableMap.Builder<String, LuceneFieldDef> fieldDefBuilder,
-      String fieldName,
-      boolean isStored,
-      boolean isIndexed) {
-    fieldDefBuilder.put(
-        fieldName, new LuceneFieldDef(fieldName, FieldType.TEXT.name, isStored, isIndexed, false));
-  }
-
-  // TODO: Move this definition to the config file.
-  public static ImmutableMap<String, LuceneFieldDef> getDefaultLuceneFieldDefinitions(
-      boolean enableFullTextSearch) {
-    ImmutableMap.Builder<String, LuceneFieldDef> fieldDefBuilder = ImmutableMap.builder();
-
-    addTextField(fieldDefBuilder, LogMessage.SystemField.SOURCE.fieldName, true, false);
-    addTextField(fieldDefBuilder, LogMessage.ReservedField.MESSAGE.fieldName, false, true);
-    if (enableFullTextSearch) {
-      addTextField(fieldDefBuilder, LogMessage.SystemField.ALL.fieldName, false, true);
-    }
-
-    String[] fieldsAsString = {
-      LogMessage.SystemField.INDEX.fieldName,
-      LogMessage.ReservedField.TYPE.fieldName,
-      LogMessage.ReservedField.HOSTNAME.fieldName,
-      LogMessage.ReservedField.PACKAGE.fieldName,
-      LogMessage.ReservedField.TAG.fieldName,
-      LogMessage.ReservedField.USERNAME.fieldName,
-      LogMessage.ReservedField.PAYLOAD.fieldName,
-      LogMessage.ReservedField.NAME.fieldName,
-      LogMessage.ReservedField.SERVICE_NAME.fieldName,
-      LogMessage.ReservedField.TRACE_ID.fieldName,
-      LogMessage.ReservedField.PARENT_ID.fieldName
-    };
-
-    for (String fieldName : fieldsAsString) {
-      fieldDefBuilder.put(
-          fieldName, new LuceneFieldDef(fieldName, FieldType.STRING.name, false, true, true));
-    }
-
-    String[] fieldsAsIds = {
-      LogMessage.SystemField.ID.fieldName,
-    };
-    for (String fieldName : fieldsAsIds) {
-      fieldDefBuilder.put(
-          fieldName, new LuceneFieldDef(fieldName, FieldType.ID.name, false, true, true));
-    }
-
-    String[] fieldsAsLong = {
-      LogMessage.ReservedField.DURATION_MS.fieldName,
-      LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName,
-    };
-
-    for (String fieldName : fieldsAsLong) {
-      fieldDefBuilder.put(
-          fieldName, new LuceneFieldDef(fieldName, FieldType.LONG.name, false, true, true));
-    }
-
-    return fieldDefBuilder.build();
-  }
 
   /**
    * This enum tracks the field conflict policy for a chunk.
@@ -228,12 +167,12 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
 
   private boolean isDocValueField(Schema.SchemaFieldType schemaFieldType, String fieldName) {
     return !fieldName.equals(LogMessage.SystemField.SOURCE.fieldName)
-        || !schemaFieldType.equals(Schema.SchemaFieldType.TEXT);
+        && !schemaFieldType.equals(Schema.SchemaFieldType.TEXT);
   }
 
   private boolean isIndexed(Schema.SchemaFieldType schemaFieldType, String fieldName) {
     return !fieldName.equals(LogMessage.SystemField.SOURCE.fieldName)
-        || !schemaFieldType.equals(Schema.SchemaFieldType.BINARY);
+        && !schemaFieldType.equals(Schema.SchemaFieldType.BINARY);
   }
 
   // In the future, we need this to take SchemaField instead of FieldType
@@ -289,10 +228,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
       MeterRegistry meterRegistry) {
     // Add basic fields by default
     return new SchemaAwareLogDocumentBuilderImpl(
-        fieldConflictPolicy,
-        getDefaultLuceneFieldDefinitions(enableFullTextSearch),
-        enableFullTextSearch,
-        meterRegistry);
+        fieldConflictPolicy, enableFullTextSearch, meterRegistry);
   }
 
   static final String DROP_FIELDS_COUNTER = "dropped_fields";
@@ -312,7 +248,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
 
   SchemaAwareLogDocumentBuilderImpl(
       FieldConflictPolicy indexFieldConflictPolicy,
-      final Map<String, LuceneFieldDef> initialFields,
       boolean enableFullTextSearch,
       MeterRegistry meterRegistry) {
     this.indexFieldConflictPolicy = indexFieldConflictPolicy;
@@ -323,9 +258,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     convertAndDuplicateFieldCounter = meterRegistry.counter(CONVERT_AND_DUPLICATE_FIELD_COUNTER);
     convertErrorCounter = meterRegistry.counter(CONVERT_ERROR_COUNTER);
     totalFieldsCounter = meterRegistry.counter(TOTAL_FIELDS_COUNTER);
-
-    totalFieldsCounter.increment(initialFields.size());
-    fieldDefMap.putAll(initialFields);
   }
 
   @Override
@@ -381,7 +313,7 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
           doc,
           LogMessage.SystemField.ID.fieldName,
           message.getId().toStringUtf8(),
-          Schema.SchemaFieldType.KEYWORD,
+          Schema.SchemaFieldType.ID,
           "",
           0);
     } else {
@@ -433,18 +365,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
     // if we don't do this LogMessage#isValid will be unhappy when we recreate the message
     // we need to fix this!!!
     indexName = computedIndexName(indexName);
-    String msgType =
-        tags.containsKey(LogMessage.ReservedField.TYPE.fieldName)
-            ? tags.get(LogMessage.ReservedField.TYPE.fieldName).getVStr()
-            : DEFAULT_LOG_MESSAGE_TYPE;
-
-    addField(
-        doc,
-        LogMessage.ReservedField.TYPE.fieldName,
-        msgType,
-        Schema.SchemaFieldType.KEYWORD,
-        "",
-        0);
 
     jsonMap.put(LogMessage.ReservedField.SERVICE_NAME.fieldName, indexName);
     addField(
@@ -463,7 +383,6 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
         0);
 
     tags.remove(LogMessage.ReservedField.SERVICE_NAME.fieldName);
-    tags.remove(LogMessage.ReservedField.TYPE.fieldName);
 
     // if any top level fields are in the tags, we should remove them
     tags.remove(LogMessage.ReservedField.PARENT_ID.fieldName);
@@ -539,6 +458,10 @@ public class SchemaAwareLogDocumentBuilderImpl implements DocumentBuilder {
       }
     }
 
+    String msgType =
+        tags.containsKey(LogMessage.ReservedField.TYPE.fieldName)
+            ? tags.get(LogMessage.ReservedField.TYPE.fieldName).getVStr()
+            : DEFAULT_LOG_MESSAGE_TYPE;
     LogWireMessage logWireMessage =
         new LogWireMessage(indexName, msgType, message.getId().toStringUtf8(), timestamp, jsonMap);
     final String msgString = JsonUtil.writeAsString(logWireMessage);

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.google.protobuf.ByteString;
 import com.slack.astra.blobfs.s3.S3CrtBlobFs;
 import com.slack.astra.blobfs.s3.S3TestUtils;
 import com.slack.astra.logstore.LogMessage;
@@ -33,7 +32,6 @@ import com.slack.astra.metadata.search.SearchMetadataStore;
 import com.slack.astra.metadata.snapshot.SnapshotMetadata;
 import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
-import com.slack.astra.proto.schema.Schema;
 import com.slack.astra.testlib.MessageUtil;
 import com.slack.astra.testlib.SpanUtil;
 import com.slack.service.murron.trace.Trace;
@@ -499,16 +497,7 @@ public class IndexingChunkImplTest {
 
     @Test
     public void testAddInvalidMessagesToChunk() {
-      Trace.Span invalidSpan =
-          Trace.Span.newBuilder()
-              .setId(ByteString.copyFromUtf8("1"))
-              .addTags(
-                  Trace.KeyValue.newBuilder()
-                      .setVInt32(123)
-                      .setKey(LogMessage.ReservedField.MESSAGE.fieldName)
-                      .setFieldType(Schema.SchemaFieldType.INTEGER)
-                      .build())
-              .build();
+      Trace.Span invalidSpan = Trace.Span.newBuilder().build();
 
       // An Invalid message is dropped but failure counter is incremented.
       chunk.addMessage(invalidSpan, TEST_KAFKA_PARTITION_ID, 1);

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -15,7 +15,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
-import com.google.protobuf.ByteString;
 import com.slack.astra.blobfs.s3.S3CrtBlobFs;
 import com.slack.astra.blobfs.s3.S3TestUtils;
 import com.slack.astra.logstore.LogMessage;
@@ -30,7 +29,6 @@ import com.slack.astra.metadata.search.SearchMetadataStore;
 import com.slack.astra.metadata.snapshot.SnapshotMetadata;
 import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
-import com.slack.astra.proto.schema.Schema;
 import com.slack.astra.testlib.MessageUtil;
 import com.slack.astra.testlib.SpanUtil;
 import com.slack.service.murron.trace.Trace;
@@ -493,16 +491,7 @@ public class RecoveryChunkImplTest {
     public void testAddInvalidMessagesToChunk() {
 
       // An Invalid message is dropped but failure counter is incremented.
-      Trace.Span invalidSpan =
-          Trace.Span.newBuilder()
-              .setId(ByteString.copyFromUtf8("1"))
-              .addTags(
-                  Trace.KeyValue.newBuilder()
-                      .setVInt32(123)
-                      .setKey(LogMessage.ReservedField.MESSAGE.fieldName)
-                      .setFieldType(Schema.SchemaFieldType.INTEGER)
-                      .build())
-              .build();
+      Trace.Span invalidSpan = Trace.Span.newBuilder().build();
       chunk.addMessage(invalidSpan, TEST_KAFKA_PARTITION_ID, 1);
       chunk.commit();
 

--- a/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/elasticsearchApi/ElasticsearchApiServiceTest.java
@@ -137,7 +137,7 @@ public class ElasticsearchApiServiceTest {
         objectMapper.convertValue(
             jsonNode.get("test").get("mappings").get("properties"), Map.class);
     assertThat(map).isNotNull();
-    assertThat(map.size()).isEqualTo(31);
+    assertThat(map.size()).isEqualTo(25);
   }
 
   // todo - test mapping

--- a/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
@@ -209,15 +209,8 @@ public class LuceneIndexStoreImplTest {
 
     @Test
     public void failIndexingDocsWithMismatchedTypeErrors() {
-      Trace.KeyValue wrongField =
-          Trace.KeyValue.newBuilder()
-              .setKey(ReservedField.HOSTNAME.fieldName)
-              .setFieldType(Schema.SchemaFieldType.INTEGER)
-              .setVInt32(20000)
-              .build();
 
-      logStore.logStore.addMessage(
-          SpanUtil.makeSpan(100, "test", Instant.now(), List.of(wrongField)));
+      logStore.logStore.addMessage(Trace.Span.newBuilder().build());
       addMessages(logStore.logStore, 1, 99, true);
       Collection<LogMessage> results =
           findAllMessages(logStore.logSearcher, MessageUtil.TEST_DATASET_NAME, "identifier", 1000);

--- a/astra/src/test/java/com/slack/astra/logstore/schema/FieldConflictStrategyTests.java
+++ b/astra/src/test/java/com/slack/astra/logstore/schema/FieldConflictStrategyTests.java
@@ -84,7 +84,7 @@ public class FieldConflictStrategyTests {
             2, "Test message", Instant.now(), List.of(hostField, tagField, conflictingTagInt));
 
     Document msg1Doc = raiseErrorDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     try {
       raiseErrorDocBuilder.fromMessage(doc2);
@@ -94,23 +94,23 @@ public class FieldConflictStrategyTests {
     }
 
     msg1Doc = dropFieldDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     Document msg2Doc = dropFieldDocBuilder.fromMessage(doc2);
     // 2 less because docValue is also missing
-    assertThat(msg2Doc.getFields().size()).isEqualTo(27);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(26);
 
     msg1Doc = convertFieldDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     msg2Doc = convertFieldDocBuilder.fromMessage(doc2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(28);
 
     msg1Doc = convertAndDuplicateFieldDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     msg2Doc = convertAndDuplicateFieldDocBuilder.fromMessage(doc2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(31);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(30);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.INTEGER);
     // Value converted and new field is added.
     assertThat(getFieldCount(msg2Doc, Set.of(conflictingFieldName, additionalCreatedFieldName)))
@@ -170,7 +170,7 @@ public class FieldConflictStrategyTests {
             3, "Test message", Instant.now(), List.of(hostField, tagField, conflictingTagInt));
 
     Document msg1Doc = raiseErrorDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     try {
       raiseErrorDocBuilder.fromMessage(doc2);
@@ -187,40 +187,40 @@ public class FieldConflictStrategyTests {
     }
 
     msg1Doc = dropFieldDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     Document msg2Doc = dropFieldDocBuilder.fromMessage(doc2);
     // 2 less because docValue is also missing
-    assertThat(msg2Doc.getFields().size()).isEqualTo(27);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(26);
 
     Document msg3Doc = dropFieldDocBuilder.fromMessage(doc3);
     // 2 less because docValue is also missing
-    assertThat(msg3Doc.getFields().size()).isEqualTo(27);
+    assertThat(msg3Doc.getFields().size()).isEqualTo(26);
 
     msg1Doc = convertFieldDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     msg2Doc = convertFieldDocBuilder.fromMessage(doc2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(28);
     // If this ever fails is because message ordering changed the getField returns the DV variant
     assertThat(msg2Doc.getField(conflictingFieldName).binaryValue().utf8ToString()).isEqualTo("F");
 
     msg3Doc = convertFieldDocBuilder.fromMessage(doc3);
-    assertThat(msg3Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg3Doc.getFields().size()).isEqualTo(28);
     assertThat(msg3Doc.getField(conflictingFieldName).binaryValue().utf8ToString()).isEqualTo("T");
 
     msg1Doc = convertAndDuplicateFieldDocBuilder.fromMessage(doc1);
-    assertThat(msg1Doc.getFields().size()).isEqualTo(29);
+    assertThat(msg1Doc.getFields().size()).isEqualTo(28);
 
     msg2Doc = convertAndDuplicateFieldDocBuilder.fromMessage(doc2);
-    assertThat(msg2Doc.getFields().size()).isEqualTo(31);
+    assertThat(msg2Doc.getFields().size()).isEqualTo(30);
     String additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.KEYWORD);
     // Value converted and new field is added.
     assertThat(getFieldCount(msg2Doc, Set.of(conflictingFieldName, additionalCreatedFieldName)))
         .isEqualTo(4);
 
     msg3Doc = convertAndDuplicateFieldDocBuilder.fromMessage(doc3);
-    assertThat(msg3Doc.getFields().size()).isEqualTo(31);
+    assertThat(msg3Doc.getFields().size()).isEqualTo(30);
     additionalCreatedFieldName = makeNewFieldOfType(conflictingFieldName, FieldType.INTEGER);
     // Value converted and new field is added.
     assertThat(getFieldCount(msg3Doc, Set.of(conflictingFieldName, additionalCreatedFieldName)))

--- a/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
@@ -1326,6 +1326,22 @@ public class LogIndexSearcherImplTest {
         .isZero();
 
     // Without the _all field as default.
+
+    assertThat(
+            strictLogStoreWithoutFts
+                .logSearcher
+                .search(
+                    TEST_DATASET_NAME,
+                    "apple baby",
+                    0L,
+                    MAX_TIME,
+                    1000,
+                    new DateHistogramAggBuilder(
+                        "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "1s"))
+                .hits
+                .size())
+        .isEqualTo(1);
+
     assertThat(
             strictLogStoreWithoutFts
                 .logSearcher
@@ -1339,7 +1355,7 @@ public class LogIndexSearcherImplTest {
                         "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "1s"))
                 .hits
                 .size())
-        .isEqualTo(2);
+        .isEqualTo(0);
 
     assertThat(
             strictLogStoreWithoutFts
@@ -1354,7 +1370,7 @@ public class LogIndexSearcherImplTest {
                         "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "1s"))
                 .hits
                 .size())
-        .isEqualTo(3);
+        .isEqualTo(2);
 
     // empty string
     assertThat(

--- a/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
+++ b/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
@@ -491,10 +491,10 @@ public class SpanFormatterWithSchemaTest {
             SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.DROP_FIELD, true, meterRegistry);
     Document luceneDocument = dropFieldBuilder.fromMessage(span);
     // message is a tag, but is a TEXT field in schema, so it is indexed and not doc values
-    // 13 tags X 2(DV and indexed) + (message,message.keyword,_id,_timesinceepoch,type,_index) x2 +
+    // 13 tags X 2(DV and indexed) + (message,message.keyword,_id,_timesinceepoch,_index) x2 +
     // _source + _all
 
-    assertThat(luceneDocument.getFields().size()).isEqualTo(39);
+    assertThat(luceneDocument.getFields().size()).isEqualTo(37);
 
     for (Map.Entry<String, Trace.KeyValue> keyAndTag : tags.entrySet()) {
       String key = keyAndTag.getKey();

--- a/astra/src/test/java/com/slack/astra/server/AstraTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraTest.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.slack.astra.blobfs.s3.S3TestUtils;
 import com.slack.astra.chunkManager.RollOverChunkTask;
-import com.slack.astra.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
 import com.slack.astra.metadata.core.AstraMetadataTestUtils;
 import com.slack.astra.metadata.core.CuratorBuilder;
 import com.slack.astra.metadata.dataset.DatasetMetadata;
@@ -275,14 +274,6 @@ public class AstraTest {
             indexerMeterRegistry);
     indexer.serviceManager.awaitHealthy(DEFAULT_START_STOP_DURATION);
 
-    await()
-        .until(
-            () ->
-                getCount(
-                        SchemaAwareLogDocumentBuilderImpl.TOTAL_FIELDS_COUNTER,
-                        indexerMeterRegistry)
-                    == 22);
-
     AstraSearch.SearchResult indexerSearchResponse =
         searchUsingGrpcApi("*:*", indexerPort, 0, end1Time.toEpochMilli(), "3650d");
     assertThat(indexerSearchResponse.getTotalNodes()).isEqualTo(1);
@@ -435,14 +426,6 @@ public class AstraTest {
             indexer1MeterRegistry);
     indexer1.serviceManager.awaitHealthy(DEFAULT_START_STOP_DURATION);
 
-    await()
-        .until(
-            () ->
-                getCount(
-                        SchemaAwareLogDocumentBuilderImpl.TOTAL_FIELDS_COUNTER,
-                        indexer1MeterRegistry)
-                    == 22);
-
     LOG.info("Starting indexer service 2");
     int indexerPort2 = 11000;
     final Instant startTime2 = Instant.now().plusSeconds(600);
@@ -460,14 +443,6 @@ public class AstraTest {
             startTime2,
             indexer2MeterRegistry);
     indexer2.serviceManager.awaitHealthy(DEFAULT_START_STOP_DURATION);
-
-    await()
-        .until(
-            () ->
-                getCount(
-                        SchemaAwareLogDocumentBuilderImpl.TOTAL_FIELDS_COUNTER,
-                        indexer2MeterRegistry)
-                    == 22);
 
     AstraSearch.SearchResult indexerSearchResponse =
         searchUsingGrpcApi("*:*", indexerPort, 0L, endTime.toEpochMilli(), "3650d");

--- a/astra/src/test/java/com/slack/astra/writer/LogMessageWriterImplTest.java
+++ b/astra/src/test/java/com/slack/astra/writer/LogMessageWriterImplTest.java
@@ -259,8 +259,7 @@ public class LogMessageWriterImplTest {
     for (IndexRequest indexRequest : indexRequests) {
       IngestDocument ingestDocument = convertRequestToDocument(indexRequest);
       Trace.Span span =
-          BulkApiRequestParser.fromIngestDocument(
-              ingestDocument, Schema.IngestSchema.newBuilder().build());
+          BulkApiRequestParser.fromIngestDocument(ingestDocument, ReservedFields.START_SCHEMA);
       ConsumerRecord<String, byte[]> spanRecord = consumerRecordWithValue(span.toByteArray());
       LogMessageWriterImpl messageWriter = new LogMessageWriterImpl(chunkManagerUtil.chunkManager);
       assertThat(messageWriter.insertRecord(spanRecord)).isTrue();
@@ -408,8 +407,6 @@ public class LogMessageWriterImplTest {
 
   @Test
   public void testReservedFields() throws IOException {
-    Schema.IngestSchema schema = Schema.IngestSchema.newBuilder().build();
-    schema = ReservedFields.addPredefinedFields(schema);
 
     String request =
         """
@@ -424,7 +421,8 @@ public class LogMessageWriterImplTest {
 
     for (IndexRequest indexRequest : indexRequests) {
       IngestDocument ingestDocument = convertRequestToDocument(indexRequest);
-      Trace.Span span = BulkApiRequestParser.fromIngestDocument(ingestDocument, schema);
+      Trace.Span span =
+          BulkApiRequestParser.fromIngestDocument(ingestDocument, ReservedFields.START_SCHEMA);
       ConsumerRecord<String, byte[]> spanRecord = consumerRecordWithValue(span.toByteArray());
       LogMessageWriterImpl messageWriter = new LogMessageWriterImpl(chunkManagerUtil.chunkManager);
       assertThat(messageWriter.insertRecord(spanRecord)).isTrue();


### PR DESCRIPTION
###  Summary

We don't need to do any special handling for the type tag. This also means user definition for type is respected and not overriden.
