### PR TITLE
Add subfield support 

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
@@ -2,6 +2,7 @@ package com.slack.astra.logstore.schema;
 
 import com.slack.astra.logstore.LogMessage;
 import com.slack.astra.proto.schema.Schema;
+import java.util.Map;
 
 public class ReservedFields {
 
@@ -20,6 +21,8 @@ public class ReservedFields {
         Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.ID).build();
 
     return Schema.IngestSchema.newBuilder()
+        .setEnableKeywordSubfield(currentSchema.getEnableKeywordSubfield())
+        .setIgnoreAboveSubfield(currentSchema.getIgnoreAboveSubfield())
         .putAllFields(currentSchema.getFieldsMap())
         .putFields(TIMESTAMP, timestampField)
         .putFields(LogMessage.ReservedField.MESSAGE.fieldName, messageField)
@@ -31,4 +34,30 @@ public class ReservedFields {
 
   public static Schema.IngestSchema START_SCHEMA =
       addPredefinedFields(Schema.IngestSchema.getDefaultInstance());
+
+  public static Schema.SchemaField getSchemaFieldForType(Schema.SchemaFieldType type) {
+    return predefinedFields.getOrDefault(
+        type, Schema.SchemaField.newBuilder().setType(type).build());
+  }
+
+  private static final Map<Schema.SchemaFieldType, Schema.SchemaField> predefinedFields =
+      getPredefinedFields();
+
+  private static Map<Schema.SchemaFieldType, Schema.SchemaField> getPredefinedFields() {
+    return Map.of(
+        Schema.SchemaFieldType.BOOLEAN,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.BOOLEAN).build(),
+        Schema.SchemaFieldType.INTEGER,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.INTEGER).build(),
+        Schema.SchemaFieldType.LONG,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.LONG).build(),
+        Schema.SchemaFieldType.FLOAT,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.FLOAT).build(),
+        Schema.SchemaFieldType.DOUBLE,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.DOUBLE).build(),
+        Schema.SchemaFieldType.KEYWORD,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.KEYWORD).build(),
+        Schema.SchemaFieldType.TEXT,
+        Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.TEXT).build());
+  }
 }

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -405,7 +405,10 @@ public class Astra {
         if (!preprocessorConfig.getSchemaFile().isEmpty()) {
           LOG.info("Loading schema file: {}", preprocessorConfig.getSchemaFile());
           schema = SchemaUtil.parseSchema(Path.of(preprocessorConfig.getSchemaFile()));
-          LOG.info("Loaded schema with total fields: {}", schema.getFieldsCount());
+          LOG.info(
+              "Loaded schema with total fields: {} enable_keyword_subfield: {}",
+              schema.getFieldsCount(),
+              schema.getEnableKeywordSubfield());
         } else {
           LOG.info("No schema file provided, using default schema");
         }

--- a/astra/src/main/proto/schema.proto
+++ b/astra/src/main/proto/schema.proto
@@ -10,6 +10,8 @@ option java_package = "com.slack.astra.proto.schema";
 message IngestSchema {
   // convert to a map
   map<string, SchemaField> fields = 1;
+  bool enable_keyword_subfield = 2;
+  int32 ignore_above_subfield = 3;
 }
 
 message SchemaField {
@@ -20,7 +22,7 @@ message SchemaField {
 
 // https://opensearch.org/docs/2.4/opensearch/supported-field-types/index/
 // Add the remaining types as needed
-enum SchemaFieldType {
+enum  SchemaFieldType {
   KEYWORD  = 0;
   TEXT  = 1;
   IP  = 2;

--- a/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
+++ b/astra/src/test/java/com/slack/astra/schema/SpanFormatterWithSchemaTest.java
@@ -370,18 +370,18 @@ public class SpanFormatterWithSchemaTest {
     Schema.IngestSchema schema = Schema.IngestSchema.getDefaultInstance();
     Trace.KeyValue kv = SpanFormatter.convertKVtoProto("host", "host1", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("host1");
-    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
 
     kv = SpanFormatter.convertKVtoProto("ip", "8.8.8.8", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("8.8.8.8");
-    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
 
     kv = SpanFormatter.convertKVtoProto("myTimestamp", "2021-01-01T00:00:00Z", schema).get(0);
     assertThat(kv.getVStr()).isEqualTo("2021-01-01T00:00:00Z");
-    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
 
     kv = SpanFormatter.convertKVtoProto("success", "true", schema).get(0);
-    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
     assertThat(kv.getVStr()).isEqualTo("true");
 
     kv = SpanFormatter.convertKVtoProto("success", true, schema).get(0);
@@ -389,7 +389,7 @@ public class SpanFormatterWithSchemaTest {
     assertThat(kv.getVBool()).isEqualTo(true);
 
     kv = SpanFormatter.convertKVtoProto("cost", "10.0", schema).get(0);
-    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
     assertThat(kv.getVStr()).isEqualTo("10.0");
 
     kv = SpanFormatter.convertKVtoProto("amount", 10.0f, schema).get(0);
@@ -408,7 +408,7 @@ public class SpanFormatterWithSchemaTest {
     assertThat(kv.getVInt64()).isEqualTo(10L);
 
     kv = SpanFormatter.convertKVtoProto("bucket", "e30=", schema).get(0);
-    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.KEYWORD);
+    assertThat(kv.getFieldType()).isEqualTo(Schema.SchemaFieldType.TEXT);
     assertThat(kv.getVStr()).isEqualTo("e30=");
   }
 


### PR DESCRIPTION
###  Summary

- This changes default "texty" field to TEXT instead of KEYWORD for any field that has not been explicitly defined
- Adds subfield support meaning we can enable it and all TEXT fields will have another KEYWORD subfield for it

