### PR TITLE
Remove listsync call from redaction

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionStoredFieldVisitor.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionStoredFieldVisitor.java
@@ -29,27 +29,27 @@ class RedactionStoredFieldVisitor extends StoredFieldVisitor {
     this.delegate = delegate;
 
     Map<String, FieldRedactionMetadata> fieldRedactionsMap = new HashMap<>();
-    fieldRedactionMetadataStore
-        .listSync()
-        .forEach(
-            redaction -> {
-              fieldRedactionsMap.put(redaction.getName(), redaction);
-            });
+//    fieldRedactionMetadataStore
+//        .listSync()
+//        .forEach(
+//            redaction -> {
+//              fieldRedactionsMap.put(redaction.getName(), redaction);
+//            });
 
     // TODO - do we need the listener at all if we listsync at the field level anyway?
-    AstraMetadataStoreChangeListener<FieldRedactionMetadata> listener =
-        new AstraMetadataStoreChangeListener() {
-          @Override
-          public void onMetadataStoreChanged(Object model) {
-            fieldRedactionMetadataStore
-                .listSync()
-                .forEach(
-                    redaction -> {
-                      fieldRedactionsMap.put(redaction.getName(), redaction);
-                    });
-          }
-        };
-    fieldRedactionMetadataStore.addListener(listener);
+//    AstraMetadataStoreChangeListener<FieldRedactionMetadata> listener =
+//        new AstraMetadataStoreChangeListener() {
+//          @Override
+//          public void onMetadataStoreChanged(Object model) {
+//            fieldRedactionMetadataStore
+//                .listSync()
+//                .forEach(
+//                    redaction -> {
+//                      fieldRedactionsMap.put(redaction.getName(), redaction);
+//                    });
+//          }
+//        };
+//    fieldRedactionMetadataStore.addListener(listener);
     this.fieldRedactionsMap = fieldRedactionsMap;
   }
 


### PR DESCRIPTION
###  Summary

Temporarily remove the `listsync` call from the `RedactionStoredFieldVisitor` to see if that is what is bringing down cache nodes on large searches. 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
