### PR TITLE
Add optional partition filters for ZK partitioning store

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
@@ -88,7 +88,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
     cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
-    cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework);
+    cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework, cacheNodeId);
     cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework);
 
     if (Boolean.getBoolean(ASTRA_NG_DYNAMIC_CHUNK_SIZES_FLAG)) {

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
 import com.slack.astra.proto.metadata.Metadata;
+import java.util.List;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -16,6 +17,16 @@ public class CacheNodeAssignmentStore extends AstraPartitioningMetadataStore<Cac
         CreateMode.PERSISTENT,
         new CacheNodeAssignmentSerializer().toModelSerializer(),
         CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH);
+  }
+
+  /** Restricts the cache node assignment store to only watching events for cacheNodeId */
+  public CacheNodeAssignmentStore(AsyncCuratorFramework curator, String cacheNodeId) {
+    super(
+        curator,
+        CreateMode.PERSISTENT,
+        new CacheNodeAssignmentSerializer().toModelSerializer(),
+        CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH,
+        List.of(cacheNodeId));
   }
 
   public ListenableFuture<?> updateAssignmentState(


### PR DESCRIPTION
###  Summary

Introduces an optional mode for the `AstraPartitioningMetadataStore` where it filters events, watchers, and data to a provided list of partition filters.