### PR TITLE
Change error logging for opensearchadapter

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -507,7 +507,7 @@ public class OpenSearchAdapter {
             new CompressedXContent(BytesReference.bytes(mapping)),
             MapperService.MergeReason.MAPPING_UPDATE);
       } catch (Exception e) {
-        LOG.error("Error doing map update", e);
+        LOG.error("Error doing map update errorMsg={}", e.getMessage());
       }
       return true;
     }


### PR DESCRIPTION
###  Summary

A common error we see is
```
{"@timestamp":"2024-05-08T19:28:49.766Z","log.level":"ERROR","log.message":"Error doing map update","process.thread.name":"Timer-2","log.logger":"com.slack.astra.logstore.opensearch.OpenSearchAdapter","error_type":"java.lang.IllegalArgumentException","error_message":"can't merge a non object mapping [service] with an object mapping","error_stack_trace":"java.lang.IllegalArgumentException: can't merge a non object mapping [service] with an object mapping\n\tat org.opensearch.index.mapper.ObjectMapper.merge(ObjectMapper.java:576)\n\tat org.opensearch.index.mapper.ObjectMapper.doMerge(ObjectMapper.java:607)\n\tat org.opensearch.index.mapper.RootObjectMapper.doMerge(RootObjectMapper.java:351)\n\tat org.opensearch.index.mapper.ObjectMapper.merge(ObjectMapper.java:580)\n\tat org.opensearch.index.mapper.RootObjectMapper.merge(RootObjectMapper.java:346)\n\tat org.opensearch.index.mapper.Mapping.merge(Mapping.java:128)\n\tat org.opensearch.index.mapper.DocumentMapper.merge(DocumentMapper.java:307)\n\tat org.opensearch.index.mapper.MapperService.internalMerge(MapperService.java:482)\n\tat org.opensearch.index.mapper.MapperService.internalMerge(MapperService.java:444)\n\tat org.opensearch.index.mapper.MapperService.merge(MapperService.java:416)\n\tat com.slack.astra.logstore.opensearch.OpenSearchAdapter.tryRegisterField(OpenSearchAdapter.java:505)\n\tat com.slack.astra.logstore.opensearch.OpenSearchAdapter.reloadSchema(OpenSearchAdapter.java:228)\n\tat com.slack.astra.logstore.search.LogIndexSearcherImpl$1.afterRefresh(LogIndexSearcherImpl.java:73)\n\tat org.apache.lucene.search.ReferenceManager.notifyRefreshListenersRefreshed(ReferenceManager.java:275)\n\tat org.apache.lucene.search.ReferenceManager.doMaybeRefresh(ReferenceManager.java:182)\n\tat org.apache.lucene.search.ReferenceManager.maybeRefresh(ReferenceManager.java:213)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl.syncRefresh(LuceneIndexStoreImpl.java:227)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl.lambda$refresh$1(LuceneIndexStoreImpl.java:295)\n\tat io.micrometer.core.instrument.AbstractTimer.record(AbstractTimer.java:247)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl.refresh(LuceneIndexStoreImpl.java:291)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl$2.run(LuceneIndexStoreImpl.java:140)\n\tat java.base/java.util.TimerThread.mainLoop(Timer.java:566)\n\tat java.base/java.util.TimerThr...","error_root_cause_class_name":"java.lang.IllegalArgumentException","error_root_cause_message":"can't merge a non object mapping [service] with an object mapping","error_root_cause_stack_trace":"java.lang.IllegalArgumentException: can't merge a non object mapping [service] with an object mapping\n\tat org.opensearch.index.mapper.ObjectMapper.merge(ObjectMapper.java:576)\n\tat org.opensearch.index.mapper.ObjectMapper.doMerge(ObjectMapper.java:607)\n\tat org.opensearch.index.mapper.RootObjectMapper.doMerge(RootObjectMapper.java:351)\n\tat org.opensearch.index.mapper.ObjectMapper.merge(ObjectMapper.java:580)\n\tat org.opensearch.index.mapper.RootObjectMapper.merge(RootObjectMapper.java:346)\n\tat org.opensearch.index.mapper.Mapping.merge(Mapping.java:128)\n\tat org.opensearch.index.mapper.DocumentMapper.merge(DocumentMapper.java:307)\n\tat org.opensearch.index.mapper.MapperService.internalMerge(MapperService.java:482)\n\tat org.opensearch.index.mapper.MapperService.internalMerge(MapperService.java:444)\n\tat org.opensearch.index.mapper.MapperService.merge(MapperService.java:416)\n\tat com.slack.astra.logstore.opensearch.OpenSearchAdapter.tryRegisterField(OpenSearchAdapter.java:505)\n\tat com.slack.astra.logstore.opensearch.OpenSearchAdapter.reloadSchema(OpenSearchAdapter.java:228)\n\tat com.slack.astra.logstore.search.LogIndexSearcherImpl$1.afterRefresh(LogIndexSearcherImpl.java:73)\n\tat org.apache.lucene.search.ReferenceManager.notifyRefreshListenersRefreshed(ReferenceManager.java:275)\n\tat org.apache.lucene.search.ReferenceManager.doMaybeRefresh(ReferenceManager.java:182)\n\tat org.apache.lucene.search.ReferenceManager.maybeRefresh(ReferenceManager.java:213)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl.syncRefresh(LuceneIndexStoreImpl.java:227)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl.lambda$refresh$1(LuceneIndexStoreImpl.java:295)\n\tat io.micrometer.core.instrument.AbstractTimer.record(AbstractTimer.java:247)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl.refresh(LuceneIndexStoreImpl.java:291)\n\tat com.slack.astra.logstore.LuceneIndexStoreImpl$2.run(LuceneIndexStoreImpl.java:140)\n\tat java.base/java.util.TimerThread.mainLoop(Timer.java:566)\n\tat java.base/java.util.TimerThr..."}

```

I don't think this stack trace is adding any value.We see tens of thousands of these across our logging clusters . let's not print the stack trace and save our logging cluster that collects these logs 
