### PR TITLE
Add ability to define default schema for texty fields

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
+++ b/astra/src/main/java/com/slack/astra/logstore/schema/ReservedFields.java
@@ -20,6 +20,7 @@ public class ReservedFields {
         Schema.SchemaField.newBuilder().setType(Schema.SchemaFieldType.ID).build();
 
     return Schema.IngestSchema.newBuilder()
+        .putAllDefaults(currentSchema.getDefaultsMap())
         .putAllFields(currentSchema.getFieldsMap())
         .putFields(TIMESTAMP, timestampField)
         .putFields(LogMessage.ReservedField.MESSAGE.fieldName, messageField)

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -403,7 +403,10 @@ public class Astra {
       if (!preprocessorConfig.getSchemaFile().isEmpty()) {
         LOG.info("Loading schema file: {}", preprocessorConfig.getSchemaFile());
         schema = SchemaUtil.parseSchema(Path.of(preprocessorConfig.getSchemaFile()));
-        LOG.info("Loaded schema with total fields: {}", schema.getFieldsCount());
+        LOG.info(
+            "Loaded schema with fields count: {}, defaults count: {}",
+            schema.getFieldsCount(),
+            schema.getDefaultsCount());
       } else {
         LOG.info("No schema file provided, using default schema");
       }

--- a/astra/src/main/proto/schema.proto
+++ b/astra/src/main/proto/schema.proto
@@ -10,6 +10,12 @@ option java_package = "com.slack.astra.proto.schema";
 message IngestSchema {
   // convert to a map
   map<string, SchemaField> fields = 1;
+  map<string, DefaultField> defaults = 2;
+}
+
+message DefaultField {
+  SchemaField mapping = 1;
+  string match_mapping_type = 2;
 }
 
 message SchemaField {

--- a/astra/src/test/resources/opensearchRequest/bulk/index_text_defaults.ndjson
+++ b/astra/src/test/resources/opensearchRequest/bulk/index_text_defaults.ndjson
@@ -1,0 +1,4 @@
+{ "index" : { "_index" : "test", "_id" : "1" } }
+{ "host" : "host1", "message" : "foo bar", "ip" : "192.168.1.1", "my_date" : "2014-09-01T12:00:00Z"}
+{ "index" : { "_index" : "test", "_id" : "2" } }
+{ "value1" : "1", "value2" : "2", "field1": "check", "ip" :  "::afff:4567:890a", "number" : 20000, "username": "me", "bucket": null }

--- a/astra/src/test/resources/schema/test_schema_defaults.yaml
+++ b/astra/src/test/resources/schema/test_schema_defaults.yaml
@@ -1,0 +1,14 @@
+defaults:
+  example:
+    match_mapping_type: 'string'
+    mapping:
+      type: TEXT
+      fields:
+        keyword:
+          type: KEYWORD
+          ignore_above: 256
+fields:
+  host:
+    type: KEYWORD
+  ip:
+    type: IP

--- a/astra/src/test/resources/schema/test_schema_defaults_only.yaml
+++ b/astra/src/test/resources/schema/test_schema_defaults_only.yaml
@@ -1,0 +1,9 @@
+defaults:
+  string_fields:
+    match_mapping_type: 'string'
+    mapping:
+      type: TEXT
+      fields:
+        keyword:
+          type: KEYWORD
+          ignore_above: 256


### PR DESCRIPTION
###  Summary

Adds the ability to set the default indexing behavior for string fields when no schema is defined. The current default is `KEYWORD`, but this allows changing to any valid schema definition (ie, `STRING` with a `KEYWORD` if below a target length).