### PR TITLE
add sampling rate in tracing config and flow through to armeria builder

### DIFF
--- a/astra/src/main/java/com/slack/astra/server/ArmeriaService.java
+++ b/astra/src/main/java/com/slack/astra/server/ArmeriaService.java
@@ -57,16 +57,11 @@ public class ArmeriaService extends AbstractIdleService {
     private final ServerBuilder serverBuilder;
     private final List<SpanHandler> spanHandlers = new ArrayList<>();
 
-    private final float traceSamplingRate;
+    private float traceSamplingRate = 0.0f;
 
-    public Builder(
-        int port,
-        String serviceName,
-        PrometheusMeterRegistry prometheusMeterRegistry,
-        float traceSamplingRate) {
+    public Builder(int port, String serviceName, PrometheusMeterRegistry prometheusMeterRegistry) {
       this.serviceName = serviceName;
       this.serverBuilder = Server.builder().http(port);
-      this.traceSamplingRate = traceSamplingRate;
 
       initializeCompression();
       initializeLogging();
@@ -116,6 +111,7 @@ public class ArmeriaService extends AbstractIdleService {
               }
             });
       }
+      this.traceSamplingRate = tracingConfig.getSamplingRate();
 
       if (!tracingConfig.getZipkinEndpoint().isBlank()) {
         LOG.info(String.format("Trace reporting enabled: %s", tracingConfig.getZipkinEndpoint()));

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -158,7 +158,6 @@ public class Astra {
     Set<Service> services = new HashSet<>();
 
     HashSet<AstraConfigs.NodeRole> roles = new HashSet<>(astraConfig.getNodeRolesList());
-    final float traceSamplingRate = astraConfig.getTracingConfig().getSamplingRate();
 
     if (roles.contains(AstraConfigs.NodeRole.INDEX)) {
       IndexingChunkManager<LogMessage> chunkManager =
@@ -187,7 +186,7 @@ public class Astra {
       Duration requestTimeout =
           Duration.ofMillis(astraConfig.getIndexerConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraIndex", meterRegistry, traceSamplingRate)
+          new ArmeriaService.Builder(serverPort, "astraIndex", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withGrpcService(searcher)
@@ -220,7 +219,7 @@ public class Astra {
       final int serverPort = astraConfig.getQueryConfig().getServerConfig().getServerPort();
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraQuery", meterRegistry, traceSamplingRate)
+          new ArmeriaService.Builder(serverPort, "astraQuery", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(astraDistributedQueryService))
@@ -258,7 +257,7 @@ public class Astra {
       Duration requestTimeout =
           Duration.ofMillis(astraConfig.getCacheConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraCache", meterRegistry, traceSamplingRate)
+          new ArmeriaService.Builder(serverPort, "astraCache", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withGrpcService(searcher)
@@ -288,7 +287,7 @@ public class Astra {
       services.add(replicaRestoreService);
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraManager", meterRegistry, traceSamplingRate)
+          new ArmeriaService.Builder(serverPort, "astraManager", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withGrpcService(
@@ -389,7 +388,7 @@ public class Astra {
           Duration.ofMillis(
               astraConfig.getRecoveryConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraRecovery", meterRegistry, traceSamplingRate)
+          new ArmeriaService.Builder(serverPort, "astraRecovery", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .build();
@@ -411,8 +410,7 @@ public class Astra {
           Duration.ofMillis(
               astraConfig.getPreprocessorConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService.Builder armeriaServiceBuilder =
-          new ArmeriaService.Builder(
-                  serverPort, "astraPreprocessor", meterRegistry, traceSamplingRate)
+          new ArmeriaService.Builder(serverPort, "astraPreprocessor", meterRegistry)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig());
 

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -158,6 +158,7 @@ public class Astra {
     Set<Service> services = new HashSet<>();
 
     HashSet<AstraConfigs.NodeRole> roles = new HashSet<>(astraConfig.getNodeRolesList());
+    final float traceSamplingRate = astraConfig.getTracingConfig().getSamplingRate();
 
     if (roles.contains(AstraConfigs.NodeRole.INDEX)) {
       IndexingChunkManager<LogMessage> chunkManager =
@@ -186,7 +187,7 @@ public class Astra {
       Duration requestTimeout =
           Duration.ofMillis(astraConfig.getIndexerConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraIndex", meterRegistry)
+          new ArmeriaService.Builder(serverPort, "astraIndex", meterRegistry, traceSamplingRate)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withGrpcService(searcher)
@@ -219,7 +220,7 @@ public class Astra {
       final int serverPort = astraConfig.getQueryConfig().getServerConfig().getServerPort();
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraQuery", meterRegistry)
+          new ArmeriaService.Builder(serverPort, "astraQuery", meterRegistry, traceSamplingRate)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withAnnotatedService(new ElasticsearchApiService(astraDistributedQueryService))
@@ -257,7 +258,7 @@ public class Astra {
       Duration requestTimeout =
           Duration.ofMillis(astraConfig.getCacheConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraCache", meterRegistry)
+          new ArmeriaService.Builder(serverPort, "astraCache", meterRegistry, traceSamplingRate)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withGrpcService(searcher)
@@ -287,7 +288,7 @@ public class Astra {
       services.add(replicaRestoreService);
 
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraManager", meterRegistry)
+          new ArmeriaService.Builder(serverPort, "astraManager", meterRegistry, traceSamplingRate)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .withGrpcService(
@@ -388,7 +389,7 @@ public class Astra {
           Duration.ofMillis(
               astraConfig.getRecoveryConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService armeriaService =
-          new ArmeriaService.Builder(serverPort, "astraRecovery", meterRegistry)
+          new ArmeriaService.Builder(serverPort, "astraRecovery", meterRegistry, traceSamplingRate)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig())
               .build();
@@ -410,7 +411,8 @@ public class Astra {
           Duration.ofMillis(
               astraConfig.getPreprocessorConfig().getServerConfig().getRequestTimeoutMs());
       ArmeriaService.Builder armeriaServiceBuilder =
-          new ArmeriaService.Builder(serverPort, "astraPreprocessor", meterRegistry)
+          new ArmeriaService.Builder(
+                  serverPort, "astraPreprocessor", meterRegistry, traceSamplingRate)
               .withRequestTimeout(requestTimeout)
               .withTracing(astraConfig.getTracingConfig());
 

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -77,6 +77,7 @@ message S3Config {
 message TracingConfig {
   string zipkin_endpoint = 1;
   map<string, string> common_tags = 2;
+  float sampling_rate = 3;
 }
 
 // Configuration for the query service.

--- a/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
@@ -180,6 +180,7 @@ public class AstraConfigTest {
     final AstraConfigs.TracingConfig tracingConfig = config.getTracingConfig();
     assertThat(tracingConfig.getZipkinEndpoint()).isEqualTo("http://localhost:9411/api/v2/spans");
     assertThat(tracingConfig.getCommonTagsMap()).isEqualTo(Map.of("clusterName", "astra_local"));
+    assertThat(tracingConfig.getSamplingRate()).isEqualTo(1.0f);
 
     final AstraConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
     assertThat(indexerConfig.getMaxMessagesPerChunk()).isEqualTo(1000);
@@ -633,6 +634,7 @@ public class AstraConfigTest {
     final AstraConfigs.TracingConfig tracingConfig = config.getTracingConfig();
     assertThat(tracingConfig.getZipkinEndpoint()).isEmpty();
     assertThat(tracingConfig.getCommonTagsMap()).isEmpty();
+    assertThat(tracingConfig.getSamplingRate()).isEqualTo(0.0f);
 
     final AstraConfigs.IndexerConfig indexerConfig = config.getIndexerConfig();
     assertThat(indexerConfig.getMaxMessagesPerChunk()).isZero();

--- a/astra/src/test/resources/test_config.json
+++ b/astra/src/test/resources/test_config.json
@@ -16,7 +16,8 @@
     "zipkinEndpoint": "http://localhost:9411/api/v2/spans",
     "commonTags": {
       "clusterName": "astra_local"
-    }
+    },
+    "samplingRate": 1.0
   },
   "indexerConfig": {
     "maxMessagesPerChunk": 1000,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,7 @@ tracingConfig:
   commonTags:
     clusterName: ${ASTRA_CLUSTER_NAME:-ASTRA_local}
     env: ${ASTRA_CLUSTER_ENV:-local}
+  sampling_rate: ${TRACING_SAMPLING_RATE:-1.0}
 
 queryConfig:
   serverConfig:

--- a/docs/topics/Config-options.md
+++ b/docs/topics/Config-options.md
@@ -295,6 +295,7 @@ tracingConfig:
   commonTags:
     clusterName: astra-local
     env: localhost
+  samplingRate: 0.01
 ```
 
 ### zipkinEndpoint
@@ -306,7 +307,8 @@ a JSON array of span data.
 Optional common tags to annotate on all submitted Zipkin traces. Can be overwritten by spans at runtime, if keys 
 collide. 
 
-<tip>Recommended common tags: <code>clusterName</code>, <code>env</code></tip>
+### samplingRate
+Rate at which to sample astra's traces. A value of `1.0` will send all traces, `0.01` will send 1% of traces, etc.
 
 ## queryConfig
 

--- a/docs/topics/Config-options.md
+++ b/docs/topics/Config-options.md
@@ -307,6 +307,8 @@ a JSON array of span data.
 Optional common tags to annotate on all submitted Zipkin traces. Can be overwritten by spans at runtime, if keys 
 collide. 
 
+<tip>Recommended common tags: <code>clusterName</code>, <code>env</code></tip>
+
 ### samplingRate
 Rate at which to sample astra's traces. A value of `1.0` will send all traces, `0.01` will send 1% of traces, etc.
 


### PR DESCRIPTION
###  Summary
Allow for configurable sampling at the zipkin export level via configuring armeria. This allows us to more efficiently trace astra itself.

This defaults the sample rate to 100% which is a no-op as that is the default behavior without a sampler.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
