### PR TITLE
Make total fields limit configurable via sysprop

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -129,7 +129,8 @@ public class OpenSearchAdapter {
 
   // we can make this configurable when SchemaAwareLogDocumentBuilderImpl enforces a limit
   // set this to a high number for now
-  private static final int TOTAL_FIELDS_LIMIT = 2500;
+  private static final int TOTAL_FIELDS_LIMIT =
+      Integer.parseInt(System.getProperty("astra.mapping.totalFieldsLimit", "2500"));
 
   // This will enable OpenSearch query parsing by default, rather than going down the
   // QueryString parsing path we have been using

--- a/docs/topics/System-properties-reference.md
+++ b/docs/topics/System-properties-reference.md
@@ -74,3 +74,12 @@ schema.
 {style="narrow"}
 defaultValue
 : 500
+
+
+## astra.mapping.totalFieldsLimit
+<tldr>experimental</tldr>
+Maximum amount of total fields used by the mapper service for query parsing.
+
+{style="narrow"}
+defaultValue
+: 2500


### PR DESCRIPTION
###  Summary

Enables setting the total fields limit used by the Opensearch query parsing to be set to a higher value via sysprops.