### PR TITLE
Fix Zipkin API ID behavior

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/LogMessage.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LogMessage.java
@@ -56,6 +56,7 @@ public class LogMessage extends LogWireMessage {
     DURATION("duration"),
     TRACE_ID("trace_id"),
     PARENT_ID("parent_id"),
+    ID("id"),
     ASTRA_INVALID_TIMESTAMP("astra_invalid_timestamp");
 
     public final String fieldName;

--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -58,6 +58,7 @@ public class ZipkinService {
         continue;
       }
 
+      String id = message.getId();
       String messageTraceId = null;
       String parentId = null;
       String name = null;
@@ -78,6 +79,8 @@ public class ZipkinService {
           serviceName = (String) value;
         } else if (LogMessage.ReservedField.DURATION.fieldName.equals(k)) {
           duration = (Long) value;
+        } else if (LogMessage.ReservedField.ID.fieldName.equals(k)) {
+          id = (String) value;
         } else {
           messageTags.put(k, String.valueOf(value));
         }
@@ -105,7 +108,7 @@ public class ZipkinService {
         continue;
       }
 
-      final ZipkinSpanResponse span = new ZipkinSpanResponse(message.getId(), messageTraceId);
+      final ZipkinSpanResponse span = new ZipkinSpanResponse(id, messageTraceId);
       span.setParentId(parentId);
       span.setName(name);
       if (serviceName != null) {

--- a/astra/src/test/java/com/slack/astra/logstore/LogMessageTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/LogMessageTest.java
@@ -27,8 +27,8 @@ public class LogMessageTest {
 
   @Test
   public void testReservedField() {
-    assertThat(ReservedField.values().length).isEqualTo(14);
-    assertThat(ReservedField.reservedFieldNames.size()).isEqualTo(14);
+    assertThat(ReservedField.values().length).isEqualTo(15);
+    assertThat(ReservedField.reservedFieldNames.size()).isEqualTo(15);
     assertThat(ReservedField.isReservedField("hostname")).isTrue();
     for (LogMessage.ReservedField f : LogMessage.ReservedField.values()) {
       assertThat(f.name().toLowerCase()).isEqualTo(f.fieldName);


### PR DESCRIPTION
###  Summary

Changes the Zipkin compatible API to attempt to use the tag value of `id` when rendering the trace, otherwise it will default to the document ID (current behavior). This fixes a regression when deploying the bulk ingest functionality.

**before**
![Screenshot 2024-07-23 at 2 21 32 PM](https://github.com/user-attachments/assets/d97e2e2a-a8ac-40cd-b4f8-a6ac486b37ec)

**after**
![Screenshot 2024-07-23 at 2 21 40 PM](https://github.com/user-attachments/assets/ff77057b-b953-4a44-85ef-7b5c4b0bd57c)

