### PR TITLE
OpenSearchAdapter - Include field name in error log about map update failure

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
+++ b/astra/src/main/java/com/slack/astra/logstore/opensearch/OpenSearchAdapter.java
@@ -543,7 +543,7 @@ public class OpenSearchAdapter {
             new CompressedXContent(BytesReference.bytes(mapping)),
             MapperService.MergeReason.MAPPING_UPDATE);
       } catch (Exception e) {
-        LOG.error("Error doing map update errorMsg={}", e.getMessage());
+        LOG.error("Error doing map update errorMsg={} for field {}", e.getMessage(), fieldName);
       }
       return true;
     }


### PR DESCRIPTION
###  Summary
When the OpenSearchAdapter has an error doing a map update for a field, it doesn't include the field name in the log message. This adds the field name to the log message.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
