### PR TITLE
Fix for cast issue in zipkin service #1011; update doc to note that duration is in microseconds

### DIFF
--- a/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
+++ b/astra/src/main/java/com/slack/astra/zipkinApi/ZipkinService.java
@@ -78,7 +78,7 @@ public class ZipkinService {
         } else if (LogMessage.ReservedField.SERVICE_NAME.fieldName.equals(k)) {
           serviceName = (String) value;
         } else if (LogMessage.ReservedField.DURATION.fieldName.equals(k)) {
-          duration = (Long) value;
+          duration = ((Number) value).longValue();
         } else if (LogMessage.ReservedField.ID.fieldName.equals(k)) {
           id = (String) value;
         } else {

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
@@ -78,8 +77,10 @@ public class ZipkinServiceSpanConversionTest {
     Instant time = Instant.now();
     List<LogWireMessage> messages;
     int duration = 10;
-    LogWireMessage logWireMessageInt = makeWireMessageForSpans("na", time, "na", Optional.empty(), duration, "na", "na");
-    LogWireMessage logWireMessageWithLong = makeWireMessageForSpans("na", time, "na", Optional.empty(), (long) duration, "na", "na");
+    LogWireMessage logWireMessageInt =
+        makeWireMessageForSpans("na", time, "na", Optional.empty(), duration, "na", "na");
+    LogWireMessage logWireMessageWithLong =
+        makeWireMessageForSpans("na", time, "na", Optional.empty(), (long) duration, "na", "na");
     messages = Lists.newArrayList(logWireMessageInt, logWireMessageWithLong);
 
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_

--- a/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
+++ b/astra/src/test/java/com/slack/astra/zipkinApi/ZipkinServiceSpanConversionTest.java
@@ -38,7 +38,7 @@ public class ZipkinServiceSpanConversionTest {
   private static List<LogWireMessage> generateLogWireMessagesForOneTrace(
       Instant time, int count, String traceId) {
     List<LogWireMessage> messages = new ArrayList<>();
-    for (long i = 1; i <= count; i++) {
+    for (int i = 1; i <= count; i++) {
       String parentId = null;
       if (i > 1) {
         parentId = String.valueOf(i - 1);
@@ -73,19 +73,20 @@ public class ZipkinServiceSpanConversionTest {
   }
 
   @Test
-  public void testLogWireMessageToZipkinSpanWithIntDurationConversion()
+  public void testLogWireMessageToZipkinSpanWithIntOrLongForDuration()
       throws JsonProcessingException {
     Instant time = Instant.now();
     List<LogWireMessage> messages;
     int duration = 10;
-    LogWireMessage logWireMessage = makeWireMessageForSpans("na", time, "na", Optional.empty(), duration, "na", "na");
-    messages = Lists.newArrayList(logWireMessage);
+    LogWireMessage logWireMessageInt = makeWireMessageForSpans("na", time, "na", Optional.empty(), duration, "na", "na");
+    LogWireMessage logWireMessageWithLong = makeWireMessageForSpans("na", time, "na", Optional.empty(), (long) duration, "na", "na");
+    messages = Lists.newArrayList(logWireMessageInt, logWireMessageWithLong);
 
     // follows output format from https://zipkin.io/zipkin-api/#/default/get_trace__traceId_
     String output =
         String.format(
-            "[{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"}]",
-            ZipkinService.convertToMicroSeconds(time));
+            "[{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"},{\"duration\":10,\"id\":\"na\",\"name\":\"na\",\"remoteEndpoint\":{\"serviceName\":\"na\"},\"timestamp\":%d,\"traceId\":\"na\"}]",
+            ZipkinService.convertToMicroSeconds(time), ZipkinService.convertToMicroSeconds(time));
     assertThat(ZipkinService.convertLogWireMessageToZipkinSpan(messages)).isEqualTo(output);
   }
 }

--- a/docs/topics/Traces.md
+++ b/docs/topics/Traces.md
@@ -13,7 +13,7 @@ In order to render traces using the [Zipkin compatible API](API-zipkin.md), the 
 <def title="trace_id">Unique trace ID</def>
 <def title="service_name">String identifying producing service</def>
 <def title="name">String identifying the span</def>
-<def title="duration">Duration in milliseconds</def>
+<def title="duration">Duration in microseconds</def>
 </deflist>
 
 


### PR DESCRIPTION
###  Summary

This PR fixes the issue described in #1011 where traces with spans with a duration that gets parsed into an int type are not able to be returned by the zipkin service because they cause a cast exception. I included a test that I verified would trigger the cast exception before adding my fix.

Also, I noticed that the docs for duration say it should use milliseconds, but the zipkin api expects it to be in microseconds, so I updated that as well.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
