### PR TITLE
Add logging at main API endpoints (bulk ingest, msearch) when 500 is returned

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/BulkIngestApi.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/BulkIngestApi.java
@@ -81,6 +81,7 @@ public class BulkIngestApi {
         BulkIngestResponse response =
             new BulkIngestResponse(0, 0, "request must contain only 1 unique index");
         future.complete(HttpResponse.ofJson(INTERNAL_SERVER_ERROR, response));
+        LOG.error("request must contain only 1 unique index");
         return HttpResponse.of(future);
       }
 

--- a/astra/src/main/java/com/slack/astra/elasticsearchApi/ElasticsearchApiService.java
+++ b/astra/src/main/java/com/slack/astra/elasticsearchApi/ElasticsearchApiService.java
@@ -100,18 +100,18 @@ public class ElasticsearchApiService {
       CurrentTraceContext currentTraceContext = Tracing.current().currentTraceContext();
       try (var scope = new StructuredTaskScope<EsSearchResponse>()) {
         List<StructuredTaskScope.Subtask<EsSearchResponse>> requestSubtasks =
-          openSearchRequest.parseHttpPostBody(postBody).stream()
-            .map((request) -> scope.fork(currentTraceContext.wrap(() -> doSearch(request))))
-            .toList();
+            openSearchRequest.parseHttpPostBody(postBody).stream()
+                .map((request) -> scope.fork(currentTraceContext.wrap(() -> doSearch(request))))
+                .toList();
 
         scope.join();
         SearchResponseMetadata responseMetadata =
-          new SearchResponseMetadata(
-            0,
-            requestSubtasks.stream().map(StructuredTaskScope.Subtask::get).toList(),
-            Map.of("traceId", getTraceId()));
+            new SearchResponseMetadata(
+                0,
+                requestSubtasks.stream().map(StructuredTaskScope.Subtask::get).toList(),
+                Map.of("traceId", getTraceId()));
         return HttpResponse.of(
-          HttpStatus.OK, MediaType.JSON_UTF_8, JsonUtil.writeAsString(responseMetadata));
+            HttpStatus.OK, MediaType.JSON_UTF_8, JsonUtil.writeAsString(responseMetadata));
       }
     } catch (Exception e) {
       LOG.error("Error fulfilling request for multisearch query", e);


### PR DESCRIPTION
###  Summary
Add 2 more places to log errors where astra returns a 500. Without this, nothing is logged in these cases when astra encounters an internal server error. I picked error level because other places where a 500 is returned, those are also logged as errors. These may not be as severe and more implementation choices. I'm curious what level the reviewers would prefer here.

In the case of `request must contain only 1 unique index`, debug may be a more suitable log level as there could be a lot of these and error logs could be spammy.

For multisearch query, an example where this is triggered would be shown in the PR: https://github.com/slackhq/astra/pull/780. (Null pointer exception due to json deserialization logic) Potentially, this could be better suited as a warning log?

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
