### PR TITLE
Fix eviction metrics, change per pod metrics to use hostname

### DIFF
--- a/astra/src/main/java/com/slack/astra/clusterManager/ClusterMonitorService.java
+++ b/astra/src/main/java/com/slack/astra/clusterManager/ClusterMonitorService.java
@@ -184,9 +184,9 @@ public class ClusterMonitorService extends AbstractScheduledService {
             .map(
                 cacheNodeMetadata ->
                     MultiGauge.Row.of(
-                        Tags.of(Tag.of("pod", cacheNodeMetadata.getName())),
+                        Tags.of(Tag.of("pod", cacheNodeMetadata.hostname)),
                         cacheNodeIdToLiveChunksPerPod.computeIfAbsent(
-                            cacheNodeMetadata.getName(),
+                            cacheNodeMetadata.hostname,
                             (_) -> new AtomicInteger(calculateLiveChunks(cacheNodeMetadata.id)))))
             .collect(Collectors.toUnmodifiableList()),
         true);
@@ -196,9 +196,9 @@ public class ClusterMonitorService extends AbstractScheduledService {
             .map(
                 cacheNodeMetadata ->
                     MultiGauge.Row.of(
-                        Tags.of(Tag.of("pod", cacheNodeMetadata.getName())),
+                        Tags.of(Tag.of("pod", cacheNodeMetadata.hostname)),
                         cacheNodeIdToFreeSpaceBytes.computeIfAbsent(
-                            cacheNodeMetadata.getName(),
+                            cacheNodeMetadata.hostname,
                             (_) -> new AtomicLong(calculateFreeSpaceForPod(cacheNodeMetadata.id)))))
             .collect(Collectors.toUnmodifiableList()),
         true);
@@ -236,7 +236,7 @@ public class ClusterMonitorService extends AbstractScheduledService {
               TimeUnit.SECONDS);
     } else {
       LOG.info(
-          "Cache node assignment task already scheduled, will run in {} ms",
+          "Cluster monitor task already scheduled, will run in {} ms",
           pendingTask.getDelay(TimeUnit.MILLISECONDS));
     }
   }


### PR DESCRIPTION
###  Summary

* Increment the correct counter for eviction successes and failures
* Use the hostname for per pod metrics instead of the pod's random UUID

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
