### PR TITLE
Add sizeInBytes field

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunk/ChunkInfo.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ChunkInfo.java
@@ -42,7 +42,8 @@ public class ChunkInfo {
         chunkInfo.getDataEndTimeEpochMs(),
         chunkInfo.maxOffset,
         chunkInfo.kafkaPartitionId,
-        Metadata.IndexType.LOGS_LUCENE9);
+        Metadata.IndexType.LOGS_LUCENE9,
+        chunkInfo.sizeInBytes);
   }
 
   /* A unique identifier for a the chunk. */
@@ -77,6 +78,9 @@ public class ChunkInfo {
 
   // Path to S3 snapshot.
   private String snapshotPath;
+
+  // Size of chunk in bytes
+  private long sizeInBytes;
 
   public ChunkInfo(
       String chunkId, long chunkCreationTimeEpochMs, String kafkaPartitionId, String snapshotPath) {
@@ -164,6 +168,14 @@ public class ChunkInfo {
     return snapshotPath;
   }
 
+  public long getSizeInBytes() {
+    return sizeInBytes;
+  }
+
+  public void setSizeInBytes(long sizeInBytes) {
+    this.sizeInBytes = sizeInBytes;
+  }
+
   public void updateMaxOffset(long newOffset) {
     maxOffset = Math.max(maxOffset, newOffset);
   }
@@ -224,6 +236,8 @@ public class ChunkInfo {
         + chunkSnapshotTimeEpochMs
         + ", snapshotPath='"
         + snapshotPath
+        + ", sizeInBytes='"
+        + sizeInBytes
         + '}';
   }
 
@@ -240,7 +254,8 @@ public class ChunkInfo {
         && chunkSnapshotTimeEpochMs == chunkInfo.chunkSnapshotTimeEpochMs
         && Objects.equals(chunkId, chunkInfo.chunkId)
         && Objects.equals(kafkaPartitionId, chunkInfo.kafkaPartitionId)
-        && Objects.equals(snapshotPath, chunkInfo.snapshotPath);
+        && Objects.equals(snapshotPath, chunkInfo.snapshotPath)
+        && sizeInBytes == chunkInfo.sizeInBytes;
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/chunk/ChunkInfo.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ChunkInfo.java
@@ -31,7 +31,8 @@ public class ChunkInfo {
         snapshotMetadata.endTimeEpochMs,
         snapshotMetadata.maxOffset,
         snapshotMetadata.partitionId,
-        snapshotMetadata.snapshotPath);
+        snapshotMetadata.snapshotPath,
+        snapshotMetadata.sizeInBytesOnDisk);
   }
 
   public static SnapshotMetadata toSnapshotMetadata(ChunkInfo chunkInfo, String chunkPrefix) {
@@ -43,7 +44,7 @@ public class ChunkInfo {
         chunkInfo.maxOffset,
         chunkInfo.kafkaPartitionId,
         Metadata.IndexType.LOGS_LUCENE9,
-        chunkInfo.sizeInBytes);
+        chunkInfo.sizeInBytesOnDisk);
   }
 
   /* A unique identifier for a the chunk. */
@@ -79,8 +80,8 @@ public class ChunkInfo {
   // Path to S3 snapshot.
   private String snapshotPath;
 
-  // Size of chunk in bytes
-  private long sizeInBytes;
+  // Size of chunk on disk in bytes
+  private long sizeInBytesOnDisk;
 
   public ChunkInfo(
       String chunkId, long chunkCreationTimeEpochMs, String kafkaPartitionId, String snapshotPath) {
@@ -94,7 +95,8 @@ public class ChunkInfo {
         0,
         DEFAULT_MAX_OFFSET,
         kafkaPartitionId,
-        snapshotPath);
+        snapshotPath,
+        0);
   }
 
   public ChunkInfo(
@@ -106,7 +108,8 @@ public class ChunkInfo {
       long chunkSnapshotTimeEpochMs,
       long maxOffset,
       String kafkaPartitionId,
-      String snapshotPath) {
+      String snapshotPath,
+      long sizeInBytesOnDisk) {
     ensureTrue(chunkId != null && !chunkId.isEmpty(), "Invalid chunk dataset name " + chunkId);
     ensureTrue(
         chunkCreationTimeEpochMs >= 0,
@@ -122,6 +125,7 @@ public class ChunkInfo {
     this.maxOffset = maxOffset;
     this.kafkaPartitionId = kafkaPartitionId;
     this.snapshotPath = snapshotPath;
+    this.sizeInBytesOnDisk = sizeInBytesOnDisk;
   }
 
   public long getChunkSnapshotTimeEpochMs() {
@@ -168,12 +172,12 @@ public class ChunkInfo {
     return snapshotPath;
   }
 
-  public long getSizeInBytes() {
-    return sizeInBytes;
+  public long getSizeInBytesOnDisk() {
+    return sizeInBytesOnDisk;
   }
 
-  public void setSizeInBytes(long sizeInBytes) {
-    this.sizeInBytes = sizeInBytes;
+  public void setSizeInBytesOnDisk(long sizeInBytesOnDisk) {
+    this.sizeInBytesOnDisk = sizeInBytesOnDisk;
   }
 
   public void updateMaxOffset(long newOffset) {
@@ -236,8 +240,8 @@ public class ChunkInfo {
         + chunkSnapshotTimeEpochMs
         + ", snapshotPath='"
         + snapshotPath
-        + ", sizeInBytes='"
-        + sizeInBytes
+        + ", sizeInBytesOnDisk='"
+        + sizeInBytesOnDisk
         + '}';
   }
 
@@ -255,7 +259,7 @@ public class ChunkInfo {
         && Objects.equals(chunkId, chunkInfo.chunkId)
         && Objects.equals(kafkaPartitionId, chunkInfo.kafkaPartitionId)
         && Objects.equals(snapshotPath, chunkInfo.snapshotPath)
-        && sizeInBytes == chunkInfo.sizeInBytes;
+        && sizeInBytesOnDisk == chunkInfo.sizeInBytesOnDisk;
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/chunk/IndexingChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/IndexingChunkImpl.java
@@ -77,7 +77,7 @@ public class IndexingChunkImpl<T> extends ReadWriteChunk<T> {
             chunkInfo.getMaxOffset(),
             chunkInfo.getKafkaPartitionId(),
             Metadata.IndexType.LOGS_LUCENE9,
-            chunkInfo.getSizeInBytes());
+            chunkInfo.getSizeInBytesOnDisk());
     snapshotMetadataStore.updateSync(updatedSnapshotMetadata);
     liveSnapshotMetadata = updatedSnapshotMetadata;
 

--- a/astra/src/main/java/com/slack/astra/chunk/IndexingChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/IndexingChunkImpl.java
@@ -76,7 +76,8 @@ public class IndexingChunkImpl<T> extends ReadWriteChunk<T> {
             chunkInfo.getDataEndTimeEpochMs(),
             chunkInfo.getMaxOffset(),
             chunkInfo.getKafkaPartitionId(),
-            Metadata.IndexType.LOGS_LUCENE9);
+            Metadata.IndexType.LOGS_LUCENE9,
+            chunkInfo.getSizeInBytes());
     snapshotMetadataStore.updateSync(updatedSnapshotMetadata);
     liveSnapshotMetadata = updatedSnapshotMetadata;
 

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
@@ -36,7 +36,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
   public final long maxOffset;
   public final String partitionId;
   public final Metadata.IndexType indexType;
-  public long sizeInBytes;
+  public long sizeInBytesOnDisk;
 
   public SnapshotMetadata(
       String snapshotId,
@@ -46,7 +46,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       long maxOffset,
       String partitionId,
       Metadata.IndexType indexType,
-      long sizeInBytes) {
+      long sizeInBytesOnDisk) {
     this(
         snapshotId,
         snapshotPath,
@@ -55,7 +55,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
         endTimeEpochMs,
         maxOffset,
         partitionId,
-        sizeInBytes,
+        sizeInBytesOnDisk,
         indexType);
   }
 
@@ -67,7 +67,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       long endTimeEpochMs,
       long maxOffset,
       String partitionId,
-      long sizeInBytes,
+      long sizeInBytesOnDisk,
       Metadata.IndexType indexType) {
     super(name);
     checkArgument(snapshotId != null && !snapshotId.isEmpty(), "snapshotId can't be null or empty");
@@ -81,7 +81,6 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
     checkArgument(
         snapshotPath != null && !snapshotPath.isEmpty(), "snapshotPath can't be null or empty");
-    checkArgument(sizeInBytes >= 0, "size should be greater than or equal to zero.");
 
     this.snapshotPath = snapshotPath;
     this.snapshotId = snapshotId;
@@ -90,7 +89,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
     this.maxOffset = maxOffset;
     this.partitionId = partitionId;
     this.indexType = indexType;
-    this.sizeInBytes = sizeInBytes;
+    this.sizeInBytesOnDisk = sizeInBytesOnDisk;
   }
 
   @Override
@@ -110,7 +109,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       return false;
     if (partitionId != null ? !partitionId.equals(that.partitionId) : that.partitionId != null)
       return false;
-    if (sizeInBytes != that.sizeInBytes) return false;
+    if (sizeInBytesOnDisk != that.sizeInBytesOnDisk) return false;
     return indexType == that.indexType;
   }
 
@@ -124,7 +123,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
     result = 31 * result + (int) (maxOffset ^ (maxOffset >>> 32));
     result = 31 * result + (partitionId != null ? partitionId.hashCode() : 0);
     result = 31 * result + (indexType != null ? indexType.hashCode() : 0);
-    result = 31 * result + Long.hashCode(sizeInBytes);
+    result = 31 * result + Long.hashCode(sizeInBytesOnDisk);
     return result;
   }
 
@@ -152,8 +151,8 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
         + '\''
         + ", indexType="
         + indexType
-        + ", sizeInBytes="
-        + sizeInBytes
+        + ", sizeInBytesOnDisk="
+        + sizeInBytesOnDisk
         + '}';
   }
 

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
@@ -36,6 +36,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
   public final long maxOffset;
   public final String partitionId;
   public final Metadata.IndexType indexType;
+  public long sizeInBytes;
 
   public SnapshotMetadata(
       String snapshotId,
@@ -44,7 +45,8 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       long endTimeEpochMs,
       long maxOffset,
       String partitionId,
-      Metadata.IndexType indexType) {
+      Metadata.IndexType indexType,
+      long sizeInBytes) {
     this(
         snapshotId,
         snapshotPath,
@@ -53,6 +55,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
         endTimeEpochMs,
         maxOffset,
         partitionId,
+        sizeInBytes,
         indexType);
   }
 
@@ -64,6 +67,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       long endTimeEpochMs,
       long maxOffset,
       String partitionId,
+      long sizeInBytes,
       Metadata.IndexType indexType) {
     super(name);
     checkArgument(snapshotId != null && !snapshotId.isEmpty(), "snapshotId can't be null or empty");
@@ -77,6 +81,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
         partitionId != null && !partitionId.isEmpty(), "partitionId can't be null or empty");
     checkArgument(
         snapshotPath != null && !snapshotPath.isEmpty(), "snapshotPath can't be null or empty");
+    checkArgument(sizeInBytes >= 0, "size should be greater than or equal to zero.");
 
     this.snapshotPath = snapshotPath;
     this.snapshotId = snapshotId;
@@ -85,6 +90,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
     this.maxOffset = maxOffset;
     this.partitionId = partitionId;
     this.indexType = indexType;
+    this.sizeInBytes = sizeInBytes;
   }
 
   @Override
@@ -104,6 +110,8 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       return false;
     if (partitionId != null ? !partitionId.equals(that.partitionId) : that.partitionId != null)
       return false;
+    if (sizeInBytes != that.sizeInBytes)
+      return false;
     return indexType == that.indexType;
   }
 
@@ -117,6 +125,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
     result = 31 * result + (int) (maxOffset ^ (maxOffset >>> 32));
     result = 31 * result + (partitionId != null ? partitionId.hashCode() : 0);
     result = 31 * result + (indexType != null ? indexType.hashCode() : 0);
+    result = 31 * result + Long.hashCode(sizeInBytes);
     return result;
   }
 
@@ -144,6 +153,8 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
         + '\''
         + ", indexType="
         + indexType
+        + ", sizeInBytes="
+        + sizeInBytes
         + '}';
   }
 

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
@@ -110,8 +110,7 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
       return false;
     if (partitionId != null ? !partitionId.equals(that.partitionId) : that.partitionId != null)
       return false;
-    if (sizeInBytes != that.sizeInBytes)
-      return false;
+    if (sizeInBytes != that.sizeInBytes) return false;
     return indexType == that.indexType;
   }
 

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -17,6 +17,7 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         .setPartitionId(snapshotMetadata.partitionId)
         .setMaxOffset(snapshotMetadata.maxOffset)
         .setIndexType(snapshotMetadata.indexType)
+        .setSizeInBytes(snapshotMetadata.sizeInBytes)
         .build();
   }
 
@@ -29,7 +30,8 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         protoSnapshotMetadata.getEndTimeEpochMs(),
         protoSnapshotMetadata.getMaxOffset(),
         protoSnapshotMetadata.getPartitionId(),
-        Metadata.IndexType.LOGS_LUCENE9);
+        Metadata.IndexType.LOGS_LUCENE9,
+        protoSnapshotMetadata.getSizeInBytes());
   }
 
   @Override

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializer.java
@@ -17,7 +17,7 @@ public class SnapshotMetadataSerializer implements MetadataSerializer<SnapshotMe
         .setPartitionId(snapshotMetadata.partitionId)
         .setMaxOffset(snapshotMetadata.maxOffset)
         .setIndexType(snapshotMetadata.indexType)
-        .setSizeInBytes(snapshotMetadata.sizeInBytes)
+        .setSizeInBytes(snapshotMetadata.sizeInBytesOnDisk)
         .build();
   }
 

--- a/astra/src/main/proto/metadata.proto
+++ b/astra/src/main/proto/metadata.proto
@@ -84,6 +84,9 @@ message SnapshotMetadata {
 
   // The type of index used to store this data.
   IndexType index_type = 8;
+
+  // Size of the snapshot in bytes
+  int64 sizeInBytes = 9;
 }
 
 message SearchMetadata {

--- a/astra/src/test/java/com/slack/astra/chunk/ChunkInfoTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ChunkInfoTest.java
@@ -357,7 +357,8 @@ public class ChunkInfoTest {
             dataEnd,
             1000,
             TEST_KAFKA_PARTITION_ID,
-            TEST_SNAPSHOT_PATH);
+            TEST_SNAPSHOT_PATH,
+            0);
     assertThat(fromSnapshotMetadata(toSnapshotMetadata(chunkInfo, ""))).isEqualTo(chunkInfo);
   }
 }

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -737,7 +737,7 @@ public class IndexingChunkImplTest {
           .contains(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
 
       // Check total size of objects uploaded was correctly tracked
-      assertThat(chunk.info().getSizeInBytes())
+      assertThat(chunk.info().getSizeInBytesOnDisk())
           .isEqualTo(objectsResponse.contents().stream().mapToLong(S3Object::size).sum());
 
       chunk.close();

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 public class IndexingChunkImplTest {
   private static final String TEST_KAFKA_PARTITION_ID = "10";
@@ -734,6 +735,10 @@ public class IndexingChunkImplTest {
       assertThat(afterSearchNodes.get(0).url).contains(String.valueOf(TEST_PORT));
       assertThat(afterSearchNodes.get(0).snapshotName)
           .contains(SnapshotMetadata.LIVE_SNAPSHOT_PATH);
+
+      // Check total size of objects uploaded was correctly tracked
+      assertThat(chunk.info().getSizeInBytes())
+          .isEqualTo(objectsResponse.contents().stream().mapToLong(S3Object::size).sum());
 
       chunk.close();
       // Ensure folder is cleared after chunk chlose. List the number of files in folder

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -511,7 +511,8 @@ public class ReadOnlyChunkImplTest {
             Instant.now().toEpochMilli(),
             1,
             "partitionId",
-            LOGS_LUCENE9));
+            LOGS_LUCENE9,
+            0));
   }
 
   private void initializeZkReplica(

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
@@ -95,7 +95,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
 
     replicaMetadataStore.createSync(
@@ -145,7 +146,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
 
     AstraConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -188,7 +190,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
 
     AstraConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -240,7 +243,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotNotLive);
 
     SnapshotMetadata snapshotLive =
@@ -251,7 +255,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "b",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotLive);
 
     AstraConfigs.ManagerConfig.ReplicaCreationServiceConfig replicaCreationServiceConfig =
@@ -335,7 +340,8 @@ public class ReplicaCreationServiceTest {
                       Instant.now().minus(1441, ChronoUnit.MINUTES).toEpochMilli(),
                       0,
                       snapshotId,
-                      LOGS_LUCENE9);
+                      LOGS_LUCENE9,
+                      0);
               snapshotList.add(snapshot);
             });
 
@@ -351,7 +357,8 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli(),
                       0,
                       snapshotId,
-                      LOGS_LUCENE9);
+                      LOGS_LUCENE9,
+                      0);
               snapshotList.add(snapshot);
             });
 
@@ -368,7 +375,8 @@ public class ReplicaCreationServiceTest {
                       Instant.now().toEpochMilli(),
                       0,
                       snapshotId,
-                      LOGS_LUCENE9);
+                      LOGS_LUCENE9,
+                      0);
               eligibleSnapshots.add(snapshot);
             });
     snapshotList.addAll(eligibleSnapshots);
@@ -454,7 +462,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
 
     await().until(() -> replicaMetadataStore.listSync().size() == 2);
@@ -526,7 +535,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
 
     await()
@@ -578,7 +588,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
@@ -627,7 +638,8 @@ public class ReplicaCreationServiceTest {
             Instant.now().toEpochMilli(),
             0,
             "a",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(snapshotA);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
@@ -97,7 +97,7 @@ public class ReplicaRestoreServiceTest {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
       SnapshotMetadata snapshotIncluded =
-          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9);
+          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9, 0);
       replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
       Thread.sleep(300);
     }
@@ -140,7 +140,7 @@ public class ReplicaRestoreServiceTest {
               long now = Instant.now().toEpochMilli();
               String id = "loop" + UUID.randomUUID();
               SnapshotMetadata snapshotIncluded =
-                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9);
+                  new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9, 0);
               try {
                 replicaRestoreService.queueSnapshotsForRestoration(List.of(snapshotIncluded));
                 Thread.sleep(300);
@@ -191,7 +191,8 @@ public class ReplicaRestoreServiceTest {
     List<SnapshotMetadata> duplicateSnapshots = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       String id = "duplicate";
-      duplicateSnapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
+      duplicateSnapshots.add(
+          new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9, 0));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(duplicateSnapshots);
@@ -210,7 +211,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < 3; i++) {
       now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9, 0));
     }
 
     replicaRestoreService.queueSnapshotsForRestoration(snapshots);
@@ -247,7 +248,7 @@ public class ReplicaRestoreServiceTest {
     for (int i = 0; i < MAX_QUEUE_SIZE; i++) {
       long now = Instant.now().toEpochMilli();
       String id = "loop" + i;
-      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9));
+      snapshots.add(new SnapshotMetadata(id, id, now + 10, now + 15, 0, id, LOGS_LUCENE9, 0));
     }
 
     assertThatExceptionOfType(SizeLimitExceededException.class)

--- a/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
@@ -168,7 +168,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
@@ -224,7 +225,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
 
     ReplicaMetadata replicaMetadata =
@@ -337,7 +339,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(500, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
     String[] s3CrtBlobFsFiles = s3CrtBlobFs.listFiles(directoryPath, true);
@@ -397,7 +400,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
 
     // replica is also expired
@@ -472,7 +476,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
@@ -530,7 +535,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
@@ -594,7 +600,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
@@ -651,7 +658,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 
@@ -748,7 +756,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
 
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
@@ -821,7 +830,8 @@ public class SnapshotDeletionServiceTest {
             Instant.now().minus(10900, ChronoUnit.MINUTES).toEpochMilli(),
             0,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createAsync(snapshotMetadata);
     await().until(() -> snapshotMetadataStore.listSync().size() == 1);
 

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -840,7 +840,8 @@ public class AstraDistributedQueryServiceTest {
                     endTime.toEpochMilli(),
                     10,
                     "1",
-                    Metadata.IndexType.LOGS_LUCENE9)));
+                    Metadata.IndexType.LOGS_LUCENE9,
+                    0)));
     DatasetMetadataStore datasetMetadataStoreMock = mock(DatasetMetadataStore.class);
     when(datasetMetadataStoreMock.listSync())
         .thenReturn(

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -969,7 +969,8 @@ public class AstraDistributedQueryServiceTest {
             chunkEndTime.toEpochMilli(),
             1234,
             partition,
-            isLive ? LIVE_SNAPSHOT_PATH : "cacheSnapshotPath");
+            isLive ? LIVE_SNAPSHOT_PATH : "cacheSnapshotPath",
+            0);
     SnapshotMetadata snapshotMetadata =
         toSnapshotMetadata(chunkInfo, isLive ? LIVE_SNAPSHOT_PREFIX : "");
 

--- a/astra/src/test/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -20,7 +20,8 @@ public class SnapshotMetadataSerializerTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshotMetadata =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
 
     String serializedSnapshot = serDe.toJsonStr(snapshotMetadata);
     assertThat(serializedSnapshot).isNotEmpty();

--- a/astra/src/test/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializerTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/snapshot/SnapshotMetadataSerializerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.slack.astra.proto.metadata.Metadata;
 import org.junit.jupiter.api.Test;
 
 public class SnapshotMetadataSerializerTest {
@@ -18,10 +19,11 @@ public class SnapshotMetadataSerializerTest {
     final long endTime = 100;
     final long maxOffset = 123;
     final String partitionId = "1";
+    final long sizeInBytes = 0;
 
     SnapshotMetadata snapshotMetadata =
         new SnapshotMetadata(
-            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, sizeInBytes);
 
     String serializedSnapshot = serDe.toJsonStr(snapshotMetadata);
     assertThat(serializedSnapshot).isNotEmpty();
@@ -29,6 +31,46 @@ public class SnapshotMetadataSerializerTest {
     SnapshotMetadata deserializedSnapshotMetadata = serDe.fromJsonStr(serializedSnapshot);
     assertThat(deserializedSnapshotMetadata).isEqualTo(snapshotMetadata);
 
+    assertThat(deserializedSnapshotMetadata.name).isEqualTo(name);
+    assertThat(deserializedSnapshotMetadata.snapshotPath).isEqualTo(path);
+    assertThat(deserializedSnapshotMetadata.snapshotId).isEqualTo(name);
+    assertThat(deserializedSnapshotMetadata.startTimeEpochMs).isEqualTo(startTime);
+    assertThat(deserializedSnapshotMetadata.endTimeEpochMs).isEqualTo(endTime);
+    assertThat(deserializedSnapshotMetadata.maxOffset).isEqualTo(maxOffset);
+    assertThat(deserializedSnapshotMetadata.partitionId).isEqualTo(partitionId);
+    assertThat(deserializedSnapshotMetadata.indexType).isEqualTo(LOGS_LUCENE9);
+    assertThat(deserializedSnapshotMetadata.sizeInBytesOnDisk).isEqualTo(sizeInBytes);
+  }
+
+  @Test
+  public void testDeserializingWithoutSizeField() throws InvalidProtocolBufferException {
+    final String name = "testSnapshotId";
+    final String path = "/testPath_" + name;
+    final long startTime = 1;
+    final long endTime = 100;
+    final long maxOffset = 123;
+    final String partitionId = "1";
+
+    Metadata.SnapshotMetadata protoSnapshotMetadata =
+        Metadata.SnapshotMetadata.newBuilder()
+            .setName(name)
+            .setSnapshotPath(path)
+            .setSnapshotId(name)
+            .setStartTimeEpochMs(startTime)
+            .setEndTimeEpochMs(endTime)
+            .setMaxOffset(maxOffset)
+            .setPartitionId(partitionId)
+            .setIndexType(LOGS_LUCENE9)
+            // leaving out the `size` field
+            .build();
+
+    SnapshotMetadata deserializedSnapshotMetadata =
+        serDe.fromJsonStr(serDe.printer.print(protoSnapshotMetadata));
+
+    // Assert size is 0
+    assertThat(deserializedSnapshotMetadata.sizeInBytesOnDisk).isEqualTo(0);
+
+    // Assert everything else is deserialized correctly
     assertThat(deserializedSnapshotMetadata.name).isEqualTo(name);
     assertThat(deserializedSnapshotMetadata.snapshotPath).isEqualTo(path);
     assertThat(deserializedSnapshotMetadata.snapshotId).isEqualTo(name);

--- a/astra/src/test/java/com/slack/astra/metadata/snapshot/SnapshotMetadataTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/snapshot/SnapshotMetadataTest.java
@@ -20,7 +20,8 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshotMetadata =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
 
     assertThat(snapshotMetadata.name).isEqualTo(name);
     assertThat(snapshotMetadata.snapshotPath).isEqualTo(path);
@@ -42,10 +43,11 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata snapshot1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     SnapshotMetadata snapshot2 =
         new SnapshotMetadata(
-            name + "2", path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+            name + "2", path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
 
     // Ensure the name field from super class is included.
     assertThat(snapshot1).isNotEqualTo(snapshot2);
@@ -69,36 +71,37 @@ public class SnapshotMetadataTest {
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    "", path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9));
+                    "", path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, "", startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9));
-
-    assertThatIllegalArgumentException()
-        .isThrownBy(
-            () ->
-                new SnapshotMetadata(name, path, 0, endTime, maxOffset, partitionId, LOGS_LUCENE9));
+                    name, "", startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, path, startTime, 0, maxOffset, partitionId, LOGS_LUCENE9));
+                    name, path, 0, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new SnapshotMetadata(
+                    name, path, startTime, 0, maxOffset, partitionId, LOGS_LUCENE9, 0));
 
     // Start time < end time
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, path, endTime, startTime, maxOffset, partitionId, LOGS_LUCENE9));
+                    name, path, endTime, startTime, maxOffset, partitionId, LOGS_LUCENE9, 0));
 
     // Start time same as end time.
     assertThat(
             new SnapshotMetadata(
-                    name, path, startTime, startTime, maxOffset, partitionId, LOGS_LUCENE9)
+                    name, path, startTime, startTime, maxOffset, partitionId, LOGS_LUCENE9, 0)
                 .endTimeEpochMs)
         .isEqualTo(startTime);
 
@@ -106,12 +109,13 @@ public class SnapshotMetadataTest {
         .isThrownBy(
             () ->
                 new SnapshotMetadata(
-                    name, path, startTime, endTime, -1, partitionId, LOGS_LUCENE9));
+                    name, path, startTime, endTime, -1, partitionId, LOGS_LUCENE9, 0));
 
     assertThatIllegalArgumentException()
         .isThrownBy(
             () ->
-                new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "", LOGS_LUCENE9));
+                new SnapshotMetadata(
+                    name, path, startTime, endTime, maxOffset, "", LOGS_LUCENE9, 0));
   }
 
   @Test
@@ -124,7 +128,8 @@ public class SnapshotMetadataTest {
     final String partitionId = "1";
 
     SnapshotMetadata nonLiveSnapshot =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     assertThat(SnapshotMetadata.isLive(nonLiveSnapshot)).isFalse();
 
     SnapshotMetadata liveSnapshot =
@@ -135,7 +140,8 @@ public class SnapshotMetadataTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     assertThat(SnapshotMetadata.isLive(liveSnapshot)).isTrue();
   }
 }

--- a/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
@@ -206,7 +206,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsOnly(livePartition1);
@@ -252,7 +253,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -263,7 +265,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsOnly(livePartition1, livePartition0);
@@ -304,7 +307,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -315,7 +319,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
         .containsOnly(livePartition1, livePartition0);
@@ -362,7 +367,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -373,11 +379,12 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -427,7 +434,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -438,11 +446,12 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -500,7 +509,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -511,11 +521,12 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -577,7 +588,8 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "0",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition0);
 
     SnapshotMetadata livePartition1 =
@@ -588,11 +600,12 @@ public class AstraIndexerTest {
             endTimeMs,
             maxOffset,
             "1",
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
 
     final SnapshotMetadata partition0 =
-        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9);
+        new SnapshotMetadata(name, path, startTimeMs, endTimeMs, maxOffset, "0", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition0);
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))

--- a/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
+++ b/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
@@ -588,38 +588,38 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata overlapsStartTimeIncluded =
         new SnapshotMetadata(
-            "a", "a", startTime, startTime + 6, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "a", "a", startTime, startTime + 6, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata overlapsStartTimeExcluded =
         new SnapshotMetadata(
-            "b", "b", startTime, startTime + 6, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "b", "b", startTime, startTime + 6, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     SnapshotMetadata fullyOverlapsStartEndTimeIncluded =
         new SnapshotMetadata(
-            "c", "c", startTime + 4, startTime + 11, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "c", "c", startTime + 4, startTime + 11, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata fullyOverlapsStartEndTimeExcluded =
         new SnapshotMetadata(
-            "d", "d", startTime + 4, startTime + 11, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "d", "d", startTime + 4, startTime + 11, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     SnapshotMetadata partiallyOverlapsStartEndTimeIncluded =
         new SnapshotMetadata(
-            "e", "e", startTime + 4, startTime + 5, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "e", "e", startTime + 4, startTime + 5, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata partiallyOverlapsStartEndTimeExcluded =
         new SnapshotMetadata(
-            "f", "f", startTime + 4, startTime + 5, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "f", "f", startTime + 4, startTime + 5, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     SnapshotMetadata overlapsEndTimeIncluded =
         new SnapshotMetadata(
-            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata overlapsEndTimeExcluded =
         new SnapshotMetadata(
-            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     SnapshotMetadata notWithinStartEndTimeExcluded1 =
         new SnapshotMetadata(
-            "i", "i", startTime, startTime + 4, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "i", "i", startTime, startTime + 4, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata notWithinStartEndTimeExcluded2 =
         new SnapshotMetadata(
-            "j", "j", startTime + 11, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "j", "j", startTime + 11, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     DatasetMetadata datasetWithDataInPartitionA =
         new DatasetMetadata(
@@ -670,10 +670,10 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata snapshotIncluded =
         new SnapshotMetadata(
-            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "g", "g", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata snapshotExcluded =
         new SnapshotMetadata(
-            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "h", "h", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     snapshotMetadataStore.createSync(snapshotIncluded);
     snapshotMetadataStore.createSync(snapshotExcluded);
@@ -714,13 +714,13 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata snapshotIncluded =
         new SnapshotMetadata(
-            "a", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "a", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata snapshotIncluded2 =
         new SnapshotMetadata(
-            "b", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "b", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata snapshotExcluded =
         new SnapshotMetadata(
-            "c", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LOGS_LUCENE9);
+            "c", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     snapshotMetadataStore.createSync(snapshotIncluded);
     snapshotMetadataStore.createSync(snapshotIncluded2);
@@ -764,13 +764,13 @@ public class ManagerApiGrpcTest {
 
     SnapshotMetadata snapshotFoo =
         new SnapshotMetadata(
-            "foo", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9);
+            "foo", "a", startTime + 10, startTime + 15, 0, "a", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata snapshotBar =
         new SnapshotMetadata(
-            "bar", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9);
+            "bar", "b", startTime + 10, startTime + 15, 0, "b", Metadata.IndexType.LOGS_LUCENE9, 0);
     SnapshotMetadata snapshotBaz =
         new SnapshotMetadata(
-            "baz", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LOGS_LUCENE9);
+            "baz", "c", startTime + 10, startTime + 15, 0, "c", Metadata.IndexType.LOGS_LUCENE9, 0);
 
     snapshotMetadataStore.createSync(snapshotFoo);
     snapshotMetadataStore.createSync(snapshotBar);

--- a/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
+++ b/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
@@ -115,7 +115,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -124,7 +125,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -133,12 +135,13 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
 
     assertThat(getStaleLiveSnapshots(List.of(partition1), partitionId)).isEmpty();
     assertThat(getStaleLiveSnapshots(List.of(partition2), partitionId)).isEmpty();
@@ -174,7 +177,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -183,7 +187,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -192,12 +197,13 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
 
     testDeleteSnapshots(List.of(partition1), 0, List.of(partition1));
     testDeleteSnapshots(List.of(partition2), 0, List.of(partition2));
@@ -254,7 +260,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -263,7 +270,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -272,12 +280,13 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
     SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
 
     testDeleteSnapshotsTimeouts(List.of(partition1), List.of(partition1), false);
     testDeleteSnapshotsTimeouts(List.of(livePartition1), List.of(livePartition1), true);
@@ -345,7 +354,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 123;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     final SnapshotMetadata livePartition1 =
         new SnapshotMetadata(
             name + "1",
@@ -354,7 +364,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     final SnapshotMetadata livePartition11 =
         new SnapshotMetadata(
             name + "11",
@@ -363,12 +374,13 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     final SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
     final SnapshotMetadata partition2 =
-        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+        new SnapshotMetadata(name + "3", path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
 
     List<SnapshotMetadata> snapshots =
         List.of(partition1, livePartition1, livePartition11, partition2, livePartition2);
@@ -439,10 +451,18 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
+            name + "1",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            partitionId,
+            LOGS_LUCENE9,
+            0);
     final SnapshotMetadata partition12 =
         new SnapshotMetadata(
             name + "12",
@@ -451,13 +471,14 @@ public class RecoveryTaskCreatorTest {
             endTime * 3,
             maxOffset * 3,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
 
     final String partitionId2 = "2";
     final long partition2Offset = maxOffset * 10;
     final SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "2", path, startTime, endTime, partition2Offset, partitionId2, LOGS_LUCENE9);
+            name + "2", path, startTime, endTime, partition2Offset, partitionId2, LOGS_LUCENE9, 0);
     final SnapshotMetadata partition21 =
         new SnapshotMetadata(
             name + "21",
@@ -466,7 +487,8 @@ public class RecoveryTaskCreatorTest {
             endTime * 2,
             partition2Offset * 2,
             partitionId2,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     final SnapshotMetadata partition22 =
         new SnapshotMetadata(
             name + "22",
@@ -475,7 +497,8 @@ public class RecoveryTaskCreatorTest {
             endTime * 3,
             partition2Offset * 3,
             partitionId2,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
 
     // empty results
     assertThat(
@@ -751,7 +774,7 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
 
@@ -760,7 +783,7 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9);
+            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition11);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -810,14 +833,14 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9);
+        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, "2", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(recoveryTaskCreator.determineStartingOffset(0, 0, indexerConfig)).isNegative();
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9);
+            name + "1", path, endTime + 1, endTime * 2, maxOffset * 2, "2", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition11);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -1093,7 +1116,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
@@ -1109,7 +1133,14 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
+            name + "11",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            partitionId,
+            LOGS_LUCENE9,
+            0);
 
     snapshotMetadataStore.createSync(partition11);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
@@ -1132,7 +1163,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(livePartition1));
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -1154,7 +1186,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition11);
     await().until(() -> snapshotMetadataStore.listSync().contains(livePartition11));
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -1171,7 +1204,14 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset * 5,
+            "2",
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition2);
     await()
         .until(
@@ -1193,7 +1233,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
+            name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition2);
     await()
         .until(
@@ -1235,7 +1275,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
@@ -1261,7 +1302,14 @@ public class RecoveryTaskCreatorTest {
 
     final SnapshotMetadata partition11 =
         new SnapshotMetadata(
-            name + "11", path, endTime + 1, endTime * 2, maxOffset * 2, partitionId, LOGS_LUCENE9);
+            name + "11",
+            path,
+            endTime + 1,
+            endTime * 2,
+            maxOffset * 2,
+            partitionId,
+            LOGS_LUCENE9,
+            0);
 
     snapshotMetadataStore.createSync(partition11);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition11));
@@ -1296,7 +1344,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
     await()
         .until(
@@ -1336,7 +1385,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition11);
     await()
         .until(
@@ -1375,7 +1425,14 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata livePartition2 =
         new SnapshotMetadata(
-            name + "2", LIVE_SNAPSHOT_PATH, startTime, endTime, maxOffset * 5, "2", LOGS_LUCENE9);
+            name + "2",
+            LIVE_SNAPSHOT_PATH,
+            startTime,
+            endTime,
+            maxOffset * 5,
+            "2",
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition2);
     await()
         .until(
@@ -1414,7 +1471,7 @@ public class RecoveryTaskCreatorTest {
     snapshotMetadataStore.createSync(livePartition11);
     SnapshotMetadata partition2 =
         new SnapshotMetadata(
-            name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9);
+            name + "3", path, startTime, endTime, maxOffset * 3, "2", LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition2);
     await()
         .until(
@@ -1480,7 +1537,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
@@ -1532,7 +1590,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
@@ -1588,7 +1647,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
@@ -1645,7 +1705,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(
@@ -1673,7 +1734,8 @@ public class RecoveryTaskCreatorTest {
             endTime,
             maxOffset,
             partitionId,
-            LOGS_LUCENE9);
+            LOGS_LUCENE9,
+            0);
     snapshotMetadataStore.createSync(livePartition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(livePartition1));
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore))
@@ -1811,7 +1873,8 @@ public class RecoveryTaskCreatorTest {
     final long maxOffset = 100;
 
     final SnapshotMetadata partition1 =
-        new SnapshotMetadata(name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9);
+        new SnapshotMetadata(
+            name, path, startTime, endTime, maxOffset, partitionId, LOGS_LUCENE9, 0);
     snapshotMetadataStore.createSync(partition1);
     await().until(() -> snapshotMetadataStore.listSync().contains(partition1));
     assertThat(

--- a/astra/src/test/java/com/slack/astra/util/SnapshotUtil.java
+++ b/astra/src/test/java/com/slack/astra/util/SnapshotUtil.java
@@ -6,6 +6,13 @@ import com.slack.astra.proto.metadata.Metadata;
 public class SnapshotUtil {
   public static SnapshotMetadata makeSnapshot(String name) {
     return new SnapshotMetadata(
-        name + "snapshotId", "/testPath_" + name, 1, 100, 1, "1", Metadata.IndexType.LOGS_LUCENE9);
+        name + "snapshotId",
+        "/testPath_" + name,
+        1,
+        100,
+        1,
+        "1",
+        Metadata.IndexType.LOGS_LUCENE9,
+        0);
   }
 }


### PR DESCRIPTION
###  Summary
Add sizeInBytes field to `SnapshotMetadata` and `ChunkInfo`. Used to keep track of size of chunks in preparation for dynamic chunk sizes.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
