### PR TITLE
Cache Node Assignment Service

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
@@ -4,14 +4,24 @@ import com.slack.astra.blobfs.BlobFs;
 import com.slack.astra.chunk.ReadOnlyChunkImpl;
 import com.slack.astra.chunk.SearchContext;
 import com.slack.astra.logstore.LogMessage;
+import com.slack.astra.metadata.cache.CacheNodeAssignment;
+import com.slack.astra.metadata.cache.CacheNodeAssignmentStore;
+import com.slack.astra.metadata.cache.CacheNodeMetadata;
+import com.slack.astra.metadata.cache.CacheNodeMetadataStore;
 import com.slack.astra.metadata.cache.CacheSlotMetadataStore;
+import com.slack.astra.metadata.core.AstraMetadataStoreChangeListener;
 import com.slack.astra.metadata.replica.ReplicaMetadataStore;
 import com.slack.astra.metadata.search.SearchMetadataStore;
 import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.proto.metadata.Metadata;
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,10 +41,19 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   private final String dataDirectoryPrefix;
   private final String replicaSet;
   private final int slotCountPerInstance;
+  private final AstraMetadataStoreChangeListener<CacheNodeAssignment>
+      cacheNodeAssignmentChangeListener = this::onAssignmentHandler;
+  private final long capacityBytes;
   private ReplicaMetadataStore replicaMetadataStore;
   private SnapshotMetadataStore snapshotMetadataStore;
   private SearchMetadataStore searchMetadataStore;
   private CacheSlotMetadataStore cacheSlotMetadataStore;
+
+  // for flag "astra.ng.dynamicChunkSizes"
+  private final String cacheNodeId;
+  private CacheNodeAssignmentStore cacheNodeAssignmentStore;
+  private CacheNodeMetadataStore cacheNodeMetadataStore;
+  private final Map<String, ReadOnlyChunkImpl<T>> chunksMap;
 
   public CachingChunkManager(
       MeterRegistry registry,
@@ -44,7 +63,8 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
       String s3Bucket,
       String dataDirectoryPrefix,
       String replicaSet,
-      int slotCountPerInstance) {
+      int slotCountPerInstance,
+      long capacityBytes) {
     this.meterRegistry = registry;
     this.curatorFramework = curatorFramework;
     this.blobFs = blobFs;
@@ -53,6 +73,9 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     this.dataDirectoryPrefix = dataDirectoryPrefix;
     this.replicaSet = replicaSet;
     this.slotCountPerInstance = slotCountPerInstance;
+    this.cacheNodeId = UUID.randomUUID().toString();
+    this.capacityBytes = capacityBytes;
+    this.chunksMap = new HashMap<>();
   }
 
   @Override
@@ -63,21 +86,29 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
     cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework);
+    cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework);
 
-    for (int i = 0; i < slotCountPerInstance; i++) {
-      chunkList.add(
-          new ReadOnlyChunkImpl<>(
-              curatorFramework,
-              meterRegistry,
-              blobFs,
-              searchContext,
-              s3Bucket,
-              dataDirectoryPrefix,
-              replicaSet,
-              cacheSlotMetadataStore,
-              replicaMetadataStore,
-              snapshotMetadataStore,
-              searchMetadataStore));
+    if (Boolean.getBoolean("astra.ng.dynamicChunkSizes")) {
+      cacheNodeAssignmentStore.addListener(cacheNodeAssignmentChangeListener);
+      cacheNodeMetadataStore.createSync(
+          new CacheNodeMetadata(cacheNodeId, searchContext.hostname, capacityBytes, replicaSet));
+    } else {
+      for (int i = 0; i < slotCountPerInstance; i++) {
+        chunkList.add(
+            new ReadOnlyChunkImpl<>(
+                curatorFramework,
+                meterRegistry,
+                blobFs,
+                searchContext,
+                s3Bucket,
+                dataDirectoryPrefix,
+                replicaSet,
+                cacheSlotMetadataStore,
+                replicaMetadataStore,
+                snapshotMetadataStore,
+                searchMetadataStore));
+      }
     }
   }
 
@@ -85,19 +116,35 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   protected void shutDown() throws Exception {
     LOG.info("Closing caching chunk manager.");
 
-    chunkList.forEach(
-        (readonlyChunk) -> {
-          try {
-            readonlyChunk.close();
-          } catch (IOException e) {
-            LOG.error("Error closing readonly chunk", e);
-          }
-        });
+    if (Boolean.getBoolean("astra.ng.dynamicChunkSizes")) {
+      chunksMap
+          .values()
+          .forEach(
+              chunk -> {
+                try {
+                  chunk.close();
+                } catch (IOException e) {
+                  LOG.error("Error closing readonly chunk", e);
+                }
+              });
+      cacheNodeAssignmentStore.removeListener(cacheNodeAssignmentChangeListener);
+      cacheNodeMetadataStore.deleteSync(cacheNodeId);
+    } else {
+      chunkList.forEach(
+          (readonlyChunk) -> {
+            try {
+              readonlyChunk.close();
+            } catch (IOException e) {
+              LOG.error("Error closing readonly chunk", e);
+            }
+          });
+    }
 
     cacheSlotMetadataStore.close();
     searchMetadataStore.close();
     snapshotMetadataStore.close();
     replicaMetadataStore.close();
+    cacheNodeAssignmentStore.close();
 
     LOG.info("Closed caching chunk manager.");
   }
@@ -117,7 +164,8 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
         s3Config.getS3Bucket(),
         cacheConfig.getDataDirectory(),
         cacheConfig.getReplicaSet(),
-        cacheConfig.getSlotsPerInstance());
+        cacheConfig.getSlotsPerInstance(),
+        cacheConfig.getCapacityBytes());
   }
 
   @Override
@@ -125,5 +173,56 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
       throws IOException {
     throw new UnsupportedOperationException(
         "Adding messages is not supported on a caching chunk manager");
+  }
+
+  private void onAssignmentHandler(CacheNodeAssignment assignment) {
+    if (Objects.equals(assignment.cacheNodeId, this.cacheNodeId)) {
+      try {
+        if (chunksMap.containsKey(assignment.assignmentId)) {
+          ReadOnlyChunkImpl<T> chunk = chunksMap.get(assignment.assignmentId);
+
+          if (chunkStateChangedToEvict(assignment, chunk)) {
+            chunk.evictChunk(assignment);
+            chunksMap.remove(assignment.assignmentId);
+          }
+        } else {
+          ReadOnlyChunkImpl<T> newChunk =
+              new ReadOnlyChunkImpl<>(
+                  curatorFramework,
+                  meterRegistry,
+                  blobFs,
+                  searchContext,
+                  s3Bucket,
+                  dataDirectoryPrefix,
+                  replicaSet,
+                  cacheSlotMetadataStore,
+                  replicaMetadataStore,
+                  snapshotMetadataStore,
+                  searchMetadataStore,
+                  cacheNodeAssignmentStore,
+                  assignment.assignmentId,
+                  assignment.cacheNodeId);
+          chunksMap.put(assignment.assignmentId, newChunk);
+        }
+      } catch (Exception e) {
+        LOG.error("Error instantiating readonly chunk", e);
+      }
+    }
+  }
+
+  private static <T> boolean chunkStateChangedToEvict(
+      CacheNodeAssignment assignment, ReadOnlyChunkImpl<T> chunk) {
+    return (chunk.getLastKnownAssignmentState() != assignment.state)
+        && (chunk.getLastKnownAssignmentState()
+            == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE)
+        && (assignment.state == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.EVICT);
+  }
+
+  public String getId() {
+    return cacheNodeId;
+  }
+
+  public Map<String, ReadOnlyChunkImpl<T>> getChunksMap() {
+    return chunksMap;
   }
 }

--- a/astra/src/main/java/com/slack/astra/clusterManager/CacheNodeAssignmentService.java
+++ b/astra/src/main/java/com/slack/astra/clusterManager/CacheNodeAssignmentService.java
@@ -1,0 +1,564 @@
+package com.slack.astra.clusterManager;
+
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.slack.astra.server.AstraConfig.DEFAULT_ZK_TIMEOUT_SECS;
+import static com.slack.astra.util.FutureUtils.successCountingCallback;
+import static com.slack.astra.util.TimeUtils.nanosToMillis;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.slack.astra.metadata.cache.CacheNodeAssignment;
+import com.slack.astra.metadata.cache.CacheNodeAssignmentStore;
+import com.slack.astra.metadata.cache.CacheNodeMetadata;
+import com.slack.astra.metadata.cache.CacheNodeMetadataStore;
+import com.slack.astra.metadata.core.AstraMetadataStoreChangeListener;
+import com.slack.astra.metadata.hpa.HpaMetricMetadata;
+import com.slack.astra.metadata.hpa.HpaMetricMetadataStore;
+import com.slack.astra.metadata.replica.ReplicaMetadata;
+import com.slack.astra.metadata.replica.ReplicaMetadataStore;
+import com.slack.astra.metadata.snapshot.SnapshotMetadata;
+import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.proto.metadata.Metadata;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service responsible for managing the assignment & cleanup of replicas to cache nodes.
+ *
+ * <p>Periodically assign replicas to cache nodes based on the configured replica sets. It fetches
+ * metadata from various stores, performs the assignments, and calculates HPA (Horizontal Pod
+ * Autoscaler) metrics for capacity management. Metrics are tracked for assignment and eviction
+ * operations.
+ */
+public class CacheNodeAssignmentService extends AbstractScheduledService {
+  private ScheduledFuture<?> pendingTask;
+  private final AstraConfigs.ManagerConfig managerConfig;
+  private final ScheduledExecutorService executorService =
+      Executors.newSingleThreadScheduledExecutor(
+          new ThreadFactoryBuilder().setNameFormat("cache-node-assignment-service-%d").build());
+  private final MeterRegistry meterRegistry;
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final CacheNodeMetadataStore cacheNodeMetadataStore;
+  private final SnapshotMetadataStore snapshotMetadataStore;
+  private final CacheNodeAssignmentStore cacheNodeAssignmentStore;
+  private final HpaMetricMetadataStore hpaMetricMetadataStore;
+
+  private final AstraMetadataStoreChangeListener<CacheNodeMetadata> cacheNodeListener =
+      (cacheNodeMetadata) -> runOneIteration();
+  private final AstraMetadataStoreChangeListener<ReplicaMetadata> replicaListener =
+      (replicaMetadata) -> runOneIteration();
+
+  protected static final Logger LOG = LoggerFactory.getLogger(ReplicaCreationService.class);
+  private static final String NEW_BIN_PREFIX = "NEW_";
+  protected static final String CACHE_HPA_METRIC_NAME = "hpa_capacity_demand_factor_%s";
+  @VisibleForTesting protected static int futuresListTimeoutSecs = DEFAULT_ZK_TIMEOUT_SECS;
+
+  public static final String ASSIGNMENT_CREATE_SUCCEEDED = "assignment_create_succeeded";
+  public static final String ASSIGNMENT_CREATE_FAILED = "assignment_create_failed";
+  public static final String ASSIGNMENT_CREATE_TIMER = "assignment_create_timer";
+  public static final String EVICT_ASSIGNMENT_TIMER = "evict_assignment_timer";
+  public static final String EVICT_SUCCEEDED = "evict_succeeded";
+  public static final String EVICT_FAILED = "evict_failed";
+
+  protected final Counter assignmentCreateSucceeded;
+  protected final Counter assignmentCreateFailed;
+  protected final Counter evictSucceeded;
+  protected final Counter evictFailed;
+  private final Timer assignmentCreateTimer;
+  private final Timer evictAssignmentTimer;
+
+  public CacheNodeAssignmentService(
+      MeterRegistry meterRegistry,
+      AstraConfigs.ManagerConfig managerConfig,
+      ReplicaMetadataStore replicaMetadataStore,
+      CacheNodeMetadataStore cacheNodeMetadataStore,
+      SnapshotMetadataStore snapshotMetadataStore,
+      CacheNodeAssignmentStore cacheNodeAssignmentStore,
+      HpaMetricMetadataStore hpaMetricMetadataStore) {
+    this.managerConfig = managerConfig;
+    this.meterRegistry = meterRegistry;
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.cacheNodeMetadataStore = cacheNodeMetadataStore;
+    this.snapshotMetadataStore = snapshotMetadataStore;
+    this.cacheNodeAssignmentStore = cacheNodeAssignmentStore;
+    this.hpaMetricMetadataStore = hpaMetricMetadataStore;
+
+    assignmentCreateSucceeded = meterRegistry.counter(ASSIGNMENT_CREATE_SUCCEEDED);
+    assignmentCreateFailed = meterRegistry.counter(ASSIGNMENT_CREATE_FAILED);
+    assignmentCreateTimer = meterRegistry.timer(ASSIGNMENT_CREATE_TIMER);
+    evictAssignmentTimer = meterRegistry.timer(EVICT_ASSIGNMENT_TIMER);
+    evictSucceeded = meterRegistry.counter(EVICT_SUCCEEDED);
+    evictFailed = meterRegistry.counter(EVICT_FAILED);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    if (pendingTask == null || pendingTask.getDelay(TimeUnit.SECONDS) <= 0) {
+      pendingTask =
+          executorService.schedule(
+              this::assignReplicasToCacheNodes,
+              managerConfig.getCacheNodeAssignmentServiceConfig().getSchedulePeriodMins(),
+              TimeUnit.SECONDS);
+    } else {
+      LOG.info(
+          "Cache node assignment task already scheduled, will run in {} ms",
+          pendingTask.getDelay(TimeUnit.MILLISECONDS));
+    }
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting cache node assignment service");
+    cacheNodeMetadataStore.addListener(cacheNodeListener);
+    replicaMetadataStore.addListener(replicaListener);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Closing cache node assignment service");
+    replicaMetadataStore.removeListener(replicaListener);
+    cacheNodeMetadataStore.removeListener(cacheNodeListener);
+    executorService.shutdownNow();
+    meterRegistry.close();
+    LOG.info("Closed cache node assignment service");
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(
+        managerConfig.getScheduleInitialDelayMins(),
+        managerConfig.getCacheNodeAssignmentServiceConfig().getSchedulePeriodMins(),
+        TimeUnit.MINUTES);
+  }
+
+  /**
+   * Assigns replicas to cache nodes based on the configured replica sets. This method fetches the
+   * list of replicas and cache nodes. Then, for each replica set, marks assignments for eviction if
+   * necessary, and calculates new assignments.
+   */
+  protected void assignReplicasToCacheNodes() {
+    Timer.Sample assignmentTimer = Timer.start(meterRegistry);
+    List<String> replicaSets =
+        managerConfig.getCacheNodeAssignmentServiceConfig().getReplicaSetsList();
+
+    for (String replicaSet : replicaSets) {
+      List<ReplicaMetadata> replicas =
+          replicaMetadataStore.listSync().stream()
+              .filter(replicaMetadata -> replicaSet.equals(replicaMetadata.getReplicaSet()))
+              .toList();
+      List<CacheNodeMetadata> cacheNodes =
+          cacheNodeMetadataStore.listSync().stream()
+              .filter(cacheNodeMetadata -> replicaSet.equals(cacheNodeMetadata.getReplicaSet()))
+              .toList();
+      List<CacheNodeAssignment> currentAssignments =
+          cacheNodeAssignmentStore.listSync().stream()
+              .filter(assignment -> replicaSet.equals(assignment.replicaSet))
+              .toList();
+
+      markAssignmentsForEviction(
+          currentAssignments, replicaMetadataBySnapshotId(replicas), Instant.now());
+
+      Map<String, SnapshotMetadata> snapshotIdsToMetadata =
+          snapshotMetadataBySnapshotId(snapshotMetadataStore);
+
+      List<SnapshotMetadata> assignedSnapshots =
+          getSnapshotsFromIds(
+              snapshotIdsToMetadata, currentAssignments.stream().map(x -> x.snapshotId).toList());
+      List<SnapshotMetadata> snapshotsWithReplicas =
+          getSnapshotsFromIds(
+              snapshotIdsToMetadata, replicas.stream().map(x -> x.snapshotId).toList());
+      List<SnapshotMetadata> unassignedSnapshots =
+          getUnassignedSnapshots(snapshotsWithReplicas, assignedSnapshots);
+
+      Map<String, CacheNodeBin> newAssignments =
+          assign(
+              cacheNodeAssignmentStore,
+              snapshotMetadataStore,
+              currentAssignments,
+              unassignedSnapshots,
+              cacheNodes);
+      int successfulAssignments =
+          createAssignments(cacheNodeAssignmentStore, newAssignments, replicaSet);
+      int failedAssignments = newAssignments.size() - successfulAssignments;
+
+      calculateAndPersistHpaMetric(hpaMetricMetadataStore, replicaSet, newAssignments, cacheNodes);
+
+      assignmentCreateSucceeded.increment(successfulAssignments);
+      assignmentCreateFailed.increment(failedAssignments);
+
+      long evictionDuration = assignmentTimer.stop(assignmentCreateTimer);
+      LOG.info(
+          "Completed cache node assignments - successfully assigned {} replicas, failed to assign {} replicas in {} ms",
+          successfulAssignments,
+          failedAssignments,
+          nanosToMillis(evictionDuration));
+    }
+  }
+
+  /**
+   * Marks assignments for eviction if they meet certain criteria (currently live, and has an
+   * expiration in the past). This method filters assignments that should be evicted based on the
+   * provided expiration time and metadata, updates their state, and logs the results.
+   *
+   * @param cacheNodeAssignments the list of cache node assignments to evaluate
+   * @param replicaMetadataBySnapshotId a map of replica metadata keyed by snapshot ID
+   * @param expireOlderThan the cutoff time for marking assignments for eviction
+   * @return the number of successful evictions
+   */
+  @VisibleForTesting
+  public int markAssignmentsForEviction(
+      List<CacheNodeAssignment> cacheNodeAssignments,
+      Map<String, ReplicaMetadata> replicaMetadataBySnapshotId,
+      Instant expireOlderThan) {
+    Timer.Sample evictionTimer = Timer.start(meterRegistry);
+
+    AtomicInteger successCounter = new AtomicInteger(0);
+    List<ListenableFuture<?>> replicaEvictions =
+        cacheNodeAssignments.stream()
+            .filter(
+                cacheNodeAssignment ->
+                    shouldEvictReplica(
+                        expireOlderThan, replicaMetadataBySnapshotId, cacheNodeAssignment))
+            .map(
+                (cacheNodeAssignment) -> {
+                  ListenableFuture<?> future =
+                      cacheNodeAssignmentStore.updateAssignmentState(
+                          cacheNodeAssignment,
+                          Metadata.CacheNodeAssignment.CacheNodeAssignmentState.EVICT);
+
+                  addCallback(
+                      future,
+                      successCountingCallback(successCounter),
+                      MoreExecutors.directExecutor());
+                  return future;
+                })
+            .collect(Collectors.toUnmodifiableList());
+
+    ListenableFuture<?> futureList = Futures.successfulAsList(replicaEvictions);
+    try {
+      futureList.get(futuresListTimeoutSecs, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      futureList.cancel(true);
+    }
+
+    int successfulEvictions = successCounter.get();
+    int failedEvictions = replicaEvictions.size() - successfulEvictions;
+
+    assignmentCreateSucceeded.increment(successfulEvictions);
+    assignmentCreateFailed.increment(failedEvictions);
+
+    long evictionDuration = evictionTimer.stop(evictAssignmentTimer);
+    LOG.info(
+        "Completed assignment evictions - successfully marked {} assignments for eviction, failed to mark {} assignments for eviction in {} ms",
+        successfulEvictions,
+        failedEvictions,
+        nanosToMillis(evictionDuration));
+
+    return successfulEvictions;
+  }
+
+  /**
+   * Calculates and persists the HPA (Horizontal Pod Autoscaler) metric based on new assignments.
+   * This method calculates the demand factor from new assignments and persists it in the HPA metric
+   * metadata store.
+   *
+   * @param hpaMetricMetadataStore the store to persist HPA metrics
+   * @param replicaSet the replica set for which to calculate the HPA metric
+   * @param newAssignments the new assignments of cache nodes to snapshots
+   * @param cacheNodes the list of cache nodes
+   */
+  private static void calculateAndPersistHpaMetric(
+      HpaMetricMetadataStore hpaMetricMetadataStore,
+      String replicaSet,
+      Map<String, CacheNodeBin> newAssignments,
+      List<CacheNodeMetadata> cacheNodes) {
+    double demandFactor =
+        calculateHpaValueFromNewAssignments(
+            newAssignments, cacheNodes.stream().mapToLong(node -> node.nodeCapacityBytes).sum());
+    persistCacheConfig(hpaMetricMetadataStore, replicaSet, demandFactor);
+  }
+
+  /**
+   * Persists cache node assignments in the cache node assignment store.
+   *
+   * @param cacheNodeAssignmentStore the store to persist cache node assignments
+   * @param newAssignments a map of new assignments keyed by cache node ID
+   * @param replicaSet the replica set for which to persist assignments
+   * @return the number of successful assignments
+   */
+  private static int createAssignments(
+      CacheNodeAssignmentStore cacheNodeAssignmentStore,
+      Map<String, CacheNodeBin> newAssignments,
+      String replicaSet) {
+    int numAssigned = 0;
+    for (Map.Entry<String, CacheNodeBin> entry : newAssignments.entrySet()) {
+      String cacheNodeId = entry.getKey();
+      for (String snapshotId : entry.getValue().getSnapshotIds()) {
+        if (cacheNodeId.startsWith(NEW_BIN_PREFIX)) {
+          continue;
+        }
+        CacheNodeAssignment newAssignment =
+            new CacheNodeAssignment(
+                UUID.randomUUID().toString(),
+                cacheNodeId,
+                snapshotId,
+                replicaSet,
+                Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LOADING);
+        cacheNodeAssignmentStore.createSync(newAssignment);
+        numAssigned++;
+      }
+    }
+    return numAssigned;
+  }
+
+  /**
+   * Gets the list of unassigned snapshots by comparing the snapshots with replicas and the assigned
+   * snapshots.
+   *
+   * <p>Unassigned snapshots are the set difference between snapshots with replicas and snapshots
+   * with existing assignments. e.g. if a snapshot has a replica created, but no assignment to a
+   * cache node, it is "unassigned".
+   *
+   * @param snapshotsWithReplicas the list of snapshots that have replicas
+   * @param assignedSnapshots the list of already assigned snapshots
+   * @return the list of unassigned snapshots
+   */
+  private static List<SnapshotMetadata> getUnassignedSnapshots(
+      List<SnapshotMetadata> snapshotsWithReplicas, List<SnapshotMetadata> assignedSnapshots) {
+    return new ArrayList<>(
+        Sets.difference(
+            Sets.newHashSet(snapshotsWithReplicas), Sets.newHashSet(assignedSnapshots)));
+  }
+
+  /**
+   * Assigns snapshots to cache nodes using a first-fit packing algorithm. This method initializes
+   * bins with existing cache nodes and existing assignments. Then, it assigns unassigned snapshots
+   * to bins, putting them in new bins if required.
+   *
+   * @param cacheNodeAssignmentStore the store for cache node assignments
+   * @param snapshotMetadataStore the store for snapshot metadata
+   * @param currentAssignments the current assignments of cache nodes to snapshots
+   * @param snapshotsToAssign the list of snapshots to be assigned
+   * @param existingCacheNodes the list of existing cache nodes
+   * @return a map of cache node bins keyed by cache node ID
+   */
+  @VisibleForTesting
+  public static Map<String, CacheNodeBin> assign(
+      CacheNodeAssignmentStore cacheNodeAssignmentStore,
+      SnapshotMetadataStore snapshotMetadataStore,
+      List<CacheNodeAssignment> currentAssignments,
+      List<SnapshotMetadata> snapshotsToAssign,
+      List<CacheNodeMetadata> existingCacheNodes) {
+    int newBinsCreated = 0;
+    Map<String, CacheNodeBin> cacheNodeBins = new HashMap<>();
+
+    // Initialize bins with existing cache nodes
+    for (CacheNodeMetadata cacheNodeMetadata : existingCacheNodes) {
+      cacheNodeBins.put(
+          cacheNodeMetadata.name, new CacheNodeBin(cacheNodeMetadata.nodeCapacityBytes));
+    }
+
+    // Add existing assignments to bins
+    for (CacheNodeAssignment assignment : currentAssignments) {
+      if (cacheNodeBins.containsKey(assignment.cacheNodeId)) {
+        CacheNodeBin bin = cacheNodeBins.get(assignment.cacheNodeId);
+        bin.addSnapshot(assignment.snapshotId);
+        bin.subtractFromSize(
+            snapshotMetadataStore.findSync(assignment.snapshotId).sizeInBytesOnDisk);
+      } else {
+        cacheNodeAssignmentStore.deleteSync(assignment);
+        snapshotsToAssign.add(snapshotMetadataStore.findSync(assignment.snapshotId));
+      }
+    }
+
+    // do first-fit packing for remaining snapshots
+    for (SnapshotMetadata snapshot : snapshotsToAssign) {
+      boolean assigned = false;
+      for (Map.Entry<String, CacheNodeBin> binEntry : cacheNodeBins.entrySet()) {
+        CacheNodeBin cacheNodeBin = binEntry.getValue();
+        if (snapshot.sizeInBytesOnDisk <= cacheNodeBin.getRemainingCapacityBytes()) {
+          cacheNodeBin.addSnapshot(snapshot.snapshotId);
+          cacheNodeBin.subtractFromSize(snapshot.sizeInBytesOnDisk);
+          assigned = true;
+          break;
+        }
+      }
+      if (!assigned) {
+        // if no bin can fit current item -> create new bin
+        String newBinKey = String.format(NEW_BIN_PREFIX + "%s", newBinsCreated);
+        CacheNodeBin newBin = new CacheNodeBin(snapshot.sizeInBytesOnDisk);
+
+        newBin.subtractFromSize(snapshot.sizeInBytesOnDisk);
+        newBin.addSnapshot(snapshot.snapshotId);
+        cacheNodeBins.put(newBinKey, newBin);
+        newBinsCreated++;
+      }
+    }
+
+    return cacheNodeBins;
+  }
+
+  /**
+   * Generates a map of snapshot metadata keyed by snapshot ID. This method retrieves a list of
+   * snapshot metadata from the store and maps each snapshot ID to its corresponding metadata.
+   *
+   * @param snapshotMetadataStore the store containing snapshot metadata
+   * @return a map of snapshot IDs to snapshot metadata
+   */
+  private static Map<String, SnapshotMetadata> snapshotMetadataBySnapshotId(
+      SnapshotMetadataStore snapshotMetadataStore) {
+    Map<String, SnapshotMetadata> snapshotIdsToMetadata = new HashMap<>();
+    snapshotMetadataStore
+        .listSync()
+        .forEach(
+            snapshotMetadata ->
+                snapshotIdsToMetadata.putIfAbsent(snapshotMetadata.snapshotId, snapshotMetadata));
+
+    return snapshotIdsToMetadata;
+  }
+
+  /**
+   * Generates a map of replica metadata keyed by snapshot ID. This method takes a list of replica
+   * metadata and maps each snapshot ID to its corresponding replica metadata.
+   *
+   * @param replicaMetadataList the list of replica metadata
+   * @return a map of snapshot IDs to replica metadata
+   */
+  private static Map<String, ReplicaMetadata> replicaMetadataBySnapshotId(
+      List<ReplicaMetadata> replicaMetadataList) {
+    Map<String, ReplicaMetadata> snapshotIdsToMetadata = new HashMap<>();
+    replicaMetadataList.forEach(
+        replicaMetadata ->
+            snapshotIdsToMetadata.putIfAbsent(replicaMetadata.snapshotId, replicaMetadata));
+
+    return snapshotIdsToMetadata;
+  }
+
+  /**
+   * Retrieves a list of snapshot metadata for the given snapshot IDs. This method takes a map of
+   * snapshot metadata and a list of snapshot IDs, and returns a list of snapshot metadata
+   * corresponding to those IDs.
+   *
+   * @param snapshotIdsToMetadata a map of snapshot IDs to snapshot metadata
+   * @param snapshotIds the list of snapshot IDs to retrieve metadata for
+   * @return a list of snapshot metadata corresponding to the given snapshot IDs
+   */
+  private static List<SnapshotMetadata> getSnapshotsFromIds(
+      Map<String, SnapshotMetadata> snapshotIdsToMetadata, List<String> snapshotIds) {
+    // use snapshotID to get size of each replica
+    List<SnapshotMetadata> snapshots = new ArrayList<>();
+    for (String snapshotId : snapshotIds) {
+      if (snapshotIdsToMetadata.containsKey(snapshotId)) {
+        snapshots.add(snapshotIdsToMetadata.get(snapshotId));
+      }
+    }
+    return snapshots;
+  }
+
+  /**
+   * Calculates the HPA (Horizontal Pod Autoscaler) value based on new assignments. This method
+   * computes the demand factor as the ratio of total bytes requiring assignment to the total
+   * capacity of cache nodes.
+   *
+   * @param newAssignments a map of new assignments keyed by cache node ID
+   * @param totalCacheNodeCapacityBytes the total capacity of all cache nodes in bytes
+   * @return the calculated HPA value
+   */
+  private static double calculateHpaValueFromNewAssignments(
+      Map<String, CacheNodeBin> newAssignments, long totalCacheNodeCapacityBytes) {
+    long totalBytesRequiringAssignment =
+        newAssignments.values().stream()
+            .mapToLong(
+                cacheNodeBin ->
+                    cacheNodeBin.getTotalCapacityBytes() - cacheNodeBin.getRemainingCapacityBytes())
+            .sum();
+
+    return (double) totalBytesRequiringAssignment / totalCacheNodeCapacityBytes;
+  }
+
+  /** Updates or inserts an (ephemeral) HPA metric for the cache nodes. This is NOT threadsafe. */
+  private static void persistCacheConfig(
+      HpaMetricMetadataStore hpaMetricMetadataStore, String replicaSet, Double demandFactor) {
+    String key = String.format(CACHE_HPA_METRIC_NAME, replicaSet);
+    if (hpaMetricMetadataStore.hasSync(key)) {
+      hpaMetricMetadataStore.updateSync(
+          new HpaMetricMetadata(key, Metadata.HpaMetricMetadata.NodeRole.CACHE, demandFactor));
+    } else {
+      hpaMetricMetadataStore.createSync(
+          new HpaMetricMetadata(key, Metadata.HpaMetricMetadata.NodeRole.CACHE, demandFactor));
+    }
+  }
+
+  /**
+   * Checks if the cache slot should be evicted (currently live, and has an expiration in the past)
+   */
+  private static boolean shouldEvictReplica(
+      Instant expireOlderThan,
+      Map<String, ReplicaMetadata> replicaMetadataByReplicaId,
+      CacheNodeAssignment cacheNodeAssignment) {
+    return cacheNodeAssignment.state.equals(
+            Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE)
+        && replicaMetadataByReplicaId.containsKey(cacheNodeAssignment.snapshotId)
+        && replicaMetadataByReplicaId.get(cacheNodeAssignment.snapshotId).expireAfterEpochMs
+            < expireOlderThan.toEpochMilli();
+  }
+}
+
+/**
+ * CacheNodeBin class represents the assignments for a cache node. It tracks the total and remaining
+ * capacity in bytes and stores snapshot IDs.
+ */
+class CacheNodeBin {
+  private long remainingCapacityBytes;
+  private final Set<String> snapshotIds;
+  private final long totalCapacityBytes;
+
+  public CacheNodeBin(long totalCapacityBytes) {
+    this.remainingCapacityBytes = totalCapacityBytes;
+    this.snapshotIds = new HashSet<>();
+    this.totalCapacityBytes = totalCapacityBytes;
+  }
+
+  public long getTotalCapacityBytes() {
+    return totalCapacityBytes;
+  }
+
+  public long getRemainingCapacityBytes() {
+    return remainingCapacityBytes;
+  }
+
+  public void subtractFromSize(long sizeToSubtract) {
+    this.remainingCapacityBytes -= sizeToSubtract;
+  }
+
+  public Set<String> getSnapshotIds() {
+    return snapshotIds;
+  }
+
+  public void addSnapshot(String snapshotId) {
+    this.snapshotIds.add(snapshotId);
+  }
+}

--- a/astra/src/main/java/com/slack/astra/clusterManager/ClusterMonitorService.java
+++ b/astra/src/main/java/com/slack/astra/clusterManager/ClusterMonitorService.java
@@ -1,22 +1,69 @@
 package com.slack.astra.clusterManager;
 
-import com.google.common.util.concurrent.AbstractIdleService;
+import static com.slack.astra.clusterManager.CacheNodeAssignmentService.getSnapshotsFromIds;
+import static com.slack.astra.clusterManager.CacheNodeAssignmentService.snapshotMetadataBySnapshotId;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.slack.astra.metadata.cache.CacheNodeAssignment;
+import com.slack.astra.metadata.cache.CacheNodeAssignmentStore;
+import com.slack.astra.metadata.cache.CacheNodeMetadata;
+import com.slack.astra.metadata.cache.CacheNodeMetadataStore;
 import com.slack.astra.metadata.cache.CacheSlotMetadataStore;
+import com.slack.astra.metadata.core.AstraMetadataStoreChangeListener;
 import com.slack.astra.metadata.dataset.DatasetMetadataStore;
 import com.slack.astra.metadata.recovery.RecoveryNodeMetadataStore;
 import com.slack.astra.metadata.recovery.RecoveryTaskMetadataStore;
 import com.slack.astra.metadata.replica.ReplicaMetadataStore;
 import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ClusterMonitor runs as a service in the manager component and monitors the state of the Astra
  * cluster.
  */
-public class ClusterMonitorService extends AbstractIdleService {
+public class ClusterMonitorService extends AbstractScheduledService {
+  private final AstraConfigs.ManagerConfig managerConfig;
+  private ScheduledFuture<?> pendingTask;
+  private final ScheduledExecutorService executorService =
+      Executors.newSingleThreadScheduledExecutor(
+          new ThreadFactoryBuilder().setNameFormat("cluster-monitor-service-%d").build());
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterMonitorService.class);
+  private final MultiGauge liveChunksPerPod;
+  private final MultiGauge freeSpacePerPod;
+
+  public static final String LIVE_CHUNKS_PER_POD = "live_chunks_per_pod";
+  public static final String FREE_SPACE_PER_POD = "free_space_per_pod";
+
+  private final CacheNodeAssignmentStore cacheNodeAssignmentStore;
+  private final CacheNodeMetadataStore cacheNodeMetadataStore;
+  private final ReplicaMetadataStore replicaMetadataStore;
+  private final AstraMetadataStoreChangeListener<CacheNodeMetadata> cacheNodeMetadataListener =
+      (_) -> runOneIteration();
+  private final AstraMetadataStoreChangeListener<CacheNodeAssignment> cacheNodeAssignmentListener =
+      (_) -> runOneIteration();
+  private final Map<String, AtomicInteger> cacheNodeIdToLiveChunksPerPod;
+  private final Map<String, AtomicLong> cacheNodeIdToFreeSpaceBytes;
+
   public ClusterMonitorService(
       ReplicaMetadataStore replicaMetadataStore,
       SnapshotMetadataStore snapshotMetadataStore,
@@ -24,7 +71,26 @@ public class ClusterMonitorService extends AbstractIdleService {
       RecoveryNodeMetadataStore recoveryNodeMetadataStore,
       CacheSlotMetadataStore cacheSlotMetadataStore,
       DatasetMetadataStore datasetMetadataStore,
+      CacheNodeAssignmentStore cacheNodeAssignmentStore,
+      CacheNodeMetadataStore cacheNodeMetadataStore,
+      AstraConfigs.ManagerConfig managerConfig,
       MeterRegistry meterRegistry) {
+    this.cacheNodeAssignmentStore = cacheNodeAssignmentStore;
+    this.cacheNodeMetadataStore = cacheNodeMetadataStore;
+    this.replicaMetadataStore = replicaMetadataStore;
+    this.cacheNodeIdToFreeSpaceBytes = new ConcurrentHashMap<>();
+    this.cacheNodeIdToLiveChunksPerPod = new ConcurrentHashMap<>();
+    this.managerConfig = managerConfig;
+
+    this.liveChunksPerPod =
+        MultiGauge.builder(LIVE_CHUNKS_PER_POD)
+            .description("Number of live chunks per pod")
+            .register(meterRegistry);
+
+    this.freeSpacePerPod =
+        MultiGauge.builder(FREE_SPACE_PER_POD)
+            .description("Free space per pod in bytes")
+            .register(meterRegistry);
 
     meterRegistry.gauge(
         "cached_replica_nodes_size", replicaMetadataStore, store -> store.listSync().size());
@@ -34,6 +100,64 @@ public class ClusterMonitorService extends AbstractIdleService {
         "cached_recovery_tasks_size", recoveryTaskMetadataStore, store -> store.listSync().size());
     meterRegistry.gauge(
         "cached_recovery_nodes_size", recoveryNodeMetadataStore, store -> store.listSync().size());
+
+    for (String replicaSet :
+        managerConfig.getCacheNodeAssignmentServiceConfig().getReplicaSetsList()) {
+      meterRegistry.gauge(
+          "total_live_bytes",
+          List.of(Tag.of("replicaSet", replicaSet)),
+          cacheNodeAssignmentStore,
+          store ->
+              store.listSync().stream()
+                  .filter(
+                      assignment ->
+                          assignment.state
+                                  == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE
+                              && Objects.equals(assignment.replicaSet, replicaSet))
+                  .mapToLong(assignment -> assignment.snapshotSize)
+                  .sum());
+
+      meterRegistry.gauge(
+          "total_assigned_bytes",
+          List.of(Tag.of("replicaSet", replicaSet)),
+          snapshotMetadataStore,
+          store -> calculateAssignedBytes(replicaSet, store));
+
+      // # of assignments
+      meterRegistry.gauge(
+          "total_num_chunks_assigned",
+          List.of(Tag.of("replicaSet", replicaSet)),
+          replicaMetadataStore,
+          store -> calculateAssignedChunks(replicaSet, store));
+
+      // # of live assignments
+      meterRegistry.gauge(
+          "total_num_live_chunks",
+          List.of(Tag.of("replicaSet", replicaSet)),
+          cacheNodeAssignmentStore,
+          store ->
+              store.listSync().stream()
+                  .filter(
+                      assignment ->
+                          assignment.state
+                                  == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE
+                              && Objects.equals(assignment.replicaSet, replicaSet))
+                  .toList()
+                  .size());
+
+      // total capacity of all cache nodes
+      meterRegistry.gauge(
+          "total_capacity_cache_nodes",
+          List.of(Tag.of("replicaSet", replicaSet)),
+          cacheNodeMetadataStore,
+          store ->
+              store.listSync().stream()
+                  .filter((node) -> Objects.equals(node.getReplicaSet(), replicaSet))
+                  .mapToLong(node -> node.nodeCapacityBytes)
+                  .sum());
+    }
+
+    updatePerPodMetrics();
 
     for (Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState :
         Metadata.CacheSlotMetadata.CacheSlotState.values()) {
@@ -54,9 +178,153 @@ public class ClusterMonitorService extends AbstractIdleService {
         "cached_service_nodes_size", datasetMetadataStore, store -> store.listSync().size());
   }
 
-  @Override
-  protected void startUp() throws Exception {}
+  private void updatePerPodMetrics() {
+    liveChunksPerPod.register(
+        cacheNodeMetadataStore.listSync().stream()
+            .map(
+                cacheNodeMetadata ->
+                    MultiGauge.Row.of(
+                        Tags.of(Tag.of("pod", cacheNodeMetadata.getName())),
+                        cacheNodeIdToLiveChunksPerPod.computeIfAbsent(
+                            cacheNodeMetadata.getName(),
+                            (_) -> new AtomicInteger(calculateLiveChunks(cacheNodeMetadata.id)))))
+            .collect(Collectors.toUnmodifiableList()),
+        true);
+
+    freeSpacePerPod.register(
+        cacheNodeMetadataStore.listSync().stream()
+            .map(
+                cacheNodeMetadata ->
+                    MultiGauge.Row.of(
+                        Tags.of(Tag.of("pod", cacheNodeMetadata.getName())),
+                        cacheNodeIdToFreeSpaceBytes.computeIfAbsent(
+                            cacheNodeMetadata.getName(),
+                            (_) -> new AtomicLong(calculateFreeSpaceForPod(cacheNodeMetadata.id)))))
+            .collect(Collectors.toUnmodifiableList()),
+        true);
+  }
+
+  private void cacheNodeAssignmentListener() {
+    try {
+      updateLiveChunksPerPod();
+      updateFreeSpacePerPod();
+      updatePerPodMetrics();
+    } catch (Exception e) {
+      LOG.error("Error updating per pod metrics", e);
+    }
+  }
+
+  private static long getTotalLiveAssignmentSize(
+      CacheNodeMetadata cacheNodeMetadata, CacheNodeAssignmentStore store) {
+    return store.listSync().stream()
+        .filter(
+            assignment ->
+                Objects.equals(assignment.cacheNodeId, cacheNodeMetadata.id)
+                    && assignment.state
+                        == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE)
+        .mapToLong(assignment -> assignment.snapshotSize)
+        .sum();
+  }
 
   @Override
-  protected void shutDown() throws Exception {}
+  protected synchronized void runOneIteration() {
+    if (pendingTask == null || pendingTask.getDelay(TimeUnit.SECONDS) <= 0) {
+      pendingTask =
+          executorService.schedule(
+              this::cacheNodeAssignmentListener,
+              managerConfig.getEventAggregationSecs(),
+              TimeUnit.SECONDS);
+    } else {
+      LOG.info(
+          "Cache node assignment task already scheduled, will run in {} ms",
+          pendingTask.getDelay(TimeUnit.MILLISECONDS));
+    }
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting cluster monitor service");
+    cacheNodeMetadataStore.addListener(cacheNodeMetadataListener);
+    cacheNodeAssignmentStore.addListener(cacheNodeAssignmentListener);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Shutting down cluster monitor service");
+    cacheNodeMetadataStore.removeListener(cacheNodeMetadataListener);
+    cacheNodeAssignmentStore.removeListener(cacheNodeAssignmentListener);
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(
+        managerConfig.getScheduleInitialDelayMins(),
+        managerConfig.getClusterMonitorServiceConfig().getSchedulePeriodMins(),
+        TimeUnit.MINUTES);
+  }
+
+  private long calculateAssignedBytes(String replicaSet, SnapshotMetadataStore store) {
+    return getSnapshotsFromIds(
+            snapshotMetadataBySnapshotId(store),
+            replicaMetadataStore.listSync().stream()
+                .filter(replicaMetadata -> replicaMetadata.getReplicaSet().equals(replicaSet))
+                .map(replica -> replica.snapshotId)
+                .collect(Collectors.toSet()))
+        .stream()
+        .mapToLong(snapshot -> snapshot.sizeInBytesOnDisk)
+        .sum();
+  }
+
+  private long calculateAssignedChunks(String replicaSet, ReplicaMetadataStore store) {
+    return store.listSync().stream()
+        .filter(replicaMetadata -> replicaMetadata.getReplicaSet().equals(replicaSet))
+        .map(replica -> replica.snapshotId)
+        .collect(Collectors.toSet())
+        .size();
+  }
+
+  private int calculateLiveChunks(String cacheNodeId) {
+    return cacheNodeAssignmentStore.listSync().stream()
+        .filter(
+            assignment ->
+                Objects.equals(assignment.cacheNodeId, cacheNodeId)
+                    && assignment.state
+                        == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE)
+        .toList()
+        .size();
+  }
+
+  private long calculateFreeSpaceForPod(String cacheNodeId) {
+    CacheNodeMetadata cacheNodeMetadata = cacheNodeMetadataStore.getSync(cacheNodeId);
+    return cacheNodeMetadata.nodeCapacityBytes
+        - getTotalLiveAssignmentSize(cacheNodeMetadata, cacheNodeAssignmentStore);
+  }
+
+  private void updateLiveChunksPerPod() {
+    for (CacheNodeMetadata cacheNodeMetadata : cacheNodeMetadataStore.listSync()) {
+      if (!cacheNodeIdToLiveChunksPerPod.containsKey(cacheNodeMetadata.id)) {
+        cacheNodeIdToLiveChunksPerPod.put(
+            cacheNodeMetadata.id, new AtomicInteger(calculateLiveChunks(cacheNodeMetadata.id)));
+        return;
+      }
+
+      cacheNodeIdToLiveChunksPerPod
+          .get(cacheNodeMetadata.id)
+          .set(calculateLiveChunks(cacheNodeMetadata.id));
+    }
+  }
+
+  private void updateFreeSpacePerPod() {
+    for (CacheNodeMetadata cacheNodeMetadata : cacheNodeMetadataStore.listSync()) {
+      if (!cacheNodeIdToFreeSpaceBytes.containsKey(cacheNodeMetadata.id)) {
+        cacheNodeIdToFreeSpaceBytes.put(
+            cacheNodeMetadata.id, new AtomicLong(calculateFreeSpaceForPod(cacheNodeMetadata.id)));
+        return;
+      }
+
+      cacheNodeIdToFreeSpaceBytes
+          .get(cacheNodeMetadata.id)
+          .set(calculateFreeSpaceForPod(cacheNodeMetadata.id));
+    }
+  }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignment.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignment.java
@@ -8,21 +8,27 @@ public class CacheNodeAssignment extends AstraPartitionedMetadata {
   public final String assignmentId;
   public final String cacheNodeId;
   public final String snapshotId;
+  public final String replicaId;
   public final String replicaSet;
+  public final long snapshotSize;
   public Metadata.CacheNodeAssignment.CacheNodeAssignmentState state;
 
   public CacheNodeAssignment(
       String assignmentId,
       String cacheNodeId,
       String snapshotId,
+      String replicaId,
       String replicaSet,
+      long snapshotSize,
       Metadata.CacheNodeAssignment.CacheNodeAssignmentState state) {
     super(assignmentId);
     this.assignmentId = assignmentId;
     this.cacheNodeId = cacheNodeId;
     this.snapshotId = snapshotId;
+    this.replicaId = replicaId;
     this.replicaSet = replicaSet;
     this.state = state;
+    this.snapshotSize = snapshotSize;
   }
 
   @Override
@@ -38,7 +44,10 @@ public class CacheNodeAssignment extends AstraPartitionedMetadata {
 
     if (!assignmentId.equals(that.assignmentId)) return false;
     if (!snapshotId.equals(that.snapshotId)) return false;
+    if (!replicaId.equals(that.replicaId)) return false;
+    if (!replicaSet.equals(that.replicaSet)) return false;
     if (!Objects.equals(cacheNodeId, that.cacheNodeId)) return false;
+    if (!(snapshotSize == that.snapshotSize)) return false;
     return Objects.equals(state, that.state);
   }
 
@@ -47,8 +56,11 @@ public class CacheNodeAssignment extends AstraPartitionedMetadata {
     int result = super.hashCode();
     result = 31 * result + assignmentId.hashCode();
     result = 31 * result + cacheNodeId.hashCode();
+    result = 31 * result + replicaId.hashCode();
+    result = 31 * result + replicaSet.hashCode();
     result = 31 * result + snapshotId.hashCode();
     result = 31 * result + state.hashCode();
+    result = 31 * result + Long.hashCode(snapshotSize);
     return result;
   }
 
@@ -63,8 +75,12 @@ public class CacheNodeAssignment extends AstraPartitionedMetadata {
         + '\''
         + ", snapshotId="
         + snapshotId
+        + ", replicaId="
+        + replicaId
         + ", state='"
         + state
+        + ", replicaSet='"
+        + replicaSet
         + '\''
         + '}';
   }

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignment.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignment.java
@@ -1,0 +1,71 @@
+package com.slack.astra.metadata.cache;
+
+import com.slack.astra.metadata.core.AstraPartitionedMetadata;
+import com.slack.astra.proto.metadata.Metadata;
+import java.util.Objects;
+
+public class CacheNodeAssignment extends AstraPartitionedMetadata {
+  public final String assignmentId;
+  public final String cacheNodeId;
+  public final String snapshotId;
+  public final String replicaSet;
+  public Metadata.CacheNodeAssignment.CacheNodeAssignmentState state;
+
+  public CacheNodeAssignment(
+      String assignmentId,
+      String cacheNodeId,
+      String snapshotId,
+      String replicaSet,
+      Metadata.CacheNodeAssignment.CacheNodeAssignmentState state) {
+    super(assignmentId);
+    this.assignmentId = assignmentId;
+    this.cacheNodeId = cacheNodeId;
+    this.snapshotId = snapshotId;
+    this.replicaSet = replicaSet;
+    this.state = state;
+  }
+
+  @Override
+  public String getPartition() {
+    return cacheNodeId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof CacheNodeAssignment that)) return false;
+    if (!super.equals(o)) return false;
+
+    if (!assignmentId.equals(that.assignmentId)) return false;
+    if (!snapshotId.equals(that.snapshotId)) return false;
+    if (!Objects.equals(cacheNodeId, that.cacheNodeId)) return false;
+    return Objects.equals(state, that.state);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + assignmentId.hashCode();
+    result = 31 * result + cacheNodeId.hashCode();
+    result = 31 * result + snapshotId.hashCode();
+    result = 31 * result + state.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CacheNodeAssignment{"
+        + "assignmentId='"
+        + assignmentId
+        + '\''
+        + ", cacheNodeId='"
+        + cacheNodeId
+        + '\''
+        + ", snapshotId="
+        + snapshotId
+        + ", state='"
+        + state
+        + '\''
+        + '}';
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializer.java
@@ -12,7 +12,9 @@ public class CacheNodeAssignmentSerializer implements MetadataSerializer<CacheNo
         cacheSlotMetadataProto.getAssignmentId(),
         cacheSlotMetadataProto.getCacheNodeId(),
         cacheSlotMetadataProto.getSnapshotId(),
+        cacheSlotMetadataProto.getReplicaId(),
         cacheSlotMetadataProto.getReplicaSet(),
+        cacheSlotMetadataProto.getSnapshotSize(),
         cacheSlotMetadataProto.getState());
   }
 
@@ -22,8 +24,10 @@ public class CacheNodeAssignmentSerializer implements MetadataSerializer<CacheNo
         .setAssignmentId(metadata.assignmentId)
         .setCacheNodeId(metadata.cacheNodeId)
         .setSnapshotId(metadata.snapshotId)
+        .setReplicaId(metadata.replicaId)
         .setReplicaSet(metadata.replicaSet)
         .setState(metadata.state)
+        .setSnapshotSize(metadata.snapshotSize)
         .build();
   }
 

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializer.java
@@ -1,0 +1,44 @@
+package com.slack.astra.metadata.cache;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.slack.astra.metadata.core.MetadataSerializer;
+import com.slack.astra.proto.metadata.Metadata;
+
+public class CacheNodeAssignmentSerializer implements MetadataSerializer<CacheNodeAssignment> {
+  private static CacheNodeAssignment fromCacheNodeAssignmentProto(
+      Metadata.CacheNodeAssignment cacheSlotMetadataProto) {
+    return new CacheNodeAssignment(
+        cacheSlotMetadataProto.getAssignmentId(),
+        cacheSlotMetadataProto.getCacheNodeId(),
+        cacheSlotMetadataProto.getSnapshotId(),
+        cacheSlotMetadataProto.getReplicaSet(),
+        cacheSlotMetadataProto.getState());
+  }
+
+  private static Metadata.CacheNodeAssignment toCacheNodeAssignmentProto(
+      CacheNodeAssignment metadata) {
+    return Metadata.CacheNodeAssignment.newBuilder()
+        .setAssignmentId(metadata.assignmentId)
+        .setCacheNodeId(metadata.cacheNodeId)
+        .setSnapshotId(metadata.snapshotId)
+        .setReplicaSet(metadata.replicaSet)
+        .setState(metadata.state)
+        .build();
+  }
+
+  @Override
+  public String toJsonStr(CacheNodeAssignment metadata) throws InvalidProtocolBufferException {
+    if (metadata == null) throw new IllegalArgumentException("metadata object can't be null");
+
+    return printer.print(toCacheNodeAssignmentProto(metadata));
+  }
+
+  @Override
+  public CacheNodeAssignment fromJsonStr(String data) throws InvalidProtocolBufferException {
+    Metadata.CacheNodeAssignment.Builder cacheNodeMetadataBuilder =
+        Metadata.CacheNodeAssignment.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(data, cacheNodeMetadataBuilder);
+    return fromCacheNodeAssignmentProto(cacheNodeMetadataBuilder.build());
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
@@ -26,7 +26,9 @@ public class CacheNodeAssignmentStore extends AstraPartitioningMetadataStore<Cac
             cacheNodeAssignment.assignmentId,
             cacheNodeAssignment.cacheNodeId,
             cacheNodeAssignment.snapshotId,
+            cacheNodeAssignment.replicaId,
             cacheNodeAssignment.replicaSet,
+            cacheNodeAssignment.snapshotSize,
             state);
 
     return JdkFutureAdapters.listenInPoolThread(

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
@@ -1,0 +1,35 @@
+package com.slack.astra.metadata.cache;
+
+import com.google.common.util.concurrent.JdkFutureAdapters;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.proto.metadata.Metadata;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.zookeeper.CreateMode;
+
+public class CacheNodeAssignmentStore extends AstraPartitioningMetadataStore<CacheNodeAssignment> {
+  public static final String CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH = "/cacheAssignment";
+
+  public CacheNodeAssignmentStore(AsyncCuratorFramework curator) {
+    super(
+        curator,
+        CreateMode.PERSISTENT,
+        new CacheNodeAssignmentSerializer().toModelSerializer(),
+        CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH);
+  }
+
+  public ListenableFuture<?> updateAssignmentState(
+      final CacheNodeAssignment cacheNodeAssignment,
+      final Metadata.CacheNodeAssignment.CacheNodeAssignmentState state) {
+    CacheNodeAssignment updatedCacheNodeAssignment =
+        new CacheNodeAssignment(
+            cacheNodeAssignment.assignmentId,
+            cacheNodeAssignment.cacheNodeId,
+            cacheNodeAssignment.snapshotId,
+            cacheNodeAssignment.replicaSet,
+            state);
+
+    return JdkFutureAdapters.listenInPoolThread(
+        updateAsync(updatedCacheNodeAssignment).toCompletableFuture());
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadata.java
@@ -1,0 +1,62 @@
+package com.slack.astra.metadata.cache;
+
+import com.slack.astra.metadata.core.AstraMetadata;
+import java.util.Objects;
+
+public class CacheNodeMetadata extends AstraMetadata {
+  public final String id;
+  public final String hostname;
+  public final long nodeCapacityBytes;
+  public final String replicaSet;
+
+  public CacheNodeMetadata(String id, String hostname, long nodeCapacityBytes, String replicaSet) {
+    super(id);
+    this.id = id;
+    this.hostname = hostname;
+    this.nodeCapacityBytes = nodeCapacityBytes;
+    this.replicaSet = replicaSet;
+  }
+
+  public String getReplicaSet() {
+    return replicaSet;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof CacheNodeMetadata that)) return false;
+    if (!super.equals(o)) return false;
+
+    if (!hostname.equals(that.hostname)) return false;
+    if (!Objects.equals(replicaSet, that.replicaSet)) return false;
+    if (nodeCapacityBytes != that.nodeCapacityBytes) return false;
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + hostname.hashCode();
+    result = 31 * result + (replicaSet != null ? replicaSet.hashCode() : 0);
+    result = 31 * result + id.hashCode();
+    result = 31 * result + Long.hashCode(nodeCapacityBytes);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CacheNodeMetadata{"
+        + "id='"
+        + id
+        + '\''
+        + ", hostname='"
+        + hostname
+        + '\''
+        + ", replicaSet="
+        + replicaSet
+        + ", nodeCapacityBytes='"
+        + nodeCapacityBytes
+        + '\''
+        + '}';
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataSerializer.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataSerializer.java
@@ -1,0 +1,42 @@
+package com.slack.astra.metadata.cache;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.slack.astra.metadata.core.MetadataSerializer;
+import com.slack.astra.proto.metadata.Metadata;
+
+public class CacheNodeMetadataSerializer implements MetadataSerializer<CacheNodeMetadata> {
+  private static CacheNodeMetadata fromCacheNodeMetadataProto(
+      Metadata.CacheNodeMetadata cacheNodeMetadataProto) {
+    return new CacheNodeMetadata(
+        cacheNodeMetadataProto.getId(),
+        cacheNodeMetadataProto.getHostname(),
+        cacheNodeMetadataProto.getNodeCapacityBytes(),
+        cacheNodeMetadataProto.getReplicaSet());
+  }
+
+  private static Metadata.CacheNodeMetadata toCacheNodeMetadataProto(CacheNodeMetadata metadata) {
+    return Metadata.CacheNodeMetadata.newBuilder()
+        .setName(metadata.name)
+        .setId(metadata.id)
+        .setHostname(metadata.hostname)
+        .setReplicaSet(metadata.replicaSet)
+        .setNodeCapacityBytes(metadata.nodeCapacityBytes)
+        .build();
+  }
+
+  @Override
+  public String toJsonStr(CacheNodeMetadata metadata) throws InvalidProtocolBufferException {
+    if (metadata == null) throw new IllegalArgumentException("metadata object can't be null");
+
+    return printer.print(toCacheNodeMetadataProto(metadata));
+  }
+
+  @Override
+  public CacheNodeMetadata fromJsonStr(String data) throws InvalidProtocolBufferException {
+    Metadata.CacheNodeMetadata.Builder cacheNodeMetadataBuilder =
+        Metadata.CacheNodeMetadata.newBuilder();
+    JsonFormat.parser().ignoringUnknownFields().merge(data, cacheNodeMetadataBuilder);
+    return fromCacheNodeMetadataProto(cacheNodeMetadataBuilder.build());
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataStore.java
@@ -1,0 +1,18 @@
+package com.slack.astra.metadata.cache;
+
+import com.slack.astra.metadata.core.AstraMetadataStore;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.zookeeper.CreateMode;
+
+public class CacheNodeMetadataStore extends AstraMetadataStore<CacheNodeMetadata> {
+  public static final String CACHE_NODE_METADATA_STORE_ZK_PATH = "/cacheNodes";
+
+  public CacheNodeMetadataStore(AsyncCuratorFramework curator) {
+    super(
+        curator,
+        CreateMode.EPHEMERAL,
+        true,
+        new CacheNodeMetadataSerializer().toModelSerializer(),
+        CACHE_NODE_METADATA_STORE_ZK_PATH);
+  }
+}

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -155,7 +155,7 @@ message CacheConfig {
   int32 default_query_timeout_ms = 4;
   string replica_set = 5;
   // Capacity of the cache node in bytes. For use when dynamic chunk sizes are enabled.
-  int32 capacity_bytes = 6;
+  int64 capacity_bytes = 6;
 }
 
 // Cluster manager config. As a convention we define a config struct for
@@ -164,6 +164,7 @@ message ManagerConfig {
   message CacheNodeAssignmentServiceConfig {
     int32 schedule_period_mins = 1;
     repeated string replica_sets = 2;
+    int32 max_concurrent_per_node = 3;
   }
 
   message ReplicaCreationServiceConfig {
@@ -202,6 +203,10 @@ message ManagerConfig {
     repeated string replica_sets = 4;
   }
 
+  message ClusterMonitorServiceConfig {
+    int32 schedule_period_mins = 1;
+  }
+
   // Event aggregation secs is a de-bounce setting. It's the time
   // a service waits to take an action after a zk notification.
   int32 event_aggregation_secs = 1;
@@ -220,7 +225,7 @@ message ManagerConfig {
   SnapshotDeletionServiceConfig snapshot_deletion_service_config = 9;
   ReplicaRestoreServiceConfig replica_restore_service_config = 10;
   CacheNodeAssignmentServiceConfig cache_node_assignment_service_config = 11;
-
+  ClusterMonitorServiceConfig cluster_monitor_service_config = 12;
 }
 
 // Config for the recovery node.

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -154,11 +154,18 @@ message CacheConfig {
   ServerConfig server_config = 3;
   int32 default_query_timeout_ms = 4;
   string replica_set = 5;
+  // Capacity of the cache node in bytes. For use when dynamic chunk sizes are enabled.
+  int32 capacity_bytes = 6;
 }
 
 // Cluster manager config. As a convention we define a config struct for
 // every service in the cluster manager.
 message ManagerConfig {
+  message CacheNodeAssignmentServiceConfig {
+    int32 schedule_period_mins = 1;
+    repeated string replica_sets = 2;
+  }
+
   message ReplicaCreationServiceConfig {
     int32 schedule_period_mins = 1;
     int32 replica_lifespan_mins = 2;
@@ -212,6 +219,8 @@ message ManagerConfig {
       recovery_task_assignment_service_config = 8;
   SnapshotDeletionServiceConfig snapshot_deletion_service_config = 9;
   ReplicaRestoreServiceConfig replica_restore_service_config = 10;
+  CacheNodeAssignmentServiceConfig cache_node_assignment_service_config = 11;
+
 }
 
 // Config for the recovery node.

--- a/astra/src/main/proto/metadata.proto
+++ b/astra/src/main/proto/metadata.proto
@@ -212,3 +212,25 @@ message ChunkSchema {
   // A generic field to store metadata for a chunk.
   map<string, string> metadata = 3;
 }
+
+message CacheNodeAssignment {
+  enum CacheNodeAssignmentState {
+    LOADING = 0;
+    LIVE = 1;
+    EVICTING = 2;
+    EVICT = 3;
+  };
+  string assignment_id = 1;
+  string cache_node_id = 2;
+  string snapshot_id = 3;
+  string replica_set = 4;
+  CacheNodeAssignmentState state = 5;
+}
+
+message CacheNodeMetadata {
+  string name = 1;
+  string id = 2;
+  string hostname = 3;
+  int64  node_capacity_bytes = 4;
+  string replica_set = 5;
+}

--- a/astra/src/main/proto/metadata.proto
+++ b/astra/src/main/proto/metadata.proto
@@ -223,8 +223,10 @@ message CacheNodeAssignment {
   string assignment_id = 1;
   string cache_node_id = 2;
   string snapshot_id = 3;
-  string replica_set = 4;
-  CacheNodeAssignmentState state = 5;
+  string replica_id = 4;
+  string replica_set = 5;
+  int64 snapshot_size = 6;
+  CacheNodeAssignmentState state = 7;
 }
 
 message CacheNodeMetadata {

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -26,6 +26,8 @@ import com.slack.astra.logstore.schema.SchemaAwareLogDocumentBuilderImpl;
 import com.slack.astra.logstore.search.SearchQuery;
 import com.slack.astra.logstore.search.SearchResult;
 import com.slack.astra.logstore.search.aggregations.DateHistogramAggBuilder;
+import com.slack.astra.metadata.cache.CacheNodeAssignment;
+import com.slack.astra.metadata.cache.CacheNodeAssignmentStore;
 import com.slack.astra.metadata.cache.CacheSlotMetadata;
 import com.slack.astra.metadata.cache.CacheSlotMetadataStore;
 import com.slack.astra.metadata.core.AstraMetadataTestUtils;
@@ -486,6 +488,105 @@ public class ReadOnlyChunkImplTest {
     assertThat(ReadOnlyChunkImpl.determineEndTime(12, 10)).isNull();
   }
 
+  @Test
+  public void shouldHandleDynamicChunkSizeLifecycle() throws Exception {
+    AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
+    AstraConfigs.ZookeeperConfig zkConfig =
+        AstraConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("shouldHandleChunkLivecycle")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    CacheNodeAssignmentStore cacheNodeAssignmentStore =
+        new CacheNodeAssignmentStore(curatorFramework);
+
+    String replicaId = "foo";
+    String snapshotId = "bar";
+    String assignmentId = "dog";
+    String cacheNodeId = "baz";
+    String replicaSet = "cat";
+
+    // setup Zk, BlobFs so data can be loaded
+    initializeZkReplica(curatorFramework, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, snapshotId);
+    initializeBlobStorageWithIndex(snapshotId);
+    initializeCacheNodeAssignment(
+        cacheNodeAssignmentStore, assignmentId, snapshotId, cacheNodeId, replicaSet);
+
+    SearchContext searchContext =
+        SearchContext.fromConfig(AstraConfig.getCacheConfig().getServerConfig());
+    ReadOnlyChunkImpl<LogMessage> readOnlyChunk =
+        new ReadOnlyChunkImpl<>(
+            curatorFramework,
+            meterRegistry,
+            s3CrtBlobFs,
+            searchContext,
+            AstraConfig.getS3Config().getS3Bucket(),
+            AstraConfig.getCacheConfig().getDataDirectory(),
+            AstraConfig.getCacheConfig().getReplicaSet(),
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            snapshotMetadataStore,
+            searchMetadataStore,
+            cacheNodeAssignmentStore,
+            assignmentId,
+            cacheNodeId);
+
+    // wait for chunk to register
+    await()
+        .until(
+            () ->
+                readOnlyChunk.getCacheNodeAssignment().state
+                    == Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE);
+
+    SearchResult<LogMessage> logMessageSearchResult =
+        readOnlyChunk.query(
+            new SearchQuery(
+                MessageUtil.TEST_DATASET_NAME,
+                "*:*",
+                Instant.now().minus(1, ChronoUnit.MINUTES).toEpochMilli(),
+                Instant.now().toEpochMilli(),
+                500,
+                new DateHistogramAggBuilder(
+                    "1", LogMessage.SystemField.TIME_SINCE_EPOCH.fieldName, "1s"),
+                Collections.emptyList()));
+    assertThat(logMessageSearchResult.hits.size()).isEqualTo(10);
+
+    //    await()
+    //        .until(
+    //            () ->
+    //                meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful",
+    // "true").timer().count()
+    //                    == 1);
+    //    assertThat(meterRegistry.get(CHUNK_ASSIGNMENT_TIMER).tag("successful",
+    // "false").timer().count())
+    //        .isEqualTo(0);
+    //    assertThat(meterRegistry.get(CHUNK_EVICTION_TIMER).tag("successful",
+    // "true").timer().count())
+    //        .isEqualTo(0);
+    //    assertThat(meterRegistry.get(CHUNK_EVICTION_TIMER).tag("successful",
+    // "false").timer().count())
+    //        .isEqualTo(0);
+
+    // ensure we registered a search node for this cache assignment
+    await().until(() -> searchMetadataStore.listSync().size() == 1);
+    assertThat(searchMetadataStore.listSync().get(0).snapshotName).isEqualTo(snapshotId);
+
+    assertThat(searchMetadataStore.listSync().get(0).url).isEqualTo("gproto+http://localhost:8080");
+    assertThat(searchMetadataStore.listSync().get(0).name)
+        .isEqualTo(SearchMetadata.generateSearchContextSnapshotId(snapshotId, "localhost"));
+
+    curatorFramework.unwrap().close();
+  }
+
   private void assignReplicaToChunk(
       CacheSlotMetadataStore cacheSlotMetadataStore,
       String replicaId,
@@ -570,6 +671,22 @@ public class ReadOnlyChunkImplTest {
 
     // Copy files to S3.
     copyToS3(dirPath, filesToUpload, TEST_S3_BUCKET, snapshotId, s3CrtBlobFs);
+  }
+
+  private void initializeCacheNodeAssignment(
+      CacheNodeAssignmentStore cacheNodeAssignmentStore,
+      String assignmentId,
+      String snapshotId,
+      String cacheNodeId,
+      String replicaSet)
+      throws Exception {
+    cacheNodeAssignmentStore.createSync(
+        new CacheNodeAssignment(
+            assignmentId,
+            cacheNodeId,
+            snapshotId,
+            replicaSet,
+            Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LOADING));
   }
 
   private AstraConfigs.AstraConfig makeCacheConfig() {

--- a/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
@@ -672,7 +672,7 @@ public class IndexingChunkManagerTest {
     // Contains messages 1-10
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     String firstChunkId =
-        chunkManager.chunkList.stream()
+        chunkManager.chunkMap.values().stream()
             .filter(c -> !c.id().equals(activeChunkId))
             .findFirst()
             .get()

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
@@ -1,0 +1,437 @@
+package com.slack.astra.clusterManager;
+
+import static com.slack.astra.clusterManager.CacheNodeAssignmentService.CACHE_HPA_METRIC_NAME;
+import static com.slack.astra.clusterManager.CacheNodeAssignmentService.assign;
+import static com.slack.astra.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.spy;
+
+import brave.Tracing;
+import com.slack.astra.metadata.cache.CacheNodeAssignment;
+import com.slack.astra.metadata.cache.CacheNodeAssignmentStore;
+import com.slack.astra.metadata.cache.CacheNodeMetadata;
+import com.slack.astra.metadata.cache.CacheNodeMetadataStore;
+import com.slack.astra.metadata.core.CuratorBuilder;
+import com.slack.astra.metadata.hpa.HpaMetricMetadataStore;
+import com.slack.astra.metadata.replica.ReplicaMetadata;
+import com.slack.astra.metadata.replica.ReplicaMetadataStore;
+import com.slack.astra.metadata.snapshot.SnapshotMetadata;
+import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.proto.metadata.Metadata;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.curator.test.TestingServer;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CacheNodeAssignmentServiceTest {
+
+  private TestingServer testingServer;
+  private MeterRegistry meterRegistry;
+  private AsyncCuratorFramework curatorFramework;
+  private CacheNodeAssignmentStore cacheNodeAssignmentStore;
+  private SnapshotMetadataStore snapshotMetadataStore;
+  private AstraConfigs.ManagerConfig managerConfig;
+  private CacheNodeMetadataStore cacheNodeMetadataStore;
+  private ReplicaMetadataStore replicaMetadataStore;
+  private HpaMetricMetadataStore hpaMetricMetadataStore;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    Tracing.newBuilder().build();
+    meterRegistry = new SimpleMeterRegistry();
+    testingServer = new TestingServer();
+
+    com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig zkConfig =
+        com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig.newBuilder()
+            .setZkConnectString(testingServer.getConnectString())
+            .setZkPathPrefix("CacheNodeAssignmentServiceTest")
+            .setZkSessionTimeoutMs(1000)
+            .setZkConnectionTimeoutMs(1000)
+            .setSleepBetweenRetriesMs(1000)
+            .build();
+
+    AstraConfigs.ManagerConfig.CacheNodeAssignmentServiceConfig cacheNodeAssignmentServiceConfig =
+        AstraConfigs.ManagerConfig.CacheNodeAssignmentServiceConfig.newBuilder()
+            .addAllReplicaSets(List.of("rep1"))
+            .setSchedulePeriodMins(1)
+            .setReplicaLifespanMins(60)
+            .build();
+
+    managerConfig =
+        AstraConfigs.ManagerConfig.newBuilder()
+            .setEventAggregationSecs(2)
+            .setCacheNodeAssignmentServiceConfig(cacheNodeAssignmentServiceConfig)
+            .build();
+
+    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework));
+    cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, false));
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    meterRegistry.close();
+    testingServer.close();
+    cacheNodeAssignmentStore.close();
+    curatorFramework.unwrap().close();
+  }
+
+  @Test
+  public void testBasicLifecycle() throws Exception {
+    String name = "foo";
+    for (int i = 0; i < 3; i++) {
+      CacheNodeMetadata cacheNodeMetadata = new CacheNodeMetadata(name + i, "foo.com", 5, "rep1");
+      cacheNodeMetadataStore.createSync(cacheNodeMetadata);
+
+      SnapshotMetadata snapshotMetadata =
+          new SnapshotMetadata(
+              "snapshot" + i, "snapshot" + i, 1L, 2L, 10L, "abcd", LOGS_LUCENE9, 5);
+      snapshotMetadataStore.createSync(snapshotMetadata);
+
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata("replica" + i, "snapshot" + i, "rep1", 1L, 2L, false, LOGS_LUCENE9);
+      replicaMetadataStore.createSync(replicaMetadata);
+    }
+    CacheNodeAssignmentService cacheNodeAssignmentService =
+        new CacheNodeAssignmentService(
+            meterRegistry,
+            managerConfig,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            snapshotMetadataStore,
+            cacheNodeAssignmentStore,
+            hpaMetricMetadataStore);
+
+    cacheNodeAssignmentService.startAsync();
+    cacheNodeAssignmentService.awaitRunning(Duration.ofSeconds(15));
+
+    await()
+        .timeout(10, TimeUnit.SECONDS)
+        .until(() -> cacheNodeAssignmentStore.listSync().size() == 3);
+    assertThat(
+            cacheNodeAssignmentStore.listSync().stream()
+                .map(assignment -> assignment.snapshotId)
+                .toList())
+        .containsOnly("snapshot0", "snapshot1", "snapshot2");
+    assertThat(hpaMetricMetadataStore.getSync(String.format(CACHE_HPA_METRIC_NAME, "rep1")).value)
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  public void testExpiredReplicasMarkedForEvictionLifecycle() throws TimeoutException {
+    String name = "foo";
+    String snapshotKey = "snapshot_%s";
+    String replicaKey = "replica_%s";
+    String replicaSet = "rep1";
+    for (int i = 0; i < 3; i++) {
+      // create assignments in the past
+      CacheNodeAssignment newAssignment =
+          new CacheNodeAssignment(
+              UUID.randomUUID().toString(),
+              name,
+              String.format(snapshotKey, i),
+              replicaSet,
+              Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE);
+      cacheNodeAssignmentStore.createSync(newAssignment);
+
+      SnapshotMetadata snapshotMetadata =
+          new SnapshotMetadata(
+              String.format(snapshotKey, i),
+              String.format(snapshotKey, i),
+              1L,
+              2L,
+              10L,
+              "abcd",
+              LOGS_LUCENE9,
+              5);
+      snapshotMetadataStore.createSync(snapshotMetadata);
+
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              String.format(replicaKey, i),
+              String.format(snapshotKey, i),
+              replicaSet,
+              1L,
+              Instant.now().minusSeconds(120).toEpochMilli(),
+              false,
+              LOGS_LUCENE9);
+      replicaMetadataStore.createSync(replicaMetadata);
+    }
+
+    assertThat(cacheNodeAssignmentStore.listSync().size()).isEqualTo(3);
+
+    CacheNodeAssignmentService cacheNodeAssignmentService =
+        new CacheNodeAssignmentService(
+            meterRegistry,
+            managerConfig,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            snapshotMetadataStore,
+            cacheNodeAssignmentStore,
+            hpaMetricMetadataStore);
+    cacheNodeAssignmentService.startAsync();
+    cacheNodeAssignmentService.awaitRunning(Duration.ofSeconds(15));
+
+    await()
+        .timeout(20, TimeUnit.SECONDS)
+        .until(() -> cacheNodeAssignmentStore.listSync().isEmpty());
+  }
+
+  @Test
+  public void testEvictExpiredReplicasOnly() {
+    String name = "foo";
+    String snapshotKey = "snapshot_%s";
+    String replicaKey = "replica_%s";
+    String replicaSet = "rep1";
+    for (int i = 0; i < 6; i++) {
+      // create assignments in the past, half LIVE half EVICT
+      CacheNodeAssignment newAssignment =
+          new CacheNodeAssignment(
+              UUID.randomUUID().toString(),
+              name,
+              String.format(snapshotKey, i),
+              replicaSet,
+              i % 2 == 0
+                  ? Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE
+                  : Metadata.CacheNodeAssignment.CacheNodeAssignmentState.EVICT);
+      cacheNodeAssignmentStore.createSync(newAssignment);
+
+      SnapshotMetadata snapshotMetadata =
+          new SnapshotMetadata(
+              String.format(snapshotKey, i),
+              String.format(snapshotKey, i),
+              1L,
+              2L,
+              10L,
+              "abcd",
+              LOGS_LUCENE9,
+              5);
+      snapshotMetadataStore.createSync(snapshotMetadata);
+
+      ReplicaMetadata replicaMetadata =
+          new ReplicaMetadata(
+              String.format(replicaKey, i),
+              String.format(snapshotKey, i),
+              replicaSet,
+              1L,
+              Instant.now().minusSeconds(120).toEpochMilli(),
+              false,
+              LOGS_LUCENE9);
+      replicaMetadataStore.createSync(replicaMetadata);
+    }
+
+    assertThat(
+            filterAssignmentsByState(Metadata.CacheNodeAssignment.CacheNodeAssignmentState.EVICT))
+        .isEqualTo(3);
+    assertThat(filterAssignmentsByState(Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE))
+        .isEqualTo(3);
+
+    CacheNodeAssignmentService cacheNodeAssignmentService =
+        new CacheNodeAssignmentService(
+            meterRegistry,
+            managerConfig,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            snapshotMetadataStore,
+            cacheNodeAssignmentStore,
+            hpaMetricMetadataStore);
+    cacheNodeAssignmentService.markAssignmentsForEviction(
+        cacheNodeAssignmentStore.listSync(),
+        replicaMetadataStore.listSync().stream()
+            .collect(Collectors.toMap(replica -> replica.snapshotId, Function.identity())),
+        Instant.now());
+
+    await()
+        .timeout(20, TimeUnit.SECONDS)
+        .until(
+            () ->
+                filterAssignmentsByState(
+                        Metadata.CacheNodeAssignment.CacheNodeAssignmentState.EVICT)
+                    == 6);
+  }
+
+  /* Test Case 1: Simple Case with Exact Fit
+  - Items: [5, 5, 5, 5]
+  - Initial Bins: [10, 10]
+  - Expected Output: Initial bins: [10: 5, 5], [10: 5, 5]
+    - Explanation: Each bin can exactly fit two items of weight 5.
+  */
+  @Test
+  public void testAssignmentSimpleFit() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(10, 10));
+    List<SnapshotMetadata> snapshots = makeSnapshotsWithSizes(List.of(5, 5, 5, 5));
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(2);
+    assertThat(result.get("node0").getSnapshotIds()).contains("snapshot0", "snapshot1");
+    assertThat(result.get("node1").getSnapshotIds()).contains("snapshot2", "snapshot3");
+  }
+
+  /* Test Case 2: Simple Case with Excess Capacity
+  - Items: [3, 7, 2, 5]
+  - Initial Bins: [8, 6]
+  - Expected Output: Initial bins: [8: 3, 5], [6: 2], New bins: [7]
+    - Explanation: The first bin is filled with items of weight 3 and 5, the second bin with 2, and a new bin with 7.
+  */
+  @Test
+  public void testAssignmentExcessCapacity() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(8, 6));
+    List<SnapshotMetadata> snapshots = makeSnapshotsWithSizes(List.of(3, 7, 2, 5));
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(3);
+    assertThat(result.get("node0").getSnapshotIds()).contains("snapshot0", "snapshot2");
+    assertThat(result.get("node1").getSnapshotIds()).contains("snapshot3");
+    assertThat(result.get("NEW_0").getSnapshotIds()).contains("snapshot1");
+  }
+
+  /* Test Case 3: Multiple Small Items
+  - Items: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+  - Initial Bins: [3, 3, 2]
+  - Expected Output: Initial bins: [3: 1, 1, 1], [3: 1, 1, 1], [2: 1, 1], New bins: [3: 1, 1, 1]
+    - Explanation: The first three bins can hold six items, and a new bin is needed for the remaining four items.
+  */
+  @Test
+  public void testAssignmentUniformSizes() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(3, 2, 5));
+    List<SnapshotMetadata> snapshots =
+        makeSnapshotsWithSizes(List.of(1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(3);
+    assertThat(result.get("node0").getSnapshotIds())
+        .contains("snapshot5", "snapshot6", "snapshot7");
+    assertThat(result.get("node1").getSnapshotIds()).contains("snapshot8", "snapshot9");
+    assertThat(result.get("node2").getSnapshotIds())
+        .contains("snapshot3", "snapshot2", "snapshot1", "snapshot0", "snapshot4");
+  }
+
+  /* Test Case 5: All Items Fit into One Bin
+  - Items: [2, 2, 2, 2, 2]
+  - Initial Bins: [10]
+  - Expected Output: Initial bins: [10: 2, 2, 2, 2, 2]
+    - Explanation: All items fit perfectly into the initial bin.
+  */
+  @Test
+  public void testAssignmentPerfectFit() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(10));
+    List<SnapshotMetadata> snapshots = makeSnapshotsWithSizes(List.of(2, 2, 2, 2, 2));
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.get("node0").getSnapshotIds())
+        .contains("snapshot0", "snapshot1", "snapshot2", "snapshot3", "snapshot4");
+  }
+
+  /* Test Case 7: No Items
+  - Items: []
+  - Initial Bins: [10]
+  - Expected Output: Initial bins: []
+    - Explanation: No items mean no bins are needed, even if they exist.
+  */
+  @Test
+  public void testAssignmentNoItems() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(10));
+    List<SnapshotMetadata> snapshots = makeSnapshotsWithSizes(List.of());
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.get("node0").getSnapshotIds()).isEmpty();
+  }
+
+  /* Test Case 8: Single Item Larger than Bin Capacity
+  - Items: [12]
+  - Initial Bins: [10]
+  - Expected Output: Initial bins: [], New bins: [12]
+    - Explanation: The item cannot fit into the initial bin, so a new bin is created.
+  */
+  @Test
+  public void testAssignmentItemLargerThanBin() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(10));
+    List<SnapshotMetadata> snapshots = makeSnapshotsWithSizes(List.of(12));
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(2);
+    assertThat(result.get("node0").getSnapshotIds()).isEmpty();
+  }
+
+  /* Test Case 10: Complex Combination
+  - Items: [4, 8, 1, 4, 7, 3, 6, 2, 5]
+  - Initial Bins: [10, 5, 8]
+  - Expected Output: Initial bins: [10: 4, 6], [5: 5], [8: 4, 3], New bins: [8: 8], [7: 7], [2: 2], [1: 1]
+    - Explanation: The items are packed into the first initial bins that have enough space, and new bins are created as needed.
+  */
+  @Test
+  public void testAssignmentComplicatedCombination() {
+    List<CacheNodeMetadata> cacheNodes = makeCacheNodesWithCapacities(List.of(10, 5, 8));
+    List<SnapshotMetadata> snapshots = makeSnapshotsWithSizes(List.of(4, 8, 1, 4, 7, 3, 6, 2, 5));
+
+    Map<String, CacheNodeBin> result =
+        assign(cacheNodeAssignmentStore, snapshotMetadataStore, List.of(), snapshots, cacheNodes);
+
+    assertThat(result.size()).isEqualTo(6);
+    assertThat(result.get("node0").getSnapshotIds()).contains("snapshot1", "snapshot7");
+    assertThat(result.get("node1").getSnapshotIds()).contains("snapshot3");
+    assertThat(result.get("node2").getSnapshotIds())
+        .contains("snapshot0", "snapshot2", "snapshot5");
+  }
+
+  private List<SnapshotMetadata> makeSnapshotsWithSizes(List<Integer> sizes) {
+    List<SnapshotMetadata> snapshots = new ArrayList<>();
+    for (int i = 0; i < sizes.size(); i++) {
+      Integer size = sizes.get(i);
+      snapshots.add(
+          new SnapshotMetadata("snapshot" + i, "/" + i, 1, 2 * 1000, 3, "a", LOGS_LUCENE9, size));
+    }
+    return snapshots;
+  }
+
+  // given N capacities, create N cache nodes with respective capacities
+  private List<CacheNodeMetadata> makeCacheNodesWithCapacities(List<Integer> capacities) {
+    List<CacheNodeMetadata> cacheNodes = new ArrayList<>();
+    for (int i = 0; i < capacities.size(); i++) {
+      Integer size = capacities.get(i);
+      cacheNodes.add(new CacheNodeMetadata("node" + i, "node" + i + ".com", size, "rep"));
+    }
+
+    return cacheNodes;
+  }
+
+  private long filterAssignmentsByState(
+      Metadata.CacheNodeAssignment.CacheNodeAssignmentState state) {
+    return cacheNodeAssignmentStore.listSync().stream()
+        .filter(assignment -> assignment.state == state)
+        .count();
+  }
+}

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import brave.Tracing;
+import com.slack.astra.metadata.cache.CacheNodeAssignmentStore;
 import com.slack.astra.metadata.cache.CacheSlotMetadata;
 import com.slack.astra.metadata.cache.CacheSlotMetadataStore;
 import com.slack.astra.metadata.core.CuratorBuilder;
@@ -49,6 +50,7 @@ public class ReplicaDeletionServiceTest {
   private AsyncCuratorFramework curatorFramework;
   private CacheSlotMetadataStore cacheSlotMetadataStore;
   private ReplicaMetadataStore replicaMetadataStore;
+  private CacheNodeAssignmentStore cacheNodeMetadataStore;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -68,6 +70,7 @@ public class ReplicaDeletionServiceTest {
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
     replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheNodeMetadataStore = spy(new CacheNodeAssignmentStore(curatorFramework));
   }
 
   @AfterEach
@@ -97,7 +100,11 @@ public class ReplicaDeletionServiceTest {
         .isThrownBy(
             () ->
                 new ReplicaDeletionService(
-                        cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry)
+                        cacheSlotMetadataStore,
+                        replicaMetadataStore,
+                        cacheNodeMetadataStore,
+                        managerConfig,
+                        meterRegistry)
                     .scheduler());
   }
 
@@ -116,7 +123,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
 
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(0);
@@ -170,7 +181,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
 
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(1);
@@ -253,7 +268,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
 
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(0);
@@ -313,7 +332,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
 
     int replicasDeleted = replicaDeletionService.deleteExpiredUnassignedReplicas(Instant.now());
     assertThat(replicasDeleted).isEqualTo(0);
@@ -370,7 +393,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
 
     AsyncStage asyncStage = mock(AsyncStage.class);
     when(asyncStage.toCompletableFuture())
@@ -456,7 +483,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
     replicaDeletionService.futuresListTimeoutSecs = 2;
 
     ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
@@ -575,7 +606,11 @@ public class ReplicaDeletionServiceTest {
 
     ReplicaDeletionService replicaDeletionService =
         new ReplicaDeletionService(
-            cacheSlotMetadataStore, replicaMetadataStore, managerConfig, meterRegistry);
+            cacheSlotMetadataStore,
+            replicaMetadataStore,
+            cacheNodeMetadataStore,
+            managerConfig,
+            meterRegistry);
 
     replicaDeletionService.startAsync();
     replicaDeletionService.awaitRunning(DEFAULT_START_STOP_DURATION);

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializerTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializerTest.java
@@ -1,3 +1,58 @@
 package com.slack.astra.metadata.cache;
 
-public class CacheNodeAssignmentSerializerTest {}
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.slack.astra.proto.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+public class CacheNodeAssignmentSerializerTest {
+  private final CacheNodeAssignmentSerializer serDe = new CacheNodeAssignmentSerializer();
+
+  @Test
+  public void testCacheNodeAssignmentSerializer() throws InvalidProtocolBufferException {
+    String assignmentId = "assignmentId";
+    String cacheNodeId = "node1";
+    String snapshotId = "snapshotId";
+    String replicaId = "replicaId";
+    String replicaSet = "rep2";
+    long snapshotSize = 1024;
+    Metadata.CacheNodeAssignment.CacheNodeAssignmentState state =
+        Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LOADING;
+
+    CacheNodeAssignment cacheNodeAssignment =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, replicaId, replicaSet, snapshotSize, state);
+
+    String serializedCacheNodeAssignment = serDe.toJsonStr(cacheNodeAssignment);
+    assertThat(serializedCacheNodeAssignment).isNotEmpty();
+
+    CacheNodeAssignment deserializedCacheNodeAssignment =
+        serDe.fromJsonStr(serializedCacheNodeAssignment);
+    assertThat(deserializedCacheNodeAssignment).isEqualTo(cacheNodeAssignment);
+
+    assertThat(deserializedCacheNodeAssignment.assignmentId).isEqualTo(assignmentId);
+    assertThat(deserializedCacheNodeAssignment.cacheNodeId).isEqualTo(cacheNodeId);
+    assertThat(deserializedCacheNodeAssignment.snapshotId).isEqualTo(snapshotId);
+    assertThat(deserializedCacheNodeAssignment.replicaId).isEqualTo(replicaId);
+    assertThat(deserializedCacheNodeAssignment.replicaSet).isEqualTo(replicaSet);
+    assertThat(deserializedCacheNodeAssignment.state).isEqualTo(state);
+    assertThat(deserializedCacheNodeAssignment.snapshotSize).isEqualTo(snapshotSize);
+  }
+
+  @Test
+  public void testInvalidSerializations() {
+    Throwable serializeNull = catchThrowable(() -> serDe.toJsonStr(null));
+    assertThat(serializeNull).isInstanceOf(IllegalArgumentException.class);
+
+    Throwable deserializeNull = catchThrowable(() -> serDe.fromJsonStr(null));
+    assertThat(deserializeNull).isInstanceOf(InvalidProtocolBufferException.class);
+
+    Throwable deserializeEmpty = catchThrowable(() -> serDe.fromJsonStr(""));
+    assertThat(deserializeEmpty).isInstanceOf(InvalidProtocolBufferException.class);
+
+    Throwable deserializeCorrupt = catchThrowable(() -> serDe.fromJsonStr("test"));
+    assertThat(deserializeCorrupt).isInstanceOf(InvalidProtocolBufferException.class);
+  }
+}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializerTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentSerializerTest.java
@@ -1,0 +1,3 @@
+package com.slack.astra.metadata.cache;
+
+public class CacheNodeAssignmentSerializerTest {}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStoreTest.java
@@ -1,3 +1,0 @@
-package com.slack.astra.metadata.cache;
-
-public class CacheNodeAssignmentStoreTest {}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStoreTest.java
@@ -1,0 +1,3 @@
+package com.slack.astra.metadata.cache;
+
+public class CacheNodeAssignmentStoreTest {}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentTest.java
@@ -1,0 +1,3 @@
+package com.slack.astra.metadata.cache;
+
+public class CacheNodeAssignmentTest {}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeAssignmentTest.java
@@ -1,3 +1,102 @@
 package com.slack.astra.metadata.cache;
 
-public class CacheNodeAssignmentTest {}
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slack.astra.proto.metadata.Metadata;
+import org.junit.jupiter.api.Test;
+
+public class CacheNodeAssignmentTest {
+  @Test
+  public void testCacheNodeAssignment() {
+    String assignmentId = "assignmentId";
+    String cacheNodeId = "node1";
+    String snapshotId = "snapshotId";
+    String replicaId = "replicaId";
+    String replicaSet = "rep2";
+    long snapshotSize = 1024;
+    Metadata.CacheNodeAssignment.CacheNodeAssignmentState state =
+        Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LOADING;
+
+    CacheNodeAssignment cacheNodeAssignment =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, replicaId, replicaSet, snapshotSize, state);
+    assertThat(cacheNodeAssignment.assignmentId).isEqualTo(assignmentId);
+    assertThat(cacheNodeAssignment.cacheNodeId).isEqualTo(cacheNodeId);
+    assertThat(cacheNodeAssignment.snapshotId).isEqualTo(snapshotId);
+    assertThat(cacheNodeAssignment.replicaId).isEqualTo(replicaId);
+    assertThat(cacheNodeAssignment.replicaSet).isEqualTo(replicaSet);
+    assertThat(cacheNodeAssignment.snapshotSize).isEqualTo(snapshotSize);
+    assertThat(cacheNodeAssignment.state).isEqualTo(state);
+  }
+
+  @Test
+  public void testCacheNodeAssignmentEqualsHashcode() {
+    String assignmentId = "assignmentId";
+    String cacheNodeId = "node1";
+    String snapshotId = "snapshotId";
+    String replicaId = "replicaId";
+    String replicaSet = "rep2";
+    long snapshotSize = 1024;
+    Metadata.CacheNodeAssignment.CacheNodeAssignmentState state =
+        Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LOADING;
+
+    CacheNodeAssignment cacheNodeAssignment =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, replicaId, replicaSet, snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDuplicate =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, replicaId, replicaSet, snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentId =
+        new CacheNodeAssignment(
+            "foo", cacheNodeId, snapshotId, replicaId, replicaSet, snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentCacheNode =
+        new CacheNodeAssignment(
+            assignmentId, "foo", snapshotId, replicaId, replicaSet, snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentSnapshot =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, "foo", replicaId, replicaSet, snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentReplica =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, "foo", replicaSet, snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentReplicaSet =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, replicaId, "foo", snapshotSize, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentSize =
+        new CacheNodeAssignment(
+            assignmentId, cacheNodeId, snapshotId, replicaId, replicaSet, 1, state);
+    CacheNodeAssignment cacheNodeAssignmentDifferentState =
+        new CacheNodeAssignment(
+            assignmentId,
+            cacheNodeId,
+            snapshotId,
+            replicaId,
+            replicaSet,
+            snapshotSize,
+            Metadata.CacheNodeAssignment.CacheNodeAssignmentState.LIVE);
+
+    assertThat(cacheNodeAssignment.hashCode()).isEqualTo(cacheNodeAssignmentDuplicate.hashCode());
+    assertThat(cacheNodeAssignment).isEqualTo(cacheNodeAssignmentDuplicate);
+
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentId);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentId.hashCode());
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentCacheNode);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentCacheNode.hashCode());
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentSnapshot);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentSnapshot.hashCode());
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentReplica);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentReplica.hashCode());
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentReplicaSet);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentReplicaSet.hashCode());
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentSize);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentSize.hashCode());
+    assertThat(cacheNodeAssignment).isNotEqualTo(cacheNodeAssignmentDifferentState);
+    assertThat(cacheNodeAssignment.hashCode())
+        .isNotEqualTo(cacheNodeAssignmentDifferentState.hashCode());
+  }
+}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataSerializerTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataSerializerTest.java
@@ -1,54 +1,35 @@
 package com.slack.astra.metadata.cache;
 
-import static com.slack.astra.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.slack.astra.proto.metadata.Metadata;
-import java.time.Instant;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class CacheNodeMetadataSerializerTest {
-  private final CacheSlotMetadataSerializer serDe = new CacheSlotMetadataSerializer();
+  private final CacheNodeMetadataSerializer serDe = new CacheNodeMetadataSerializer();
 
   @Test
-  public void testCacheSlotMetadataSerializer() throws InvalidProtocolBufferException {
-    String name = "name";
-    String hostname = "hostname";
+  public void testCacheNodeMetadataSerializer() throws InvalidProtocolBufferException {
+    String id = "abcd";
+    String hostname = "host";
     String replicaSet = "rep1";
-    com.slack.astra.proto.metadata.Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
-        com.slack.astra.proto.metadata.Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
-    String replicaId = "123";
-    long updatedTimeEpochMs = Instant.now().toEpochMilli();
-    List<Metadata.IndexType> supportedIndexTypes = List.of(LOGS_LUCENE9, LOGS_LUCENE9);
+    long nodeCapacityBytes = 4096;
 
-    CacheSlotMetadata cacheSlotMetadata =
-        new CacheSlotMetadata(
-            name,
-            cacheSlotState,
-            replicaId,
-            updatedTimeEpochMs,
-            supportedIndexTypes,
-            hostname,
-            replicaSet);
+    CacheNodeMetadata cacheNodeMetadata =
+        new CacheNodeMetadata(id, hostname, nodeCapacityBytes, replicaSet);
 
-    String serializedCacheSlotMetadata = serDe.toJsonStr(cacheSlotMetadata);
-    assertThat(serializedCacheSlotMetadata).isNotEmpty();
+    String serializedCacheNodeMetadata = serDe.toJsonStr(cacheNodeMetadata);
+    assertThat(serializedCacheNodeMetadata).isNotEmpty();
 
-    CacheSlotMetadata deserializedCacheSlotMetadata =
-        serDe.fromJsonStr(serializedCacheSlotMetadata);
-    assertThat(deserializedCacheSlotMetadata).isEqualTo(cacheSlotMetadata);
+    CacheNodeMetadata deserializedCacheNodeMetadata =
+        serDe.fromJsonStr(serializedCacheNodeMetadata);
+    assertThat(deserializedCacheNodeMetadata).isEqualTo(cacheNodeMetadata);
 
-    assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
-    assertThat(deserializedCacheSlotMetadata.hostname).isEqualTo(hostname);
-    assertThat(deserializedCacheSlotMetadata.replicaSet).isEqualTo(replicaSet);
-    assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
-    assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
-    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
-    assertThat(deserializedCacheSlotMetadata.supportedIndexTypes)
-        .containsExactlyInAnyOrderElementsOf(supportedIndexTypes);
+    assertThat(deserializedCacheNodeMetadata.id).isEqualTo(id);
+    assertThat(deserializedCacheNodeMetadata.hostname).isEqualTo(hostname);
+    assertThat(deserializedCacheNodeMetadata.nodeCapacityBytes).isEqualTo(nodeCapacityBytes);
+    assertThat(deserializedCacheNodeMetadata.replicaSet).isEqualTo(replicaSet);
   }
 
   @Test

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataSerializerTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataSerializerTest.java
@@ -1,0 +1,68 @@
+package com.slack.astra.metadata.cache;
+
+import static com.slack.astra.proto.metadata.Metadata.IndexType.LOGS_LUCENE9;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.slack.astra.proto.metadata.Metadata;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CacheNodeMetadataSerializerTest {
+  private final CacheSlotMetadataSerializer serDe = new CacheSlotMetadataSerializer();
+
+  @Test
+  public void testCacheSlotMetadataSerializer() throws InvalidProtocolBufferException {
+    String name = "name";
+    String hostname = "hostname";
+    String replicaSet = "rep1";
+    com.slack.astra.proto.metadata.Metadata.CacheSlotMetadata.CacheSlotState cacheSlotState =
+        com.slack.astra.proto.metadata.Metadata.CacheSlotMetadata.CacheSlotState.ASSIGNED;
+    String replicaId = "123";
+    long updatedTimeEpochMs = Instant.now().toEpochMilli();
+    List<Metadata.IndexType> supportedIndexTypes = List.of(LOGS_LUCENE9, LOGS_LUCENE9);
+
+    CacheSlotMetadata cacheSlotMetadata =
+        new CacheSlotMetadata(
+            name,
+            cacheSlotState,
+            replicaId,
+            updatedTimeEpochMs,
+            supportedIndexTypes,
+            hostname,
+            replicaSet);
+
+    String serializedCacheSlotMetadata = serDe.toJsonStr(cacheSlotMetadata);
+    assertThat(serializedCacheSlotMetadata).isNotEmpty();
+
+    CacheSlotMetadata deserializedCacheSlotMetadata =
+        serDe.fromJsonStr(serializedCacheSlotMetadata);
+    assertThat(deserializedCacheSlotMetadata).isEqualTo(cacheSlotMetadata);
+
+    assertThat(deserializedCacheSlotMetadata.name).isEqualTo(name);
+    assertThat(deserializedCacheSlotMetadata.hostname).isEqualTo(hostname);
+    assertThat(deserializedCacheSlotMetadata.replicaSet).isEqualTo(replicaSet);
+    assertThat(deserializedCacheSlotMetadata.cacheSlotState).isEqualTo(cacheSlotState);
+    assertThat(deserializedCacheSlotMetadata.replicaId).isEqualTo(replicaId);
+    assertThat(deserializedCacheSlotMetadata.updatedTimeEpochMs).isEqualTo(updatedTimeEpochMs);
+    assertThat(deserializedCacheSlotMetadata.supportedIndexTypes)
+        .containsExactlyInAnyOrderElementsOf(supportedIndexTypes);
+  }
+
+  @Test
+  public void testInvalidSerializations() {
+    Throwable serializeNull = catchThrowable(() -> serDe.toJsonStr(null));
+    assertThat(serializeNull).isInstanceOf(IllegalArgumentException.class);
+
+    Throwable deserializeNull = catchThrowable(() -> serDe.fromJsonStr(null));
+    assertThat(deserializeNull).isInstanceOf(InvalidProtocolBufferException.class);
+
+    Throwable deserializeEmpty = catchThrowable(() -> serDe.fromJsonStr(""));
+    assertThat(deserializeEmpty).isInstanceOf(InvalidProtocolBufferException.class);
+
+    Throwable deserializeCorrupt = catchThrowable(() -> serDe.fromJsonStr("test"));
+    assertThat(deserializeCorrupt).isInstanceOf(InvalidProtocolBufferException.class);
+  }
+}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataStoreTest.java
@@ -1,3 +1,0 @@
-package com.slack.astra.metadata.cache;
-
-public class CacheNodeMetadataStoreTest {}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataStoreTest.java
@@ -1,0 +1,3 @@
+package com.slack.astra.metadata.cache;
+
+public class CacheNodeMetadataStoreTest {}

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheNodeMetadataTest.java
@@ -1,0 +1,55 @@
+package com.slack.astra.metadata.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class CacheNodeMetadataTest {
+  @Test
+  public void testCacheNodeMetadata() {
+    String id = "abcd";
+    String hostname = "host";
+    String replicaSet = "rep1";
+    long nodeCapacityBytes = 4096;
+
+    CacheNodeMetadata cacheNodeMetadata =
+        new CacheNodeMetadata(id, hostname, nodeCapacityBytes, replicaSet);
+    assertThat(cacheNodeMetadata.name).isEqualTo(id);
+    assertThat(cacheNodeMetadata.hostname).isEqualTo(hostname);
+    assertThat(cacheNodeMetadata.replicaSet).isEqualTo(replicaSet);
+    assertThat(cacheNodeMetadata.nodeCapacityBytes).isEqualTo(nodeCapacityBytes);
+  }
+
+  @Test
+  public void testCacheNodeEqualsHashcode() {
+    String id = "abcd";
+    String hostname = "host";
+    String replicaSet = "rep1";
+    long nodeCapacityBytes = 4096;
+
+    CacheNodeMetadata cacheNode =
+        new CacheNodeMetadata(id, hostname, nodeCapacityBytes, replicaSet);
+    CacheNodeMetadata cacheNodeDuplicate =
+        new CacheNodeMetadata(id, hostname, nodeCapacityBytes, replicaSet);
+    CacheNodeMetadata cacheNodeDifferentHostname =
+        new CacheNodeMetadata(id, "localhost", nodeCapacityBytes, replicaSet);
+    CacheNodeMetadata cacheNodeDifferentId =
+        new CacheNodeMetadata("dog", hostname, nodeCapacityBytes, replicaSet);
+    CacheNodeMetadata cacheNodeDifferentCapacity =
+        new CacheNodeMetadata(id, hostname, 1024, replicaSet);
+    CacheNodeMetadata cacheNodeDifferentReplica =
+        new CacheNodeMetadata(id, hostname, nodeCapacityBytes, "rep2");
+
+    assertThat(cacheNode.hashCode()).isEqualTo(cacheNodeDuplicate.hashCode());
+    assertThat(cacheNode).isEqualTo(cacheNodeDuplicate);
+
+    assertThat(cacheNode).isNotEqualTo(cacheNodeDifferentHostname);
+    assertThat(cacheNode.hashCode()).isNotEqualTo(cacheNodeDifferentHostname.hashCode());
+    assertThat(cacheNode).isNotEqualTo(cacheNodeDifferentId);
+    assertThat(cacheNode.hashCode()).isNotEqualTo(cacheNodeDifferentId.hashCode());
+    assertThat(cacheNode).isNotEqualTo(cacheNodeDifferentCapacity);
+    assertThat(cacheNode.hashCode()).isNotEqualTo(cacheNodeDifferentCapacity.hashCode());
+    assertThat(cacheNode).isNotEqualTo(cacheNodeDifferentReplica);
+    assertThat(cacheNode.hashCode()).isNotEqualTo(cacheNodeDifferentReplica.hashCode());
+  }
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,6 +64,7 @@ cacheConfig:
   replicaSet: ${ASTRA_CACHE_REPLICA_SET:-rep1}
   dataDirectory: ${ASTRA_CACHE_DATA_DIR:-/tmp}
   defaultQueryTimeoutMs: ${ASTRA_CACHE_DEFAULT_QUERY_TIMEOUT_MS:-2500}
+  capacityBytes: ${ASTRA_CACHE_CAPACITY_BYTES:-0}
   serverConfig:
     serverPort: ${ASTRA_CACHE_SERVER_PORT:-8082}
     serverAddress: ${ASTRA_CACHE_SERVER_ADDRESS:-localhost}
@@ -71,7 +72,7 @@ cacheConfig:
 
 managerConfig:
   eventAggregationSecs: ${ASTRA_MANAGER_AGGREGATION_SECS:-10}
-  scheduleInitialDelayMins: ${ASTRA_MANAGER_INITIAL_DELAY_MINS:-1}
+  scheduleInitialDelayMins: ${ASTRA_MANAGER_INITIAL_DELAY_MINS:-2}
   serverConfig:
     serverPort: ${ASTRA_MANAGER_SERVER_PORT:-8083}
     serverAddress: ${ASTRA_MANAGER_SERVER_ADDRESS:-localhost}
@@ -98,6 +99,12 @@ managerConfig:
     maxReplicasPerRequest: ${ASTRA_MANAGER_REPLICA_RESTORE_MAX_REPLICAS_PER_REQUEST:-200}
     replicaLifespanMins: ${ASTRA_MANAGER_REPLICA_RESTORE_LIFESPAN_MINS:-60}
     replicaSets: [${ASTRA_MANAGER_REPLICA_SETS:-rep1}]
+  cacheNodeAssignmentServiceConfig:
+    schedulePeriodMins: ${ASTRA_MANAGER_ASSIGNMENT_PERIOD_MINS:-15}
+    replicaSets: [${ASTRA_MANAGER_REPLICA_SETS:-rep1}]
+    maxConcurrentPerNode: ${ASTRA_MANAGER_MAX_CONCURRENT_ASSIGNMENTS_PER_NODE:-2}
+  clusterMonitorServiceConfig:
+    schedulePeriodMins: ${ASTRA_MANAGER_CLUSTER_MONITOR_PERIOD_MINS:-15}
 
 clusterConfig:
   clusterName: ${ASTRA_CLUSTER_NAME:-ASTRA_local}


### PR DESCRIPTION
###  Summary
This PR adds a basic draft of the cache node assignment service + tests. Several other changes were added in order to support the service, they include:
* Adding `CacheNodeAssignment` and `CacheNodeMetadata` classes (plus serializers, ZK store classes, proto file changes)
* Having the `CachingChunkManager` listen for changes in assignments and download data as appropriate


### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
