### PR TITLE
Remove java string templates, bump google java format dep

### DIFF
--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -665,7 +665,7 @@
                     <dependency>
                         <groupId>com.google.googlejavaformat</groupId>
                         <artifactId>google-java-format</artifactId>
-                        <version>1.22.0</version>
+                        <version>1.23.0</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
+++ b/astra/src/main/java/com/slack/astra/writer/SpanFormatter.java
@@ -106,7 +106,7 @@ public class SpanFormatter {
       }
       return tagBuilder.build();
     } catch (Exception e) {
-      tagBuilder.setKey(STR."failed_\{key}");
+      tagBuilder.setKey(String.format("failed_%s", key));
       tagBuilder.setFieldType(Schema.SchemaFieldType.KEYWORD);
       tagBuilder.setVStr(value.toString());
       return tagBuilder.build();
@@ -133,7 +133,7 @@ public class SpanFormatter {
         }
         Trace.KeyValue additionalKV =
             makeTraceKV(
-                STR."\{key}.\{additionalField.getKey()}",
+                String.format("%s.%s", key, additionalField.getKey()),
                 value,
                 additionalField.getValue().getType());
         tags.add(additionalKV);
@@ -155,7 +155,7 @@ public class SpanFormatter {
           .forEach(
               (key1, value1) -> {
                 List<Trace.KeyValue> nestedValues =
-                    convertKVtoProtoDefault(STR."\{key}.\{key1}", value1, schema);
+                    convertKVtoProtoDefault(String.format("%s.%s", key, key1), value1, schema);
                 tags.addAll(nestedValues);
               });
     } else if (value instanceof String || value instanceof List) {
@@ -176,7 +176,7 @@ public class SpanFormatter {
           }
           Trace.KeyValue additionalKV =
               makeTraceKV(
-                  STR."\{key}.\{additionalField.getKey()}",
+                  String.format("%s.%s", key, additionalField.getKey()),
                   value,
                   additionalField.getValue().getType());
           tags.add(additionalKV);

--- a/astra/src/test/java/com/slack/astra/logstore/opensearch/OpenSearchAdapterTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/opensearch/OpenSearchAdapterTest.java
@@ -482,7 +482,7 @@ public class OpenSearchAdapterTest {
     IndexSearcher indexSearcher = logStoreAndSearcherRule.logStore.getSearcherManager().acquire();
     Query idQuery =
         openSearchAdapter.buildQuery(
-            "foo", STR."\{idField}:\{idValue}", null, null, indexSearcher, null);
+            "foo", String.format("%s:%s", idField, idValue), null, null, indexSearcher, null);
     BytesRef queryStrBytes = new BytesRef(Uid.encodeId("1").bytes);
     // idQuery.toString="#_id:([fe 1f])"
     // queryStrBytes.toString="[fe 1f]"


### PR DESCRIPTION
###  Summary

Manual dependency update of #1016, due to the removal of Java string templates (https://bugs.openjdk.org/browse/JDK-8329949).