### PR TITLE
Add manager offset reset functionality

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadata.java
@@ -25,8 +25,8 @@ public class SnapshotMetadata extends AstraPartitionedMetadata {
   public final String snapshotId;
   public final long startTimeEpochMs;
   public final long endTimeEpochMs;
-  public final long maxOffset;
   public final String partitionId;
+  public long maxOffset;
   public long sizeInBytesOnDisk;
 
   public SnapshotMetadata(

--- a/astra/src/main/java/com/slack/astra/server/RecoveryTaskCreator.java
+++ b/astra/src/main/java/com/slack/astra/server/RecoveryTaskCreator.java
@@ -244,8 +244,9 @@ public class RecoveryTaskCreator {
     if (currentEndOffsetForPartition < highestDurableOffsetForPartition) {
       final String message =
           String.format(
-              "The current head for the partition %d can't "
-                  + "be lower than the highest durable offset for that partition %d",
+              "The current head for the partition %d can't be lower than the highest durable offset for that "
+                  + "partition %d. To manually reset this partition's stored offset, see the ResetPartitionData "
+                  + "function in the manager.",
               currentEndOffsetForPartition, highestDurableOffsetForPartition);
       LOG.error(message);
       throw new IllegalStateException(message);

--- a/astra/src/main/proto/manager_api.proto
+++ b/astra/src/main/proto/manager_api.proto
@@ -23,6 +23,9 @@ service ManagerApiService {
 
   rpc RestoreReplica(RestoreReplicaRequest) returns (RestoreReplicaResponse) {}
   rpc RestoreReplicaIds(RestoreReplicaIdsRequest) returns (RestoreReplicaIdsResponse) {}
+
+  // Resets the partition offset data to allow using a newer offset for a partition ID
+  rpc ResetPartitionData(ResetPartitionDataRequest) returns (ResetPartitionDataResponse) {}
 }
 
 // CreateDatasetMetadataRequest represents a new dataset with uninitialized thoughput and partition assignments
@@ -91,5 +94,14 @@ message RestoreReplicaIdsRequest {
 }
 
 message RestoreReplicaIdsResponse {
+  string status = 1;
+}
+
+message ResetPartitionDataRequest {
+  string partition_id = 1;
+  bool dry_run = 2;
+}
+
+message ResetPartitionDataResponse {
   string status = 1;
 }


### PR DESCRIPTION
###  Summary

Adds a new manager API that allows forcefully resetting the partition IDs for persisted snapshots to 0. This is a workaround for #906, until a more complete implementation can be considered. Now in the event of an offset rollback it is possible to issue a manager reset to allow those partitions to come online.