### PR TITLE
Fix race condition in indexer timer tasks

### DIFF
--- a/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
@@ -309,7 +309,7 @@ public class LuceneIndexStoreImplTest {
     public SuppressExceptionsOnClosedWriter() throws IOException {}
 
     @Test
-    public void testSearcherOnclosedWriter() {
+    public void testSearcherOnclosedWriter() throws IOException {
       addMessages(testLogStore.logStore, 1, 100, true);
       testLogStore.logStore.close();
       testLogStore.logStore = null;


### PR DESCRIPTION
###  Summary

The original indexer used timers to schedule the commit and refresh, which are susceptible to a race condition with the close. Scheduled executors are a much better fit here, as they have a mechanism to allow a graceful shutdown, waiting on existing work to complete.