### PR TITLE
ClusterHpaMetricService.java: Account for replicaSet in calculations

### DIFF
--- a/astra/src/main/java/com/slack/astra/clusterManager/ClusterHpaMetricService.java
+++ b/astra/src/main/java/com/slack/astra/clusterManager/ClusterHpaMetricService.java
@@ -119,6 +119,7 @@ public class ClusterHpaMetricService extends AbstractScheduledService {
 
       long totalCacheNodeCapacityBytes =
           cacheNodeMetadataStore.listSync().stream()
+              .filter(metadata -> metadata.getReplicaSet().equals(replicaSet))
               .mapToLong(node -> node.nodeCapacityBytes)
               .sum();
       long totalDemandBytes =


### PR DESCRIPTION
###  Summary

Account for replicaSet in HPA metric calculations. Previously, it was getting the sum of ALL cache nodes' capacity resulting in an HPA metric that was smaller than expected. Now, the HPA metric is calculated based on the available capacity per replica set.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
