### PR TITLE
Narrow grpc metric collecting decorator to just the grpc services

### DIFF
--- a/astra/src/main/java/com/slack/astra/server/ArmeriaService.java
+++ b/astra/src/main/java/com/slack/astra/server/ArmeriaService.java
@@ -151,9 +151,9 @@ public class ArmeriaService extends AbstractIdleService {
                       return next.startCall(call, headers);
                     }
                   });
-      serverBuilder.decorator(
+      serverBuilder.service(
+          searchBuilder.build(),
           MetricCollectingService.newDecorator(GrpcMeterIdPrefixFunction.of("grpc.service")));
-      serverBuilder.service(searchBuilder.build());
       return this;
     }
 


### PR DESCRIPTION
###  Summary
Instead of adding the grpc.service metric decorator to all services declared with the builder, scope it to the grpc service.

When I was looking at the decorator usage a while ago, I noticed that the metric decorator was being added globally in a place that I wouldn't expect it to add a global decorator. This narrows that scope to just the grpc service being added.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
