### PR TITLE
make kafka transactions optional and disable by default

### DIFF
--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -112,10 +112,26 @@ class BulkIngestKafkaProducerTest {
   @AfterEach
   public void tearDown() throws Exception {
     System.clearProperty("astra.bulkIngest.useKafkaTransactions");
-    bulkIngestKafkaProducer.stopAsync();
-    bulkIngestKafkaProducer.awaitTerminated(DEFAULT_START_STOP_DURATION);
-    kafkaServer.close();
-    zkServer.close();
+    if (bulkIngestKafkaProducer != null) {
+      bulkIngestKafkaProducer.stopAsync();
+      bulkIngestKafkaProducer.awaitTerminated(DEFAULT_START_STOP_DURATION);
+    }
+
+    if (kafkaServer != null) {
+      kafkaServer.close();
+    }
+    if (meterRegistry != null) {
+      meterRegistry.close();
+    }
+    if (datasetMetadataStore != null) {
+      datasetMetadataStore.close();
+    }
+    if (curatorFramework != null) {
+      curatorFramework.unwrap().close();
+    }
+    if (zkServer != null) {
+      zkServer.close();
+    }
   }
 
   @Test

--- a/docs/topics/Config-options.md
+++ b/docs/topics/Config-options.md
@@ -59,7 +59,7 @@ indexerConfig:
 
 ### maxTimePerChunkSeconds
 Maximum time that a <tooltip term="chunk">chunk</tooltip> can be open before closing and uploading to S3. Defaults to 90 minutes.
-THis configuration is useful for ensuring that chunks are uploaded to S3 within a set time frame,
+This configuration is useful for ensuring that chunks are uploaded to S3 within a set time frame,
 during non-peak hours when we don't hit maxMessagesPerChunk or maxBytesPerChunk for several hours
 
 ```yaml

--- a/docs/topics/Config-options.md
+++ b/docs/topics/Config-options.md
@@ -57,6 +57,16 @@ indexerConfig:
   maxBytesPerChunk: 1000000
 ```
 
+### maxTimePerChunkSeconds
+Maximum time that a <tooltip term="chunk">chunk</tooltip> can be open before closing and uploading to S3. Defaults to 90 minutes.
+THis configuration is useful for ensuring that chunks are uploaded to S3 within a set time frame,
+during non-peak hours when we don't hit maxMessagesPerChunk or maxBytesPerChunk for several hours
+
+```yaml
+indexerConfig:
+  maxTimePerChunkSeconds: 5400
+```
+
 ### luceneConfig
 
 ```yaml

--- a/docs/topics/System-properties-reference.md
+++ b/docs/topics/System-properties-reference.md
@@ -14,6 +14,20 @@ How long Astra will wait before starting the next bulk batch if the last batch w
 defaultValue
 : 50
 
+### astra.bulkIngest.useKafkaTransactions
+<tldr>experimental</tldr>
+The preprocessor can write documents to kafka using transactions.
+Enable this to ensure that all documents are written using exactly once semantics 
+and all kafka brokers for a partition acknowledge a write. Defaults to false.
+
+```bash
+-Dastra.bulkIngest.useKafkaTransactions=true
+```
+
+{style="narrow"}
+defaultValue
+: 50
+
 ## astra.concurrent.query
 <tldr>experimental</tldr>
 The amount of concurrent queries that are permitted at the application level.

--- a/docs/topics/System-properties-reference.md
+++ b/docs/topics/System-properties-reference.md
@@ -24,10 +24,6 @@ and all kafka brokers for a partition acknowledge a write. Defaults to false.
 -Dastra.bulkIngest.useKafkaTransactions=true
 ```
 
-{style="narrow"}
-defaultValue
-: 50
-
 ## astra.concurrent.query
 <tldr>experimental</tldr>
 The amount of concurrent queries that are permitted at the application level.


### PR DESCRIPTION
###  Summary

make kafka transactions optional and disable by default. Our internal kafka cluster is quite under-provisioned to handle acks=all which is mandatory when using transactions. 

So we want the ability to disable it. Which we'll do for all application log clusters to increase throughput. 

This PR adds some missing docs, a counter for error tracking
