### PR TITLE
Adding DecodingService Decorator to ArmeriaService

### DIFF
--- a/astra/src/main/java/com/slack/astra/server/ArmeriaService.java
+++ b/astra/src/main/java/com/slack/astra/server/ArmeriaService.java
@@ -14,6 +14,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.brave.BraveService;
 import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.encoding.DecodingService;
 import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
@@ -119,7 +120,7 @@ public class ArmeriaService extends AbstractIdleService {
     }
 
     public Builder withAnnotatedService(Object service) {
-      serverBuilder.annotatedService(service);
+      serverBuilder.annotatedService(service, DecodingService.newDecorator());
       return this;
     }
 


### PR DESCRIPTION
###  Summary

Adding DecodingService Decorator to ArmeriaService to allow accepting compressed data via _bulk endpoint

Local testing:
Sent `gzip` data via `_bulk` endpoint

`zarna_parekh@Zarnas-MacBook-Pro ~ % vi data.json zarna_parekh@Zarnas-MacBook-Pro ~ % gzip -c data.json| curl -X POST 'http://localhost:8086/_bulk' \ -H "Content-Encoding: gzip" \ -H "Content-Type: application/json" \ --data-binary @- {"totalDocs":1,"failedDocs":0,"errorMsg":""}%`
`zarna_parekh@Zarnas-MacBook-Pro ~ % cat data.json { "index" : { "_index" : "test", "_id" : "100" } } { "@timestamp": "2024-03-07T12:00:00.000Z", "level": "INFO", "message": "This is a log message", "service-name": "test" }`

Also, tested in airbnb env

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
