### PR TITLE
Add missing min doc count param to terms agg

### DIFF
--- a/astra/src/main/java/com/slack/astra/elasticsearchApi/OpenSearchRequest.java
+++ b/astra/src/main/java/com/slack/astra/elasticsearchApi/OpenSearchRequest.java
@@ -248,6 +248,7 @@ public class OpenSearchRequest {
                                               .ValueSourceAggregation.TermsAggregation.newBuilder()
                                               .setSize(getSize(terms))
                                               .putAllOrder(getTermsOrder(terms))
+                                              .setMinDocCount(getTermsMinDocCount(terms))
                                               .build())
                                       .build());
                         } else if (aggregationObject.equals(AvgAggBuilder.TYPE)) {
@@ -577,6 +578,11 @@ public class OpenSearchRequest {
   private static long getHistogramMinDocCount(JsonNode dateHistogram) {
     // min_doc_count is provided as a string in the json payload
     return Long.parseLong(dateHistogram.get("min_doc_count").asText());
+  }
+
+  private static long getTermsMinDocCount(JsonNode terms) {
+    // min_doc_count is provided as a string in the json payload
+    return Long.parseLong(terms.get("min_doc_count").asText());
   }
 
   private static Map<String, Long> getDateHistogramExtendedBounds(JsonNode dateHistogram) {

--- a/astra/src/test/java/com/slack/astra/elasticsearchApi/OpenSearchRequestTest.java
+++ b/astra/src/test/java/com/slack/astra/elasticsearchApi/OpenSearchRequestTest.java
@@ -379,4 +379,25 @@ public class OpenSearchRequestTest {
     assertThat(filtersAggregation.getFilters().getFiltersMap().get("bar").getAnalyzeWildcard())
         .isEqualTo(false);
   }
+
+  @Test
+  public void testTermsAggregation() throws IOException {
+    String rawRequest = getRawQueryString("terms");
+
+    OpenSearchRequest openSearchRequest = new OpenSearchRequest();
+    List<AstraSearch.SearchRequest> parsedRequestList =
+        openSearchRequest.parseHttpPostBody(rawRequest);
+    assertThat(parsedRequestList.size()).isEqualTo(1);
+
+    AstraSearch.SearchRequest.SearchAggregation rawTermsAggregation =
+        parsedRequestList.get(0).getAggregations();
+
+    AstraSearch.SearchRequest.SearchAggregation.ValueSourceAggregation.TermsAggregation
+        typedTermsAggregation = rawTermsAggregation.getValueSource().getTerms();
+
+    assertThat(rawTermsAggregation.getValueSource().getField()).isEqualTo("host");
+    assertThat(typedTermsAggregation.getMinDocCount()).isEqualTo(1);
+    assertThat(typedTermsAggregation.getSize()).isEqualTo(10);
+    assertThat(typedTermsAggregation.getOrderMap().get("_term")).isEqualTo("desc");
+  }
 }

--- a/astra/src/test/resources/opensearchRequest/terms.ndjson
+++ b/astra/src/test/resources/opensearchRequest/terms.ndjson
@@ -1,0 +1,2 @@
+{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"_all"}
+{"size":0,"query":{"bool":{"filter":[{"range":{"_timesinceepoch":{"gte":1683041914647,"lte":1683045514647,"format":"epoch_millis"}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"aggs":{"2":{"terms":{"field":"host","size":10,"order":{"_term":"desc"},"min_doc_count":1}}}}


### PR DESCRIPTION
###  Summary

Adds a missing param on the terms aggregation where min doc count wasn't being correctly set. Adds tests to verify that param is set as expected now.