### PR TITLE
Rework chunk `preSnapshot` to commit after final merge

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
@@ -200,6 +200,7 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
     this.readOnly = readOnly;
   }
 
+  @VisibleForTesting
   public void commit() {
     logStore.commit();
     logStore.refresh();
@@ -209,8 +210,10 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
   public void preSnapshot() {
     logger.info("Started RW chunk pre-snapshot {}", chunkInfo);
     setReadOnly(true);
-    commit();
+    logStore.refresh();
     logStore.finalMerge();
+    logStore.commit();
+    logStore.refresh();
     logger.info("Finished RW chunk pre-snapshot {}", chunkInfo);
   }
 

--- a/astra/src/main/java/com/slack/astra/logstore/LogStore.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LogStore.java
@@ -21,6 +21,11 @@ public interface LogStore extends Closeable {
 
   void refresh();
 
+  /**
+   * Final merge likely requires a following commit to ensure the data is appropriately flushed to
+   * disk. Without a following commit this can result in work that is done as part of the final
+   * merge that is never written to the disk.
+   */
   void finalMerge();
 
   boolean isOpen();

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -616,7 +616,7 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(2);
       assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
       assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(0);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
@@ -679,7 +679,7 @@ public class IndexingChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(2);
       assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
       assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(0);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -603,7 +603,7 @@ public class RecoveryChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(2);
       assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
       assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(0);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);
@@ -654,7 +654,7 @@ public class RecoveryChunkImplTest {
 
       assertThat(getCount(MESSAGES_RECEIVED_COUNTER, registry)).isEqualTo(100);
       assertThat(getCount(MESSAGES_FAILED_COUNTER, registry)).isEqualTo(0);
-      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(1);
+      assertThat(getTimerCount(REFRESHES_TIMER, registry)).isEqualTo(2);
       assertThat(getTimerCount(COMMITS_TIMER, registry)).isEqualTo(1);
       assertThat(getCount(INDEX_FILES_UPLOAD, registry)).isEqualTo(0);
       assertThat(getCount(INDEX_FILES_UPLOAD_FAILED, registry)).isEqualTo(0);


### PR DESCRIPTION
###  Summary

Reworks the `preSnapshot` call to commit after the final merge. This was missing which was resulting in wasted work to merge to a final segment that was never uploaded to S3. Additionally, since a commit never happened after the final merge it caused out of disk exceptions in some cases for deploys that assumed indexes would never exceed x2 the allocated disk space.