### PR TITLE
use otel collector to receive astra traces and send to astra preprocessor (self ingestion of traces)

### DIFF
--- a/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
+++ b/astra/src/main/java/com/slack/astra/bulkIngestApi/opensearch/BulkApiRequestParser.java
@@ -111,6 +111,10 @@ public class BulkApiRequestParser {
           ByteString.copyFromUtf8(
               String.valueOf(sourceAndMetadata.get(LogMessage.ReservedField.TRACE_ID.fieldName))));
       sourceAndMetadata.remove(LogMessage.ReservedField.TRACE_ID.fieldName);
+    } else if (sourceAndMetadata.get("traceId") != null) {
+      spanBuilder.setTraceId(
+          ByteString.copyFromUtf8(String.valueOf(sourceAndMetadata.get("traceId"))));
+      sourceAndMetadata.remove("traceId");
     }
     if (sourceAndMetadata.get(LogMessage.ReservedField.NAME.fieldName) != null) {
       spanBuilder.setName(

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,9 @@
 nodeRoles: [${NODE_ROLES:-QUERY,INDEX,CACHE,MANAGER,RECOVERY,PREPROCESSOR}]
 
 indexerConfig:
-  maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-100000}
+  maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-1000000}
   maxBytesPerChunk: ${INDEXER_MAX_BYTES_PER_CHUNK:-1000000}
-  maxTimePerChunkSeconds: ${INDEXER_MAX_TIME_PER_CHUNK_SECONDS:-5400}
+  maxTimePerChunkSeconds: ${INDEXER_MAX_TIME_PER_CHUNK_SECONDS:-0}
   luceneConfig:
     commitDurationSecs: ${INDEXER_COMMIT_DURATION_SECS:-10}
     refreshDurationSecs: ${INDEXER_REFRESH_DURATION_SECS:-11}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,9 @@
 nodeRoles: [${NODE_ROLES:-QUERY,INDEX,CACHE,MANAGER,RECOVERY,PREPROCESSOR}]
 
 indexerConfig:
-  maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-1000000}
+  maxMessagesPerChunk: ${INDEXER_MAX_MESSAGES_PER_CHUNK:-100000}
   maxBytesPerChunk: ${INDEXER_MAX_BYTES_PER_CHUNK:-1000000}
-  maxTimePerChunkSeconds: ${INDEXER_MAX_TIME_PER_CHUNK_SECONDS:-0}
+  maxTimePerChunkSeconds: ${INDEXER_MAX_TIME_PER_CHUNK_SECONDS:-5400}
   luceneConfig:
     commitDurationSecs: ${INDEXER_COMMIT_DURATION_SECS:-10}
     refreshDurationSecs: ${INDEXER_REFRESH_DURATION_SECS:-11}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
       - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
+      - INDEXER_MAX_TIME_PER_CHUNK_SECONDS=0
     depends_on:
       - astra_preprocessor
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,6 @@ services:
     environment:
       - initialBuckets=test-s3-bucket
 
-  openzipkin:
-    image: 'openzipkin/zipkin-slim'
-    container_name: dep_openzipkin
-    ports:
-      - 9411:9411
-
   #to build this image run 'docker build -t slackhq/astra .'
   astra_preprocessor:
     image: 'slackhq/astra'
@@ -72,13 +66,12 @@ services:
       # Shared settings
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
       - zookeeper
       - kafka
       - s3
-      - openzipkin
 
   astra_index:
     image: 'slackhq/astra'
@@ -92,7 +85,7 @@ services:
       # Shared settings
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
       - astra_preprocessor
@@ -109,7 +102,7 @@ services:
       # Shared settings
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
       - astra_preprocessor
@@ -127,7 +120,7 @@ services:
       # Shared settings
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
       - astra_preprocessor
@@ -144,7 +137,7 @@ services:
       # Shared settings
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
       - astra_preprocessor
@@ -161,7 +154,23 @@ services:
       # Shared settings
       - ASTRA_ZK_CONNECTION_STRING=zookeeper:2181
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
-      - ZIPKIN_TRACING_ENDPOINT=http://openzipkin:9411/api/v2/spans
+      - ZIPKIN_TRACING_ENDPOINT=http://host.docker.internal:9411/api/v2/spans
       - S3_ENDPOINT=http://dep_s3:9090
     depends_on:
       - astra_preprocessor
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel/config.yaml
+    ports:
+      - 1888:1888 # pprof extension
+      - 8888:8888 # Prometheus metrics exposed by the Collector
+      - 8889:8889 # Prometheus exporter metrics
+      - 13133:13133 # health_check extension
+      - 4317:4317 # OTLP gRPC receiver
+      - 4318:4318 # OTLP http receiver
+      - 55679:55679 # zpages extension
+      - 9411:9411 #zipkin
+    command:
+      --config /etc/otel/config.yaml

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -1,0 +1,47 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+  jaeger:
+    protocols:
+      grpc:
+      thrift_http:
+      thrift_compact:
+      thrift_binary:
+  zipkin:
+    endpoint: "0.0.0.0:9411"  # Default Zipkin endpoint
+
+exporters:
+  opensearch:
+    http:
+      endpoint: "http://astra_preprocessor:8086"
+      tls:
+        insecure: true
+
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 4000
+    spike_limit_mib: 500
+  batch:
+    send_batch_max_size: 100
+    send_batch_size: 100
+    timeout: 10s
+
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+  pprof:
+    endpoint: "0.0.0.0:1888"
+
+service:
+  extensions: [health_check, pprof]
+  pipelines:
+    traces:
+      receivers: [otlp, jaeger, zipkin]
+      processors: [memory_limiter, batch]
+      exporters: [opensearch]

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -3,12 +3,6 @@ receivers:
     protocols:
       grpc:
       http:
-  jaeger:
-    protocols:
-      grpc:
-      thrift_http:
-      thrift_compact:
-      thrift_binary:
   zipkin:
     endpoint: "0.0.0.0:9411"  # Default Zipkin endpoint
 
@@ -42,6 +36,6 @@ service:
   extensions: [health_check, pprof]
   pipelines:
     traces:
-      receivers: [otlp, jaeger, zipkin]
+      receivers: [otlp, zipkin]
       processors: [memory_limiter, batch]
       exporters: [opensearch]


### PR DESCRIPTION
###  Summary
Does self ingestion of astra traces rather than using the zipkin plugin.  I see in other tracing projects, they show functionality with self ingestion. I thought a good way to do this was to utilize otel collector to receive and send spans to the preprocessor.

Uses otel-collector for self-ingestion into the preprocessor.  This shows a small change to the bulk ingest api to support otlp collected traces exported using the opensearch exporter.

This is blocked by: https://github.com/slackhq/astra/pull/1054 (and setting a reasonable default, maybe 1% sampling) so we dont go into a spiral of self-ingestion.

Potentially, a better implementation would be to implement the OTLP API as an ingestion input.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

### Screenshot
![image](https://github.com/user-attachments/assets/1491ea4f-ac1f-44b5-8445-28a16b8fdde1)

Note: it looks like a processor is needed to fix duration on this. (todo if we want to merge this example)
