### PR TITLE
Move buildQuery so that the index searcher is released during exception

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
@@ -111,13 +111,12 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
       // Acquire an index searcher from searcher manager.
       // This is a useful optimization for indexes that are static.
       IndexSearcher searcher = searcherManager.acquire();
-
-      Query query =
-          openSearchAdapter.buildQuery(
-              dataset, queryStr, startTimeMsEpoch, endTimeMsEpoch, searcher);
       try {
         List<LogMessage> results;
         InternalAggregation internalAggregation = null;
+        Query query =
+            openSearchAdapter.buildQuery(
+                dataset, queryStr, startTimeMsEpoch, endTimeMsEpoch, searcher);
 
         if (howMany > 0) {
           CollectorManager<TopFieldCollector, TopFieldDocs> topFieldCollector =


### PR DESCRIPTION
###  Summary

If an exception is thrown during building a query, this can currently cause the searcher manager to fail to release the acquired index searcher instance. This results in additional memory pressure over time, and due to the force merge can also result in excessive disk use. This is because the searchers that were not released maintain a reference to the files on disk, and they cannot be deleted until that searcher is closed.

This results in chunks on disk that can easily exceed 60GB, and have thousands of files - even though the uploaded assets to S3 are under 15GB and less than 20 files.

```
bash-5.2# du -sc *
62561384	aec2ba73-6c40-4dde-82a1-5bef2cff8a09
30330240	e9697715-e8fe-4e99-bb31-4b50885ac9dc
92891624	total
```

References: https://blog.mikemccandless.com/2011/09/lucenes-searchermanager-simplifies.html