### PR TITLE
Make ZK Cache Init Timeout Configurable

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
@@ -94,11 +94,12 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting caching chunk manager");
 
-    replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    replicaMetadataStore = new ReplicaMetadataStore(curatorFramework, zkConfig);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
-    cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
-    cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework, cacheNodeId);
+    cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework, zkConfig);
+    cacheNodeAssignmentStore =
+        new CacheNodeAssignmentStore(curatorFramework, zkConfig, cacheNodeId);
     cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework, zkConfig);
 
     if (Boolean.getBoolean(ASTRA_NG_DYNAMIC_CHUNK_SIZES_FLAG)) {

--- a/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
@@ -96,7 +96,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
 
     replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
     cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
     cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework, cacheNodeId);
     cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework, zkConfig);

--- a/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/CachingChunkManager.java
@@ -42,6 +42,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
 
   private final MeterRegistry meterRegistry;
   private final AsyncCuratorFramework curatorFramework;
+  private final AstraConfigs.ZookeeperConfig zkConfig;
   private final BlobStore blobStore;
   private final SearchContext searchContext;
   private final String s3Bucket;
@@ -68,6 +69,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   public CachingChunkManager(
       MeterRegistry registry,
       AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
       BlobStore blobStore,
       SearchContext searchContext,
       String s3Bucket,
@@ -77,6 +79,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
       long capacityBytes) {
     this.meterRegistry = registry;
     this.curatorFramework = curatorFramework;
+    this.zkConfig = zkConfig;
     this.blobStore = blobStore;
     this.searchContext = searchContext;
     this.s3Bucket = s3Bucket;
@@ -96,7 +99,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
     cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
     cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework, cacheNodeId);
-    cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework);
+    cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework, zkConfig);
 
     if (Boolean.getBoolean(ASTRA_NG_DYNAMIC_CHUNK_SIZES_FLAG)) {
       cacheNodeAssignmentStore.addListener(cacheNodeAssignmentChangeListener);
@@ -158,6 +161,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
   public static CachingChunkManager<LogMessage> fromConfig(
       MeterRegistry meterRegistry,
       AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
       AstraConfigs.S3Config s3Config,
       AstraConfigs.CacheConfig cacheConfig,
       BlobStore blobStore)
@@ -165,6 +169,7 @@ public class CachingChunkManager<T> extends ChunkManagerBase<T> {
     return new CachingChunkManager<>(
         meterRegistry,
         curatorFramework,
+        zkConfig,
         blobStore,
         SearchContext.fromConfig(cacheConfig.getServerConfig()),
         s3Config.getS3Bucket(),

--- a/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
@@ -388,7 +388,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
     LOG.info("Starting indexing chunk manager");
 
     searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
 
     stopIngestion = false;
   }

--- a/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
@@ -65,6 +65,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   private final AsyncCuratorFramework curatorFramework;
   private final SearchContext searchContext;
   private final AstraConfigs.IndexerConfig indexerConfig;
+  private final AstraConfigs.ZookeeperConfig zkConfig;
   private ReadWriteChunk<T> activeChunk;
 
   private final MeterRegistry meterRegistry;
@@ -120,7 +121,8 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
       ListeningExecutorService rolloverExecutorService,
       AsyncCuratorFramework curatorFramework,
       SearchContext searchContext,
-      AstraConfigs.IndexerConfig indexerConfig) {
+      AstraConfigs.IndexerConfig indexerConfig,
+      AstraConfigs.ZookeeperConfig zkConfig) {
 
     ensureNonNullString(dataDirectory, "The data directory shouldn't be empty");
     this.dataDirectory = new File(dataDirectory);
@@ -138,6 +140,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
     this.curatorFramework = curatorFramework;
     this.searchContext = searchContext;
     this.indexerConfig = indexerConfig;
+    this.zkConfig = zkConfig;
 
     stopIngestion = true;
     activeChunk = null;
@@ -384,7 +387,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting indexing chunk manager");
 
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
 
     stopIngestion = false;
@@ -444,6 +447,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
       MeterRegistry meterRegistry,
       AsyncCuratorFramework curatorFramework,
       AstraConfigs.IndexerConfig indexerConfig,
+      AstraConfigs.ZookeeperConfig zkConfig,
       BlobStore blobStore,
       AstraConfigs.S3Config s3Config) {
 
@@ -459,6 +463,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
         makeDefaultRollOverExecutor(),
         curatorFramework,
         SearchContext.fromConfig(indexerConfig.getServerConfig()),
-        indexerConfig);
+        indexerConfig,
+        zkConfig);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeAssignmentStore.java
@@ -3,6 +3,7 @@ package com.slack.astra.metadata.cache;
 import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.proto.metadata.Metadata;
 import java.util.List;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -11,18 +12,22 @@ import org.apache.zookeeper.CreateMode;
 public class CacheNodeAssignmentStore extends AstraPartitioningMetadataStore<CacheNodeAssignment> {
   public static final String CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH = "/cacheAssignment";
 
-  public CacheNodeAssignmentStore(AsyncCuratorFramework curator) {
+  public CacheNodeAssignmentStore(
+      AsyncCuratorFramework curator, AstraConfigs.ZookeeperConfig zkConfig) {
     super(
         curator,
+        zkConfig,
         CreateMode.PERSISTENT,
         new CacheNodeAssignmentSerializer().toModelSerializer(),
         CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH);
   }
 
   /** Restricts the cache node assignment store to only watching events for cacheNodeId */
-  public CacheNodeAssignmentStore(AsyncCuratorFramework curator, String cacheNodeId) {
+  public CacheNodeAssignmentStore(
+      AsyncCuratorFramework curator, AstraConfigs.ZookeeperConfig zkConfig, String cacheNodeId) {
     super(
         curator,
+        zkConfig,
         CreateMode.PERSISTENT,
         new CacheNodeAssignmentSerializer().toModelSerializer(),
         CACHE_NODE_ASSIGNMENT_STORE_ZK_PATH,

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataStore.java
@@ -1,15 +1,18 @@
 package com.slack.astra.metadata.cache;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class CacheNodeMetadataStore extends AstraMetadataStore<CacheNodeMetadata> {
   public static final String CACHE_NODE_METADATA_STORE_ZK_PATH = "/cacheNodes";
 
-  public CacheNodeMetadataStore(AsyncCuratorFramework curator) {
+  public CacheNodeMetadataStore(
+      AsyncCuratorFramework curator, AstraConfigs.ZookeeperConfig zkConfig) {
     super(
         curator,
+        zkConfig,
         CreateMode.EPHEMERAL,
         true,
         new CacheNodeMetadataSerializer().toModelSerializer(),

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheSlotMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheSlotMetadataStore.java
@@ -3,6 +3,7 @@ package com.slack.astra.metadata.cache;
 import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.proto.metadata.Metadata;
 import java.time.Instant;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -15,9 +16,12 @@ public class CacheSlotMetadataStore extends AstraPartitioningMetadataStore<Cache
    * Initializes a cache slot metadata store at the CACHE_SLOT_ZK_PATH. This should be used to
    * create/update the cache slots, and for listening to all cache slot events.
    */
-  public CacheSlotMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
+  public CacheSlotMetadataStore(
+      AsyncCuratorFramework curatorFramework, AstraConfigs.ZookeeperConfig zkConfig)
+      throws Exception {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.EPHEMERAL,
         new CacheSlotMetadataSerializer().toModelSerializer(),
         CACHE_SLOT_ZK_PATH);

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
@@ -1,7 +1,5 @@
 package com.slack.astra.metadata.core;
 
-// import static com.slack.astra.server.AstraConfig.DEFAULT_ZK_TIMEOUT_SECS;
-
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.util.RuntimeHalterImpl;

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
@@ -1,7 +1,5 @@
 package com.slack.astra.metadata.core;
 
-import static com.slack.astra.server.AstraConfig.DEFAULT_ZK_TIMEOUT_SECS;
-
 import com.google.common.collect.Sets;
 import com.slack.astra.proto.config.AstraConfigs;
 import java.io.Closeable;
@@ -194,7 +192,7 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     try {
       createAsync(metadataNode)
           .toCompletableFuture()
-          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
     }
@@ -208,7 +206,7 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     try {
       return getAsync(partition, path)
           .toCompletableFuture()
-          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
     }
@@ -232,7 +230,7 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    */
   public T findSync(String path) {
     try {
-      return findAsync(path).toCompletableFuture().get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+      return findAsync(path).toCompletableFuture().get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
     }
@@ -246,7 +244,7 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     try {
       updateAsync(metadataNode)
           .toCompletableFuture()
-          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
     }
@@ -260,7 +258,7 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     try {
       deleteAsync(metadataNode)
           .toCompletableFuture()
-          .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (ExecutionException | InterruptedException | TimeoutException e) {
       throw new InternalMetadataStoreException(
           "Error deleting node under at path: " + metadataNode.name, e);
@@ -285,7 +283,7 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
 
   public List<T> listSync() {
     try {
-      return listAsync().toCompletableFuture().get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+      return listAsync().toCompletableFuture().get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (ExecutionException | InterruptedException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error listing nodes", e);
     }

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
@@ -230,7 +230,9 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    */
   public T findSync(String path) {
     try {
-      return findAsync(path).toCompletableFuture().get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+      return findAsync(path)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
     }
@@ -283,7 +285,9 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
 
   public List<T> listSync() {
     try {
-      return listAsync().toCompletableFuture().get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+      return listAsync()
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
     } catch (ExecutionException | InterruptedException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error listing nodes", e);
     }

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
@@ -60,20 +60,20 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
 
   public AstraPartitioningMetadataStore(
       AsyncCuratorFramework curator,
+      AstraConfigs.ZookeeperConfig zkConfig,
       CreateMode createMode,
       ModelSerializer<T> modelSerializer,
-      String storeFolder,
-      AstraConfigs.ZookeeperConfig zkConfig) {
-    this(curator, createMode, modelSerializer, storeFolder, List.of(), zkConfig);
+      String storeFolder) {
+    this(curator, zkConfig, createMode, modelSerializer, storeFolder, List.of());
   }
 
   public AstraPartitioningMetadataStore(
       AsyncCuratorFramework curator,
+      AstraConfigs.ZookeeperConfig zkConfig,
       CreateMode createMode,
       ModelSerializer<T> modelSerializer,
       String storeFolder,
-      List<String> partitionFilters,
-      AstraConfigs.ZookeeperConfig zkConfig) {
+      List<String> partitionFilters) {
     this.curator = curator;
     this.storeFolder = storeFolder;
     this.createMode = createMode;
@@ -140,8 +140,8 @@ public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * <p>This method creates stores internally when they are detected in ZK storing them to the store
    * map, and removes stores that are in the map that no longer exist in ZK.
    *
-   * @see AstraMetadataStore#AstraMetadataStore(AsyncCuratorFramework, CreateMode, boolean,
-   *     ModelSerializer, String, AstraConfigs.ZookeeperConfig)
+   * @see AstraMetadataStore#AstraMetadataStore(AsyncCuratorFramework, AstraConfigs.ZookeeperConfig,
+   *     CreateMode, boolean, ModelSerializer, String)
    */
   private Watcher buildWatcher() {
     return event -> {

--- a/astra/src/main/java/com/slack/astra/metadata/dataset/DatasetMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/dataset/DatasetMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.dataset;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -8,9 +9,12 @@ public class DatasetMetadataStore extends AstraMetadataStore<DatasetMetadata> {
   // TODO: The path should be dataset, but leaving it as /service for backwards compatibility.
   public static final String DATASET_METADATA_STORE_ZK_PATH = "/service";
 
-  public DatasetMetadataStore(AsyncCuratorFramework curator, boolean shouldCache) throws Exception {
+  public DatasetMetadataStore(
+      AsyncCuratorFramework curator, AstraConfigs.ZookeeperConfig zkConfig, boolean shouldCache)
+      throws Exception {
     super(
         curator,
+        zkConfig,
         CreateMode.PERSISTENT,
         shouldCache,
         new DatasetMetadataSerializer().toModelSerializer(),

--- a/astra/src/main/java/com/slack/astra/metadata/hpa/HpaMetricMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/hpa/HpaMetricMetadataStore.java
@@ -1,15 +1,18 @@
 package com.slack.astra.metadata.hpa;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class HpaMetricMetadataStore extends AstraMetadataStore<HpaMetricMetadata> {
   public static final String AUTOSCALER_METADATA_STORE_ZK_PATH = "/hpa_metrics";
 
-  public HpaMetricMetadataStore(AsyncCuratorFramework curator, boolean shouldCache) {
+  public HpaMetricMetadataStore(
+      AsyncCuratorFramework curator, AstraConfigs.ZookeeperConfig zkConfig, boolean shouldCache) {
     super(
         curator,
+        zkConfig,
         CreateMode.EPHEMERAL,
         shouldCache,
         new HpaMetricMetadataSerializer().toModelSerializer(),

--- a/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.recovery;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -11,9 +12,13 @@ public class RecoveryNodeMetadataStore extends AstraMetadataStore<RecoveryNodeMe
    * Initializes a recovery node metadata store at the RECOVERY_NODE_ZK_PATH. This should be used to
    * create/update the recovery nodes, and for listening to all recovery node events.
    */
-  public RecoveryNodeMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache) {
+  public RecoveryNodeMetadataStore(
+      AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      boolean shouldCache) {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.EPHEMERAL,
         shouldCache,
         new RecoveryNodeMetadataSerializer().toModelSerializer(),
@@ -26,9 +31,13 @@ public class RecoveryNodeMetadataStore extends AstraMetadataStore<RecoveryNodeMe
    * mutating any nodes.
    */
   public RecoveryNodeMetadataStore(
-      AsyncCuratorFramework curatorFramework, String recoveryNodeName, boolean shouldCache) {
+      AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      String recoveryNodeName,
+      boolean shouldCache) {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.EPHEMERAL,
         shouldCache,
         new RecoveryNodeMetadataSerializer().toModelSerializer(),

--- a/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryTaskMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryTaskMetadataStore.java
@@ -1,16 +1,21 @@
 package com.slack.astra.metadata.recovery;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class RecoveryTaskMetadataStore extends AstraMetadataStore<RecoveryTaskMetadata> {
   public static final String RECOVERY_TASK_ZK_PATH = "/recoveryTask";
 
-  public RecoveryTaskMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache)
+  public RecoveryTaskMetadataStore(
+      AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      boolean shouldCache)
       throws Exception {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.PERSISTENT,
         shouldCache,
         new RecoveryTaskMetadataSerializer().toModelSerializer(),

--- a/astra/src/main/java/com/slack/astra/metadata/replica/ReplicaMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/replica/ReplicaMetadataStore.java
@@ -1,15 +1,19 @@
 package com.slack.astra.metadata.replica;
 
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
 public class ReplicaMetadataStore extends AstraPartitioningMetadataStore<ReplicaMetadata> {
   public static final String REPLICA_STORE_ZK_PATH = "/partitioned_replica";
 
-  public ReplicaMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
+  public ReplicaMetadataStore(
+      AsyncCuratorFramework curatorFramework, AstraConfigs.ZookeeperConfig zkConfig)
+      throws Exception {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.PERSISTENT,
         new ReplicaMetadataSerializer().toModelSerializer(),
         REPLICA_STORE_ZK_PATH);

--- a/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.search;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.curator.x.async.AsyncStage;
 import org.apache.zookeeper.CreateMode;
@@ -9,10 +10,14 @@ import org.apache.zookeeper.data.Stat;
 public class SearchMetadataStore extends AstraMetadataStore<SearchMetadata> {
   public static final String SEARCH_METADATA_STORE_ZK_PATH = "/search";
 
-  public SearchMetadataStore(AsyncCuratorFramework curatorFramework, boolean shouldCache)
+  public SearchMetadataStore(
+      AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      boolean shouldCache)
       throws Exception {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.EPHEMERAL,
         shouldCache,
         new SearchMetadataSerializer().toModelSerializer(),

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.snapshot;
 
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
 
@@ -9,9 +10,12 @@ public class SnapshotMetadataStore extends AstraPartitioningMetadataStore<Snapsh
 
   // TODO: Consider restricting the update methods to only update live nodes only?
 
-  public SnapshotMetadataStore(AsyncCuratorFramework curatorFramework) throws Exception {
+  public SnapshotMetadataStore(
+      AsyncCuratorFramework curatorFramework, AstraConfigs.ZookeeperConfig zkConfig)
+      throws Exception {
     super(
         curatorFramework,
+        zkConfig,
         CreateMode.PERSISTENT,
         new SnapshotMetadataSerializer().toModelSerializer(),
         SNAPSHOT_METADATA_STORE_ZK_PATH);

--- a/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
+++ b/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
@@ -135,8 +135,12 @@ public class RecoveryService extends AbstractIdleService {
   protected void startUp() throws Exception {
     LOG.info("Starting recovery service");
 
-    recoveryNodeMetadataStore = new RecoveryNodeMetadataStore(curatorFramework, false);
-    recoveryTaskMetadataStore = new RecoveryTaskMetadataStore(curatorFramework, false);
+    recoveryNodeMetadataStore =
+        new RecoveryNodeMetadataStore(
+            curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig(), false);
+    recoveryTaskMetadataStore =
+        new RecoveryTaskMetadataStore(
+            curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig(), false);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
 
@@ -149,7 +153,11 @@ public class RecoveryService extends AbstractIdleService {
     recoveryNodeLastKnownState = Metadata.RecoveryNodeMetadata.RecoveryNodeState.FREE;
 
     recoveryNodeListenerMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, searchContext.hostname, true);
+        new RecoveryNodeMetadataStore(
+            curatorFramework,
+            AstraConfig.getMetadataStoreConfig().getZookeeperConfig(),
+            searchContext.hostname,
+            true);
     recoveryNodeListenerMetadataStore.addListener(recoveryNodeListener);
   }
 

--- a/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
+++ b/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
@@ -141,7 +141,9 @@ public class RecoveryService extends AbstractIdleService {
     recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(
             curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig(), false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig());
     searchMetadataStore =
         new SearchMetadataStore(
             curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig(), false);

--- a/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
+++ b/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
@@ -142,7 +142,9 @@ public class RecoveryService extends AbstractIdleService {
         new RecoveryTaskMetadataStore(
             curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig(), false);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    searchMetadataStore =
+        new SearchMetadataStore(
+            curatorFramework, AstraConfig.getMetadataStoreConfig().getZookeeperConfig(), false);
 
     recoveryNodeMetadataStore.createSync(
         new RecoveryNodeMetadata(

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -173,6 +173,7 @@ public class Astra {
           new AstraIndexer(
               chunkManager,
               curatorFramework,
+              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
               astraConfig.getIndexerConfig(),
               astraConfig.getIndexerConfig().getKafkaConfig(),
               meterRegistry);
@@ -234,13 +235,15 @@ public class Astra {
           CachingChunkManager.fromConfig(
               meterRegistry,
               curatorFramework,
+              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
               astraConfig.getS3Config(),
               astraConfig.getCacheConfig(),
               blobStore);
       services.add(chunkManager);
 
       HpaMetricMetadataStore hpaMetricMetadataStore =
-          new HpaMetricMetadataStore(curatorFramework, true);
+          new HpaMetricMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
       services.add(
           new CloseableLifecycleManager(
               AstraConfigs.NodeRole.CACHE, List.of(hpaMetricMetadataStore)));
@@ -272,13 +275,16 @@ public class Astra {
       ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
       SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-          new RecoveryTaskMetadataStore(curatorFramework, true);
+          new RecoveryTaskMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
       RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-          new RecoveryNodeMetadataStore(curatorFramework, true);
+          new RecoveryNodeMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
       CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
       DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
       HpaMetricMetadataStore hpaMetricMetadataStore =
-          new HpaMetricMetadataStore(curatorFramework, true);
+          new HpaMetricMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
 
       Duration requestTimeout =
           Duration.ofMillis(astraConfig.getManagerConfig().getServerConfig().getRequestTimeoutMs());
@@ -333,7 +339,9 @@ public class Astra {
               replicaMetadataStore, snapshotMetadataStore, blobStore, managerConfig, meterRegistry);
       services.add(snapshotDeletionService);
 
-      CacheNodeMetadataStore cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework);
+      CacheNodeMetadataStore cacheNodeMetadataStore =
+          new CacheNodeMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
       CacheNodeAssignmentStore cacheNodeAssignmentStore =
           new CacheNodeAssignmentStore(curatorFramework);
 

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -165,6 +165,7 @@ public class Astra {
               meterRegistry,
               curatorFramework,
               astraConfig.getIndexerConfig(),
+              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
               blobStore,
               astraConfig.getS3Config());
       services.add(chunkManager);
@@ -196,7 +197,9 @@ public class Astra {
     }
 
     if (roles.contains(AstraConfigs.NodeRole.QUERY)) {
-      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      SearchMetadataStore searchMetadataStore =
+          new SearchMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
       SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
       DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
 

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -200,8 +200,12 @@ public class Astra {
       SearchMetadataStore searchMetadataStore =
           new SearchMetadataStore(
               curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
+      DatasetMetadataStore datasetMetadataStore =
+          new DatasetMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
 
       services.add(
           new CloseableLifecycleManager(
@@ -275,16 +279,24 @@ public class Astra {
       final AstraConfigs.ManagerConfig managerConfig = astraConfig.getManagerConfig();
       final int serverPort = managerConfig.getServerConfig().getServerPort();
 
-      ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      ReplicaMetadataStore replicaMetadataStore =
+          new ReplicaMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
       RecoveryTaskMetadataStore recoveryTaskMetadataStore =
           new RecoveryTaskMetadataStore(
               curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
       RecoveryNodeMetadataStore recoveryNodeMetadataStore =
           new RecoveryNodeMetadataStore(
               curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
-      CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
-      DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+      CacheSlotMetadataStore cacheSlotMetadataStore =
+          new CacheSlotMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
+      DatasetMetadataStore datasetMetadataStore =
+          new DatasetMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
       HpaMetricMetadataStore hpaMetricMetadataStore =
           new HpaMetricMetadataStore(
               curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
@@ -346,7 +358,8 @@ public class Astra {
           new CacheNodeMetadataStore(
               curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
       CacheNodeAssignmentStore cacheNodeAssignmentStore =
-          new CacheNodeAssignmentStore(curatorFramework);
+          new CacheNodeAssignmentStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig());
 
       ClusterHpaMetricService clusterHpaMetricService =
           new ClusterHpaMetricService(
@@ -411,7 +424,9 @@ public class Astra {
     }
 
     if (roles.contains(AstraConfigs.NodeRole.PREPROCESSOR)) {
-      DatasetMetadataStore datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+      DatasetMetadataStore datasetMetadataStore =
+          new DatasetMetadataStore(
+              curatorFramework, astraConfig.getMetadataStoreConfig().getZookeeperConfig(), true);
 
       final AstraConfigs.PreprocessorConfig preprocessorConfig =
           astraConfig.getPreprocessorConfig();

--- a/astra/src/main/java/com/slack/astra/server/AstraIndexer.java
+++ b/astra/src/main/java/com/slack/astra/server/AstraIndexer.java
@@ -91,7 +91,8 @@ public class AstraIndexer extends AbstractExecutionThreadService {
    */
   private long indexerPreStart() throws Exception {
     LOG.info("Starting Astra indexer pre start.");
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(curatorFramework, zkConfig, true);
 

--- a/astra/src/main/java/com/slack/astra/server/AstraIndexer.java
+++ b/astra/src/main/java/com/slack/astra/server/AstraIndexer.java
@@ -28,6 +28,7 @@ public class AstraIndexer extends AbstractExecutionThreadService {
 
   private final AsyncCuratorFramework curatorFramework;
   private final MeterRegistry meterRegistry;
+  private final AstraConfigs.ZookeeperConfig zkConfig;
   private final AstraConfigs.IndexerConfig indexerConfig;
   private final AstraConfigs.KafkaConfig kafkaConfig;
   private final AstraKafkaConsumer kafkaConsumer;
@@ -53,11 +54,13 @@ public class AstraIndexer extends AbstractExecutionThreadService {
   public AstraIndexer(
       IndexingChunkManager<LogMessage> chunkManager,
       AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
       AstraConfigs.IndexerConfig indexerConfig,
       AstraConfigs.KafkaConfig kafkaConfig,
       MeterRegistry meterRegistry) {
     checkNotNull(chunkManager, "Chunk manager can't be null");
     this.curatorFramework = curatorFramework;
+    this.zkConfig = zkConfig;
     this.indexerConfig = indexerConfig;
     this.kafkaConfig = kafkaConfig;
     this.meterRegistry = meterRegistry;
@@ -90,7 +93,7 @@ public class AstraIndexer extends AbstractExecutionThreadService {
     LOG.info("Starting Astra indexer pre start.");
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, true);
+        new RecoveryTaskMetadataStore(curatorFramework, zkConfig, true);
 
     String partitionId = kafkaConfig.getKafkaTopicPartition();
     long maxOffsetDelay = indexerConfig.getMaxOffsetDelayMessages();

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -62,6 +62,7 @@ message ZookeeperConfig {
   int32 zk_session_timeout_ms = 3;
   int32 zk_connection_timeout_ms = 4;
   int32 sleep_between_retries_ms = 5;
+  int32 zk_cache_init_timeout_ms = 6;
 }
 
 // S3 Configuration.

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -68,6 +68,7 @@ class BulkIngestKafkaProducerTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
@@ -92,7 +93,7 @@ class BulkIngestKafkaProducerTest {
             .setRateLimiterMaxBurstSeconds(1)
             .build();
 
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, zkConfig, true);
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
             INDEX_NAME,

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -114,7 +114,8 @@ public class IndexingChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      SearchMetadataStore searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, zkConfig, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -464,7 +465,8 @@ public class IndexingChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      SearchMetadataStore searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, zkConfig, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -548,7 +550,7 @@ public class IndexingChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -107,6 +107,7 @@ public class IndexingChunkImplTest {
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
+              .setZkCacheInitTimeoutMs(1000)
               .build();
 
       registry = new SimpleMeterRegistry();
@@ -459,6 +460,7 @@ public class IndexingChunkImplTest {
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
+              .setZkCacheInitTimeoutMs(1000)
               .build();
 
       registry = new SimpleMeterRegistry();
@@ -545,6 +547,7 @@ public class IndexingChunkImplTest {
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
+              .setZkCacheInitTimeoutMs(1000)
               .build();
 
       registry = new SimpleMeterRegistry();

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -113,7 +113,8 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, zkConfig);
       SearchMetadataStore searchMetadataStore =
           new SearchMetadataStore(curatorFramework, zkConfig, true);
 
@@ -464,7 +465,8 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      SnapshotMetadataStore snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, zkConfig);
       SearchMetadataStore searchMetadataStore =
           new SearchMetadataStore(curatorFramework, zkConfig, true);
 
@@ -549,7 +551,7 @@ public class IndexingChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, true);
 
       final LuceneIndexStoreImpl logStore =

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -107,6 +107,7 @@ public class ReadOnlyChunkImplTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
@@ -250,6 +251,7 @@ public class ReadOnlyChunkImplTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
@@ -320,6 +322,7 @@ public class ReadOnlyChunkImplTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
@@ -390,6 +393,7 @@ public class ReadOnlyChunkImplTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
@@ -497,6 +501,7 @@ public class ReadOnlyChunkImplTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -110,18 +110,21 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, zkConfig);
 
     String replicaId = "foo";
     String snapshotId = "bar";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, snapshotId, 0);
+    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 0);
     initializeBlobStorageWithIndex(snapshotId);
 
     SearchContext searchContext =
@@ -250,18 +253,21 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, zkConfig);
 
     String replicaId = "foo";
     String snapshotId = "bar";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, snapshotId, 0);
+    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 0);
 
     ReadOnlyChunkImpl<LogMessage> readOnlyChunk =
         new ReadOnlyChunkImpl<>(
@@ -317,17 +323,20 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, zkConfig);
 
     String replicaId = "foo";
     String snapshotId = "bar";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, replicaId, snapshotId);
+    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
     // we intentionally do not initialize a Snapshot, so the lookup is expected to fail
 
     ReadOnlyChunkImpl<LogMessage> readOnlyChunk =
@@ -384,18 +393,21 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, zkConfig);
 
     String replicaId = "foo";
     String snapshotId = "bar";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, snapshotId, 0);
+    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 0);
     initializeBlobStorageWithIndex(snapshotId);
 
     ReadOnlyChunkImpl<LogMessage> readOnlyChunk =
@@ -488,13 +500,16 @@ public class ReadOnlyChunkImplTest {
             .build();
 
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, true);
-    CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
+    CacheSlotMetadataStore cacheSlotMetadataStore =
+        new CacheSlotMetadataStore(curatorFramework, zkConfig);
     CacheNodeAssignmentStore cacheNodeAssignmentStore =
-        new CacheNodeAssignmentStore(curatorFramework);
+        new CacheNodeAssignmentStore(curatorFramework, zkConfig);
 
     String replicaId = "foo";
     String snapshotId = "boo";
@@ -503,8 +518,8 @@ public class ReadOnlyChunkImplTest {
     String replicaSet = "cat";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, snapshotId, 29);
+    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 29);
     initializeBlobStorageWithIndex(snapshotId);
     initializeCacheNodeAssignment(
         cacheNodeAssignmentStore, assignmentId, snapshotId, cacheNodeId, replicaSet, replicaId);
@@ -604,9 +619,13 @@ public class ReadOnlyChunkImplTest {
   }
 
   private void initializeZkSnapshot(
-      AsyncCuratorFramework curatorFramework, String snapshotId, long sizeInBytesOnDisk)
+      AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      String snapshotId,
+      long sizeInBytesOnDisk)
       throws Exception {
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     snapshotMetadataStore.createSync(
         new SnapshotMetadata(
             snapshotId,
@@ -618,9 +637,13 @@ public class ReadOnlyChunkImplTest {
   }
 
   private void initializeZkReplica(
-      AsyncCuratorFramework curatorFramework, String replicaId, String snapshotId)
+      AsyncCuratorFramework curatorFramework,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      String replicaId,
+      String snapshotId)
       throws Exception {
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
     replicaMetadataStore.createSync(
         new ReplicaMetadata(
             replicaId,

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -112,7 +112,8 @@ public class ReadOnlyChunkImplTest {
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, zkConfig, true);
     CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
 
     String replicaId = "foo";
@@ -251,7 +252,8 @@ public class ReadOnlyChunkImplTest {
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, zkConfig, true);
     CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
 
     String replicaId = "foo";
@@ -317,7 +319,8 @@ public class ReadOnlyChunkImplTest {
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, zkConfig, true);
     CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
 
     String replicaId = "foo";
@@ -383,7 +386,8 @@ public class ReadOnlyChunkImplTest {
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, zkConfig, true);
     CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
 
     String replicaId = "foo";
@@ -486,7 +490,8 @@ public class ReadOnlyChunkImplTest {
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
     SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-    SearchMetadataStore searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+    SearchMetadataStore searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, zkConfig, true);
     CacheSlotMetadataStore cacheSlotMetadataStore = new CacheSlotMetadataStore(curatorFramework);
     CacheNodeAssignmentStore cacheNodeAssignmentStore =
         new CacheNodeAssignmentStore(curatorFramework);

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -91,7 +91,7 @@ public class RecoveryChunkImplTest {
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
 
       final LuceneIndexStoreImpl logStore =
@@ -452,7 +452,7 @@ public class RecoveryChunkImplTest {
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
 
       final LuceneIndexStoreImpl logStore =
@@ -537,7 +537,7 @@ public class RecoveryChunkImplTest {
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
       searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, true);
 
       final LuceneIndexStoreImpl logStore =

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -88,7 +88,7 @@ public class RecoveryChunkImplTest {
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
-                  .setZkCacheInitTimeoutMs(1000)
+              .setZkCacheInitTimeoutMs(1000)
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
@@ -444,13 +444,13 @@ public class RecoveryChunkImplTest {
       registry = new SimpleMeterRegistry();
 
       AstraConfigs.ZookeeperConfig zkConfig =
-
+          AstraConfigs.ZookeeperConfig.newBuilder()
               .setZkConnectString(testingServer.getConnectString())
               .setZkPathPrefix("shouldHandleChunkLivecycle")
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
-                  .setSleepBetweenRetriesMs(1000)
+              .setZkCacheInitTimeoutMs(1000)
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
@@ -527,12 +527,13 @@ public class RecoveryChunkImplTest {
       Tracing.newBuilder().build();
       testingServer = new TestingServer();
       AstraConfigs.ZookeeperConfig zkConfig =
-
+          AstraConfigs.ZookeeperConfig.newBuilder()
               .setZkConnectString(testingServer.getConnectString())
               .setZkPathPrefix("shouldHandleChunkLivecycle")
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
+              .setZkCacheInitTimeoutMs(1000)
               .build();
 
       registry = new SimpleMeterRegistry();

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -92,7 +92,7 @@ public class RecoveryChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -453,7 +453,7 @@ public class RecoveryChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -538,7 +538,7 @@ public class RecoveryChunkImplTest {
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
       snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, true);
+      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -88,6 +88,7 @@ public class RecoveryChunkImplTest {
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
+                  .setZkCacheInitTimeoutMs(1000)
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
@@ -443,12 +444,13 @@ public class RecoveryChunkImplTest {
       registry = new SimpleMeterRegistry();
 
       AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
+
               .setZkConnectString(testingServer.getConnectString())
               .setZkPathPrefix("shouldHandleChunkLivecycle")
               .setZkSessionTimeoutMs(1000)
               .setZkConnectionTimeoutMs(1000)
               .setSleepBetweenRetriesMs(1000)
+                  .setSleepBetweenRetriesMs(1000)
               .build();
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
@@ -525,7 +527,7 @@ public class RecoveryChunkImplTest {
       Tracing.newBuilder().build();
       testingServer = new TestingServer();
       AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
+
               .setZkConnectString(testingServer.getConnectString())
               .setZkPathPrefix("shouldHandleChunkLivecycle")
               .setZkSessionTimeoutMs(1000)

--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -130,7 +130,7 @@ public class CachingChunkManagerTest {
             .build();
 
     zkConfig =
-
+        AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("test")
             .setZkSessionTimeoutMs(1000)

--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -160,8 +160,8 @@ public class CachingChunkManagerTest {
   }
 
   private CacheNodeAssignment initAssignment(String snapshotId) throws Exception {
-    cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    cacheNodeAssignmentStore = new CacheNodeAssignmentStore(curatorFramework, zkConfig);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
     snapshotMetadataStore.createSync(new SnapshotMetadata(snapshotId, 1, 1, 0, "abcd", 29));
     CacheNodeAssignment newAssignment =
         new CacheNodeAssignment(

--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -130,7 +130,7 @@ public class CachingChunkManagerTest {
             .build();
 
     zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
+
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("test")
             .setZkSessionTimeoutMs(1000)

--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -72,6 +72,7 @@ public class CachingChunkManagerTest {
           .build();
 
   private AsyncCuratorFramework curatorFramework;
+  private AstraConfigs.ZookeeperConfig zkConfig;
   private CachingChunkManager<LogMessage> cachingChunkManager;
   private CacheNodeAssignmentStore cacheNodeAssignmentStore;
   private SnapshotMetadataStore snapshotMetadataStore;
@@ -128,13 +129,14 @@ public class CachingChunkManagerTest {
             .setS3Config(s3Config)
             .build();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("test")
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
@@ -143,6 +145,7 @@ public class CachingChunkManagerTest {
         new CachingChunkManager<>(
             meterRegistry,
             curatorFramework,
+            zkConfig,
             blobStore,
             SearchContext.fromConfig(AstraConfig.getCacheConfig().getServerConfig()),
             AstraConfig.getS3Config().getS3Bucket(),
@@ -271,7 +274,8 @@ public class CachingChunkManagerTest {
     enableDynamicChunksFlag();
 
     cachingChunkManager = initChunkManager();
-    CacheNodeMetadataStore cacheNodeMetadataStore = new CacheNodeMetadataStore(curatorFramework);
+    CacheNodeMetadataStore cacheNodeMetadataStore =
+        new CacheNodeMetadataStore(curatorFramework, zkConfig);
 
     List<CacheNodeMetadata> cacheNodeMetadatas = cacheNodeMetadataStore.listSync();
     assertThat(cachingChunkManager.getChunkList().size()).isEqualTo(0);

--- a/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
@@ -134,7 +134,7 @@ public class IndexingChunkManagerTest {
     localZkServer.start();
 
     zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
+
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
             .setZkSessionTimeoutMs(15000)

--- a/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
@@ -143,7 +143,7 @@ public class IndexingChunkManagerTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
   }
 
@@ -1251,7 +1251,8 @@ public class IndexingChunkManagerTest {
     // The stores are closed so temporarily re-create them so we can query the data in ZK.
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, false);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     assertThat(AstraMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
     List<SnapshotMetadata> snapshots =
         AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
@@ -1304,7 +1305,8 @@ public class IndexingChunkManagerTest {
     // All ephemeral data is ZK is deleted and no data or metadata is persisted.
     SearchMetadataStore searchMetadataStore =
         new SearchMetadataStore(curatorFramework, zkConfig, false);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
     assertThat(AstraMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
     searchMetadataStore.close();

--- a/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
@@ -134,12 +134,13 @@ public class IndexingChunkManagerTest {
     localZkServer.start();
 
     zkConfig =
-
+        AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
             .setZkSessionTimeoutMs(15000)
             .setZkConnectionTimeoutMs(1500)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -104,12 +104,13 @@ public class RecoveryChunkManagerTest {
     localZkServer.start();
 
     AstraConfigs.ZookeeperConfig zkConfig =
-
+        AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
             .setZkSessionTimeoutMs(15000)
             .setZkConnectionTimeoutMs(1500)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -113,7 +113,7 @@ public class RecoveryChunkManagerTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, false);
+    searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
     snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
   }
 

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -114,7 +114,7 @@ public class RecoveryChunkManagerTest {
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
     searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -104,7 +104,7 @@ public class RecoveryChunkManagerTest {
     localZkServer.start();
 
     AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
+
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
             .setZkSessionTimeoutMs(15000)

--- a/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -97,7 +97,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     localZkServer.start();
 
     zkConfig =
-
+        AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
             .setZkSessionTimeoutMs(15000)

--- a/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -103,6 +103,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             .setZkSessionTimeoutMs(15000)
             .setZkConnectionTimeoutMs(1500)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -72,6 +72,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
   private BlobStore blobStore;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
+  private AstraConfigs.ZookeeperConfig zkConfig;
 
   private static long MAX_BYTES_PER_CHUNK = 12000;
 
@@ -95,7 +96,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     localZkServer = new TestingServer();
     localZkServer.start();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
@@ -140,7 +141,8 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             listeningExecutorService,
             curatorFramework,
             searchContext,
-            AstraConfigUtil.makeIndexerConfig(TEST_PORT, 1000, 100));
+            AstraConfigUtil.makeIndexerConfig(TEST_PORT, 1000, 100),
+            zkConfig);
     chunkManager.startAsync();
     chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 

--- a/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -97,7 +97,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     localZkServer.start();
 
     zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
+
             .setZkConnectString(localZkServer.getConnectString())
             .setZkPathPrefix(ZK_PATH_PREFIX)
             .setZkSessionTimeoutMs(15000)

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
@@ -81,10 +81,10 @@ public class CacheNodeAssignmentServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework));
+    cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig));
     cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework, zkConfig));
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
@@ -64,6 +64,7 @@ public class CacheNodeAssignmentServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AstraConfigs.ManagerConfig.CacheNodeAssignmentServiceConfig cacheNodeAssignmentServiceConfig =
@@ -81,7 +82,7 @@ public class CacheNodeAssignmentServiceTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework));
-    cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework));
+    cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework, zkConfig));
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
     replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
   }

--- a/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
@@ -67,11 +67,11 @@ class ClusterHpaMetricServiceTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, zkConfig));
+    cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig));
     cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework, zkConfig));
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
     hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, zkConfig, true));
   }
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
@@ -62,6 +62,7 @@ class ClusterHpaMetricServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
@@ -69,9 +70,9 @@ class ClusterHpaMetricServiceTest {
     replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
     cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
     cacheNodeAssignmentStore = spy(new CacheNodeAssignmentStore(curatorFramework));
-    cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework));
+    cacheNodeMetadataStore = spy(new CacheNodeMetadataStore(curatorFramework, zkConfig));
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true));
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, zkConfig, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -60,11 +60,14 @@ public class RecoveryTaskAssignmentServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    recoveryTaskMetadataStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
-    recoveryNodeMetadataStore = spy(new RecoveryNodeMetadataStore(curatorFramework, true));
+    recoveryTaskMetadataStore =
+        spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, true));
+    recoveryNodeMetadataStore =
+        spy(new RecoveryNodeMetadataStore(curatorFramework, zkConfig, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
@@ -68,8 +68,8 @@ public class ReplicaAssignmentServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
@@ -65,6 +65,7 @@ public class ReplicaAssignmentServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
@@ -65,6 +65,7 @@ public class ReplicaCreationServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
@@ -48,6 +48,7 @@ public class ReplicaCreationServiceTest {
   private MeterRegistry meterRegistry;
 
   private AsyncCuratorFramework curatorFramework;
+  private AstraConfigs.ZookeeperConfig zkConfig;
   private SnapshotMetadataStore snapshotMetadataStore;
   private ReplicaMetadataStore replicaMetadataStore;
 
@@ -57,7 +58,7 @@ public class ReplicaCreationServiceTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("ReplicaCreatorServiceTest")
@@ -67,8 +68,8 @@ public class ReplicaCreationServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
   }
 
   @AfterEach
@@ -83,8 +84,10 @@ public class ReplicaCreationServiceTest {
 
   @Test
   public void shouldDoNothingIfReplicasAlreadyExist() throws Exception {
-    ReplicaMetadataStore replicaMetadataStore = new ReplicaMetadataStore(curatorFramework);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    ReplicaMetadataStore replicaMetadataStore =
+        new ReplicaMetadataStore(curatorFramework, zkConfig);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, zkConfig);
 
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
@@ -63,6 +63,7 @@ public class ReplicaDeletionServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
@@ -66,9 +66,9 @@ public class ReplicaDeletionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
-    cacheNodeMetadataStore = spy(new CacheNodeAssignmentStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
+    cacheNodeMetadataStore = spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
@@ -62,6 +62,7 @@ public class ReplicaEvictionServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
@@ -65,8 +65,8 @@ public class ReplicaEvictionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    cacheSlotMetadataStore = spy(new CacheSlotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
@@ -69,7 +69,7 @@ public class ReplicaRestoreServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
@@ -52,6 +52,7 @@ public class ReplicaRestoreServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     AstraConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =

--- a/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
@@ -81,6 +81,7 @@ public class SnapshotDeletionServiceTest {
             .setZkSessionTimeoutMs(2500)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
@@ -84,8 +84,8 @@ public class SnapshotDeletionServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
 
     s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
     blobStore = spy(new BlobStore(s3AsyncClient, S3_TEST_BUCKET));

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -83,6 +83,7 @@ public class AstraDistributedQueryServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -87,9 +87,9 @@ public class AstraDistributedQueryServiceTest {
 
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
 
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
     searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, zkConfig, true));
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, zkConfig, true);
 
     indexer1SearchContext = new SearchContext("indexer_host1", 10000);
     indexer2SearchContext = new SearchContext("indexer_host2", 10001);

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -88,7 +88,7 @@ public class AstraDistributedQueryServiceTest {
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
 
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, true));
+    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, zkConfig, true));
     datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
 
     indexer1SearchContext = new SearchContext("indexer_host1", 10000);

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -41,6 +41,7 @@ public class CacheSlotMetadataStoreTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     this.store = new CacheSlotMetadataStore(curatorFramework, zkConfig);

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -34,7 +34,7 @@ public class CacheSlotMetadataStoreTest {
     // flaky.
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zookeeperConfig =
+    AstraConfigs.ZookeeperConfig zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("Test")
@@ -42,8 +42,8 @@ public class CacheSlotMetadataStoreTest {
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
-    this.store = new CacheSlotMetadataStore(curatorFramework);
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    this.store = new CacheSlotMetadataStore(curatorFramework, zkConfig);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataStoreTest.java
@@ -45,7 +45,7 @@ public class AstraMetadataStoreTest {
             .setZkSessionTimeoutMs(10000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
-            .setZkCacheInitTimeoutMs(1000)
+            .setZkCacheInitTimeoutMs(10000)
             .build();
     this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }

--- a/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataStoreTest.java
@@ -29,7 +29,7 @@ public class AstraMetadataStoreTest {
 
   private AsyncCuratorFramework curatorFramework;
 
-  private AstraConfigs.ZookeeperConfig zookeeperConfig;
+  private AstraConfigs.ZookeeperConfig zkConfig;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -38,7 +38,7 @@ public class AstraMetadataStoreTest {
     // flaky.
     testingServer = new TestingServer();
 
-    zookeeperConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("Test")
@@ -46,7 +46,7 @@ public class AstraMetadataStoreTest {
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }
 
   @AfterEach
@@ -100,6 +100,7 @@ public class AstraMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             true,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -157,6 +158,7 @@ public class AstraMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             true,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -178,6 +180,7 @@ public class AstraMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             false,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -212,6 +215,7 @@ public class AstraMetadataStoreTest {
       public PersistentMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             false,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -223,6 +227,7 @@ public class AstraMetadataStoreTest {
       public EphemeralMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.EPHEMERAL,
             false,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -253,7 +258,7 @@ public class AstraMetadataStoreTest {
     // close curator, and then instantiate a new copy
     // This is because we cannot restart the closed curator.
     curatorFramework.unwrap().close();
-    curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
     try (AstraMetadataStore<TestMetadata> persistentStore = new PersistentMetadataStore()) {
       assertThat(persistentStore.getSync("foo")).isEqualTo(metadata1);
@@ -272,6 +277,7 @@ public class AstraMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             true,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -311,6 +317,7 @@ public class AstraMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             true,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -374,7 +381,12 @@ public class AstraMetadataStoreTest {
     class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
       public TestMetadataStore() {
         super(
-            curatorFramework, CreateMode.PERSISTENT, true, new CountingSerializer(), STORE_FOLDER);
+            curatorFramework,
+            zkConfig,
+            CreateMode.PERSISTENT,
+            true,
+            new CountingSerializer(),
+            STORE_FOLDER);
       }
     }
 
@@ -401,6 +413,7 @@ public class AstraMetadataStoreTest {
       public FastMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             true,
             new JacksonModelSerializer<>(TestMetadata.class),
@@ -430,7 +443,13 @@ public class AstraMetadataStoreTest {
 
     class SlowMetadataStore extends AstraMetadataStore<TestMetadata> {
       public SlowMetadataStore() {
-        super(curatorFramework, CreateMode.PERSISTENT, true, new SlowSerializer(), STORE_FOLDER);
+        super(
+            curatorFramework,
+            zkConfig,
+            CreateMode.PERSISTENT,
+            true,
+            new SlowSerializer(),
+            STORE_FOLDER);
       }
     }
 

--- a/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataStoreTest.java
@@ -45,6 +45,7 @@ public class AstraMetadataStoreTest {
             .setZkSessionTimeoutMs(10000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }

--- a/astra/src/test/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStoreTest.java
@@ -41,7 +41,7 @@ class AstraPartitioningMetadataStoreTest {
   private TestingServer testingServer;
   private AsyncCuratorFramework curatorFramework;
 
-  private AstraConfigs.ZookeeperConfig zookeeperConfig;
+  private AstraConfigs.ZookeeperConfig zkConfig;
 
   private static final String ZNODE_CONTAINER_CHECK_INTERVAL_MS = "znode.container.checkIntervalMs";
   private final Integer checkInterval = Integer.getInteger(ZNODE_CONTAINER_CHECK_INTERVAL_MS);
@@ -189,7 +189,7 @@ class AstraPartitioningMetadataStoreTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    zookeeperConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             // .setZkConnectString("127.0.0.1:2181")
             .setZkConnectString(testingServer.getConnectString())
@@ -198,7 +198,7 @@ class AstraPartitioningMetadataStoreTest {
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }
 
   @AfterEach
@@ -214,6 +214,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_znodes")) {
@@ -247,6 +248,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_create")) {
@@ -270,6 +272,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_update")) {
@@ -302,6 +305,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_delete")) {
@@ -328,6 +332,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_find")) {
@@ -350,6 +355,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_find_missing")) {
@@ -364,6 +370,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_snapshot_duplicate_create")) {
@@ -382,6 +389,7 @@ class AstraPartitioningMetadataStoreTest {
       public PersistentMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_persistent");
@@ -392,6 +400,7 @@ class AstraPartitioningMetadataStoreTest {
       public EphemeralMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.EPHEMERAL,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_ephemeral");
@@ -423,7 +432,7 @@ class AstraPartitioningMetadataStoreTest {
     // close curator, and then instantiate a new copy
     // This is because we cannot restart the closed curator.
     curatorFramework.unwrap().close();
-    curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
     try (AstraPartitioningMetadataStore<ExampleMetadata> persistentStore =
         new PersistentMetadataStore()) {
@@ -444,6 +453,7 @@ class AstraPartitioningMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_zk_reconnect");
@@ -482,6 +492,7 @@ class AstraPartitioningMetadataStoreTest {
     try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
         new AstraPartitioningMetadataStore<>(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_snapshot_listeners")) {
@@ -585,6 +596,7 @@ class AstraPartitioningMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new ExampleMetadataSerializer().toModelSerializer(),
             "/partitioned_add_remove_listeners");
@@ -629,6 +641,7 @@ class AstraPartitioningMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new FixedPartitionMetadataSerializer().toModelSerializer(),
             "/partitioned_duplicate_listeners");
@@ -695,6 +708,7 @@ class AstraPartitioningMetadataStoreTest {
       public TestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new FixedPartitionMetadataSerializer().toModelSerializer(),
             partitionStoreFolder);
@@ -706,6 +720,7 @@ class AstraPartitioningMetadataStoreTest {
       public FilteredTestMetadataStore() {
         super(
             curatorFramework,
+            zkConfig,
             CreateMode.PERSISTENT,
             new FixedPartitionMetadataSerializer().toModelSerializer(),
             partitionStoreFolder,

--- a/astra/src/test/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStoreTest.java
@@ -197,6 +197,7 @@ class AstraPartitioningMetadataStoreTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }

--- a/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -45,7 +45,7 @@ public class DatasetPartitionMetadataTest {
             .build();
 
     this.curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    this.datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    this.datasetMetadataStore = new DatasetMetadataStore(curatorFramework, zkConfig, true);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -42,6 +42,7 @@ public class DatasetPartitionMetadataTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     this.curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
@@ -17,6 +17,7 @@ public class SearchMetadataStoreTest {
   private SimpleMeterRegistry meterRegistry;
   private TestingServer testingServer;
   private AsyncCuratorFramework curatorFramework;
+  private AstraConfigs.ZookeeperConfig zkConfig;
   private SearchMetadataStore store;
 
   @BeforeEach
@@ -24,7 +25,7 @@ public class SearchMetadataStoreTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zookeeperConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testingServer.getConnectString())
             .setZkPathPrefix("Test")
@@ -32,7 +33,7 @@ public class SearchMetadataStoreTest {
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zookeeperConfig);
+    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }
 
   @AfterEach
@@ -45,7 +46,7 @@ public class SearchMetadataStoreTest {
 
   @Test
   public void testSearchMetadataStoreIsNotUpdatable() throws Exception {
-    store = new SearchMetadataStore(curatorFramework, true);
+    store = new SearchMetadataStore(curatorFramework, zkConfig, true);
     SearchMetadata searchMetadata = new SearchMetadata("test", "snapshot", "http");
     Throwable exAsync = catchThrowable(() -> store.updateAsync(searchMetadata));
     assertThat(exAsync).isInstanceOf(UnsupportedOperationException.class);

--- a/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
@@ -32,6 +32,7 @@ public class SearchMetadataStoreTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
   }

--- a/astra/src/test/java/com/slack/astra/recovery/RecoveryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/recovery/RecoveryServiceTest.java
@@ -157,7 +157,9 @@ public class RecoveryServiceTest {
     final Instant startTime = Instant.now();
     produceMessagesToKafka(kafkaServer.getBroker(), startTime, TEST_KAFKA_TOPIC_1, 0);
 
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig());
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
@@ -227,7 +229,9 @@ public class RecoveryServiceTest {
     await()
         .until(() -> localTestConsumer.getEndOffSetForPartition() == msgsToProduce + msgsToProduce);
 
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig());
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery service
@@ -309,7 +313,9 @@ public class RecoveryServiceTest {
     await()
         .until(() -> localTestConsumer.getEndOffSetForPartition() == msgsToProduce + msgsToProduce);
 
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig());
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery service
@@ -363,7 +369,9 @@ public class RecoveryServiceTest {
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name())
         .isNotEqualTo(fakeS3Bucket);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig());
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery
@@ -400,7 +408,9 @@ public class RecoveryServiceTest {
 
     assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig());
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
@@ -486,7 +496,9 @@ public class RecoveryServiceTest {
     // fakeS3Bucket is not present.
     assertThat(s3AsyncClient.listBuckets().get().buckets().size()).isEqualTo(1);
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
-    SnapshotMetadataStore snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework);
+    SnapshotMetadataStore snapshotMetadataStore =
+        new SnapshotMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig());
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();

--- a/astra/src/test/java/com/slack/astra/recovery/RecoveryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/recovery/RecoveryServiceTest.java
@@ -406,7 +406,8 @@ public class RecoveryServiceTest {
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig(), false);
     assertThat(AstraMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -418,7 +419,8 @@ public class RecoveryServiceTest {
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, false);
+        new RecoveryNodeMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig(), false);
     List<RecoveryNodeMetadata> recoveryNodes =
         AstraMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);
@@ -490,7 +492,8 @@ public class RecoveryServiceTest {
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig(), false);
     assertThat(AstraMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -502,7 +505,8 @@ public class RecoveryServiceTest {
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, false);
+        new RecoveryNodeMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig(), false);
     List<RecoveryNodeMetadata> recoveryNodes =
         AstraMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);
@@ -654,7 +658,8 @@ public class RecoveryServiceTest {
 
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, false);
+        new RecoveryTaskMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig(), false);
     assertThat(AstraMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 0, 0, Instant.now().toEpochMilli());
@@ -666,7 +671,8 @@ public class RecoveryServiceTest {
 
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
-        new RecoveryNodeMetadataStore(curatorFramework, false);
+        new RecoveryNodeMetadataStore(
+            curatorFramework, astraCfg.getMetadataStoreConfig().getZookeeperConfig(), false);
     List<RecoveryNodeMetadata> recoveryNodes =
         AstraMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);

--- a/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
@@ -81,6 +81,7 @@ public class AstraIndexerTest {
   private TestKafkaServer kafkaServer;
   private TestingServer testZKServer;
   private AsyncCuratorFramework curatorFramework;
+  private AstraConfigs.ZookeeperConfig zkConfig;
   private SnapshotMetadataStore snapshotMetadataStore;
   private RecoveryTaskMetadataStore recoveryTaskStore;
   private SearchMetadataStore searchMetadataStore;
@@ -93,13 +94,14 @@ public class AstraIndexerTest {
 
     testZKServer = new TestingServer();
     // Metadata store
-    AstraConfigs.ZookeeperConfig zkConfig =
+    zkConfig =
         AstraConfigs.ZookeeperConfig.newBuilder()
             .setZkConnectString(testZKServer.getConnectString())
             .setZkPathPrefix("indexerTest")
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
@@ -120,7 +122,7 @@ public class AstraIndexerTest {
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, false));
+    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, false));
     searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, false));
 
     kafkaServer = new TestKafkaServer();
@@ -172,6 +174,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -209,6 +212,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -255,6 +259,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -290,6 +295,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -338,6 +344,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -388,6 +395,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(50),
             getKafkaConfig(),
             metricsRegistry);
@@ -446,6 +454,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(50),
             getKafkaConfig(),
             metricsRegistry);
@@ -508,6 +517,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -562,6 +572,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
+            zkConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);

--- a/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
@@ -122,7 +122,7 @@ public class AstraIndexerTest {
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
     recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, false));
     searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, zkConfig, false));
 

--- a/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
@@ -116,14 +116,15 @@ public class AstraIndexerTest {
             100,
             new SearchContext(TEST_HOST, TEST_PORT),
             curatorFramework,
-            indexerConfig);
+            indexerConfig,
+            zkConfig);
 
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
     recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, false));
-    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, false));
+    searchMetadataStore = spy(new SearchMetadataStore(curatorFramework, zkConfig, false));
 
     kafkaServer = new TestKafkaServer();
   }
@@ -564,7 +565,8 @@ public class AstraIndexerTest {
             100,
             new SearchContext(TEST_HOST, TEST_PORT),
             curatorFramework,
-            makeIndexerConfig());
+            makeIndexerConfig(),
+            zkConfig);
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 

--- a/astra/src/test/java/com/slack/astra/server/AstraTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraTest.java
@@ -124,7 +124,7 @@ public class AstraTest {
             .setSleepBetweenRetriesMs(1000)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, zkConfig, true);
     final DatasetPartitionMetadata partition =
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);

--- a/astra/src/test/java/com/slack/astra/server/AstraTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraTest.java
@@ -122,6 +122,7 @@ public class AstraTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     datasetMetadataStore = new DatasetMetadataStore(curatorFramework, zkConfig, true);

--- a/astra/src/test/java/com/slack/astra/server/BulkIngestApiTest.java
+++ b/astra/src/test/java/com/slack/astra/server/BulkIngestApiTest.java
@@ -79,6 +79,7 @@ public class BulkIngestApiTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
@@ -103,7 +104,7 @@ public class BulkIngestApiTest {
             .setRateLimiterMaxBurstSeconds(1)
             .build();
 
-    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, true);
+    datasetMetadataStore = new DatasetMetadataStore(curatorFramework, zkConfig, true);
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
             INDEX_NAME,

--- a/astra/src/test/java/com/slack/astra/server/HpaMetricPublisherServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/server/HpaMetricPublisherServiceTest.java
@@ -39,10 +39,11 @@ class HpaMetricPublisherServiceTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(new SimpleMeterRegistry(), zkConfig);
-    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, true));
+    hpaMetricMetadataStore = spy(new HpaMetricMetadataStore(curatorFramework, zkConfig, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
+++ b/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
@@ -77,9 +77,9 @@ public class ManagerApiGrpcTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    datasetMetadataStore = spy(new DatasetMetadataStore(curatorFramework, true));
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework));
+    datasetMetadataStore = spy(new DatasetMetadataStore(curatorFramework, zkConfig, true));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
+    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig));
 
     AstraConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         AstraConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()

--- a/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
+++ b/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
@@ -74,6 +74,7 @@ public class ManagerApiGrpcTest {
             .setZkSessionTimeoutMs(30000)
             .setZkConnectionTimeoutMs(30000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);

--- a/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
+++ b/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
@@ -70,6 +70,7 @@ public class RecoveryTaskCreatorTest {
             .setZkSessionTimeoutMs(1000)
             .setZkConnectionTimeoutMs(1000)
             .setSleepBetweenRetriesMs(500)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
 
     // Default behavior
@@ -83,7 +84,7 @@ public class RecoveryTaskCreatorTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
-    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, true));
+    recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
+++ b/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
@@ -83,7 +83,7 @@ public class RecoveryTaskCreatorTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework));
+    snapshotMetadataStore = spy(new SnapshotMetadataStore(curatorFramework, zkConfig));
     recoveryTaskStore = spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, true));
   }
 

--- a/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
@@ -68,6 +68,7 @@ public class AstraConfigUtil {
             .setZkSessionTimeoutMs(15000)
             .setZkConnectionTimeoutMs(15000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder().setZookeeperConfig(zkConfig).build();

--- a/astra/src/test/java/com/slack/astra/testlib/ChunkManagerUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/ChunkManagerUtil.java
@@ -60,6 +60,7 @@ public class ChunkManagerUtil<T> {
             .setZkSessionTimeoutMs(30000)
             .setZkConnectionTimeoutMs(30000)
             .setSleepBetweenRetriesMs(1000)
+            .setZkCacheInitTimeoutMs(1000)
             .build();
     AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
@@ -72,7 +73,8 @@ public class ChunkManagerUtil<T> {
         maxMessagesPerChunk,
         new SearchContext(TEST_HOST, TEST_PORT),
         curatorFramework,
-        indexerConfig);
+        indexerConfig,
+        zkConfig);
   }
 
   public ChunkManagerUtil(
@@ -84,7 +86,8 @@ public class ChunkManagerUtil<T> {
       long maxMessagesPerChunk,
       SearchContext searchContext,
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.IndexerConfig indexerConfig)
+      AstraConfigs.IndexerConfig indexerConfig,
+      AstraConfigs.ZookeeperConfig zkConfig)
       throws Exception {
 
     tempFolder = Files.createTempDir(); // TODO: don't use beta func.
@@ -111,7 +114,8 @@ public class ChunkManagerUtil<T> {
             MoreExecutors.newDirectExecutorService(),
             curatorFramework,
             searchContext,
-            indexerConfig);
+            indexerConfig,
+            zkConfig);
   }
 
   public void close() throws IOException, TimeoutException {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,6 +58,7 @@ metadataStoreConfig:
     zkPathPrefix: ${ASTRA_ZK_PATH_PREFIX:-ASTRA}
     zkSessionTimeoutMs: ${ASTRA_ZK_SESSION_TIMEOUT_MS:-5000}
     zkConnectionTimeoutMs: ${ASTRA_ZK_CONNECT_TIMEOUT_MS:-500}
+    zkCacheInitTimeoutMs: ${ASTRA_ZK_CACHE_INIT_TIMEOUT_MS:-30000}
     sleepBetweenRetriesMs: ${ASTRA_ZK_SLEEP_RETRIES_MS:-100}
 
 cacheConfig:


### PR DESCRIPTION
###  Summary

Thread the Zookeeper config through to the `AstraMetadataStore` so we can make the timeout for Zookeeper cache init configurable. 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
