### PR TITLE
Fix incorrect rate limiter message counter

### DIFF
--- a/astra/src/main/java/com/slack/astra/preprocessor/PreprocessorRateLimiter.java
+++ b/astra/src/main/java/com/slack/astra/preprocessor/PreprocessorRateLimiter.java
@@ -156,7 +156,7 @@ public class PreprocessorRateLimiter {
           // message should be dropped due to rate limit
           meterRegistry
               .counter(MESSAGES_DROPPED, getMeterTags(index, MessageDropReason.OVER_LIMIT))
-              .increment();
+              .increment(docs.size());
           meterRegistry
               .counter(BYTES_DROPPED, getMeterTags(index, MessageDropReason.OVER_LIMIT))
               .increment(totalBytes);


### PR DESCRIPTION
###  Summary

Counter previously was keeping track of _batches_, and not individual messages.