### PR TITLE
Fixing the local Setup to help with dev testing (docker compose)

### DIFF
--- a/astra/src/main/java/com/slack/astra/blobfs/s3/S3CrtBlobFs.java
+++ b/astra/src/main/java/com/slack/astra/blobfs/s3/S3CrtBlobFs.java
@@ -143,6 +143,9 @@ public class S3CrtBlobFs extends BlobFs {
           throw new RuntimeException(e);
         }
       }
+      if (config.getS3ForcePathStyle()) {
+        s3AsyncClient.forcePathStyle(true);
+      }
       return s3AsyncClient.build();
     } catch (S3Exception e) {
       throw new RuntimeException("Could not initialize S3blobFs", e);

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -72,6 +72,7 @@ message S3Config {
   string s3_end_point = 4;
   string s3_bucket = 5;
   double s3_target_throughput_gbps = 6;
+  bool s3_force_path_style=7;
 }
 
 message TracingConfig {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,9 +33,10 @@ s3Config:
   s3AccessKey: ${S3_ACCESS_KEY:-access}
   s3SecretKey: ${S3_SECRET_KEY:-key}
   s3Region: ${S3_REGION:-us-east-1}
-  s3EndPoint: ${S3_ENDPOINT:-http://localhost:9090}
+  s3EndPoint: ${S3_ENDPOINT:-http://localhost:9090/}
   s3Bucket: ${S3_BUCKET:-test-s3-bucket}
   s3TargetThroughputGbps: ${S3_TARGET_THROUGHPUT_GBPS:-25}
+  s3ForcePathStyle: ${S3_FORCE_PATH_STYLE:-false}
 
 tracingConfig:
   zipkinEndpoint: ${ZIPKIN_TRACING_ENDPOINT:-http://localhost:9411/api/v2/spans}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-astra-app,slack-astra-app-backend-datasource"
 
   s3:
-    image: 'adobe/s3mock:2.1.29'
+    image: 'adobe/s3mock:latest'
     container_name: dep_s3
     ports:
       - 9090:9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,11 @@ services:
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - S3_ENDPOINT=http://dep_s3:9090
+      - S3_ENDPOINT=http://s3:9090/
+      - ASTRA_ZK_SESSION_TIMEOUT_MS=60000
+      - ASTRA_ZK_CONNECT_TIMEOUT_MS=15000
+      - ASTRA_ZK_SLEEP_RETRIES_MS=5000
+      - S3_FORCE_PATH_STYLE=true
     depends_on:
       - zookeeper
       - kafka
@@ -93,7 +97,15 @@ services:
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - S3_ENDPOINT=http://dep_s3:9090
+      - S3_ENDPOINT=http://s3:9090/
+      - INDEXER_MAX_BYTES_PER_CHUNK=500
+      - INDEXER_MAX_MESSAGES_PER_CHUNK=100
+      - INDEXER_MAX_TIME_PER_CHUNK_SECONDS=3600
+      - INDEXER_MAX_TIME_PER_CHUNK_SECONDS=900
+      - ASTRA_ZK_SESSION_TIMEOUT_MS=60000
+      - ASTRA_ZK_CONNECT_TIMEOUT_MS=15000
+      - ASTRA_ZK_SLEEP_RETRIES_MS=5000
+      - S3_FORCE_PATH_STYLE=true
     depends_on:
       - astra_preprocessor
 
@@ -110,7 +122,13 @@ services:
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - S3_ENDPOINT=http://dep_s3:9090
+      - S3_ENDPOINT=http://s3:9090/
+      - S3_FORCE_PATH_STYLE=true
+      - ASTRA_ZK_SESSION_TIMEOUT_MS=60000
+      - ASTRA_ZK_CONNECT_TIMEOUT_MS=15000
+      - ASTRA_ZK_SLEEP_RETRIES_MS=5000
+      - ASTRA_MANAGER_REPLICA_LIFESPAN_MINS=30
+      - ASTRA_MANAGER_SNAPSHOT_LIFESPAN_MINS=120
     depends_on:
       - astra_preprocessor
 
@@ -128,7 +146,11 @@ services:
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - S3_ENDPOINT=http://dep_s3:9090
+      - S3_ENDPOINT=http://s3:9090/
+      - ASTRA_ZK_SESSION_TIMEOUT_MS=60000
+      - ASTRA_ZK_CONNECT_TIMEOUT_MS=15000
+      - ASTRA_ZK_SLEEP_RETRIES_MS=5000
+      - S3_FORCE_PATH_STYLE=true
     depends_on:
       - astra_preprocessor
 
@@ -145,7 +167,11 @@ services:
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - S3_ENDPOINT=http://dep_s3:9090
+      - S3_ENDPOINT=http://s3:9090/
+      - ASTRA_ZK_SESSION_TIMEOUT_MS=60000
+      - ASTRA_ZK_CONNECT_TIMEOUT_MS=15000
+      - ASTRA_ZK_SLEEP_RETRIES_MS=5000
+      - S3_FORCE_PATH_STYLE=true
     depends_on:
       - astra_preprocessor
 
@@ -162,6 +188,10 @@ services:
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
-      - S3_ENDPOINT=http://dep_s3:9090
+      - S3_ENDPOINT=http://s3:9090/
+      - ASTRA_ZK_SESSION_TIMEOUT_MS=60000
+      - ASTRA_ZK_CONNECT_TIMEOUT_MS=15000
+      - ASTRA_ZK_SLEEP_RETRIES_MS=5000
+      - S3_FORCE_PATH_STYLE=true
     depends_on:
       - astra_preprocessor


### PR DESCRIPTION
###  Summary

- Fixing the local setup configuration to help with dev testing.
- Added a flag (S3_FORCE_PATH_STYLE) for S3Async client to indicate how to read the buckets.
### Requirements

* [ ] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
