### PR TITLE
Fix Redaction

### DIFF
--- a/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionLeafReader.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionLeafReader.java
@@ -1,6 +1,7 @@
 package com.slack.astra.logstore.search.fieldRedaction;
 
 import com.slack.astra.metadata.fieldredaction.FieldRedactionMetadata;
+import com.slack.astra.metadata.fieldredaction.FieldRedactionMetadataStore;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.lucene.codecs.StoredFieldsReader;
@@ -16,11 +17,13 @@ import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
  */
 class RedactionLeafReader extends SequentialStoredFieldsLeafReader {
   private final HashMap<String, FieldRedactionMetadata> fieldRedactionsMap;
+  private final FieldRedactionMetadataStore fieldRedactionMetadataStore;
 
   public RedactionLeafReader(
-      LeafReader in, HashMap<String, FieldRedactionMetadata> fieldRedactionsMap) {
+      LeafReader in, FieldRedactionMetadataStore fieldRedactionMetadataStore) {
     super(in);
-    this.fieldRedactionsMap = fieldRedactionsMap;
+    this.fieldRedactionMetadataStore = fieldRedactionMetadataStore;
+    this.fieldRedactionsMap = new HashMap<>();
   }
 
   @Override
@@ -36,12 +39,14 @@ class RedactionLeafReader extends SequentialStoredFieldsLeafReader {
   // RedactionStoredFieldVisitor can be called here or in the RedactedFieldReader
   @Override
   public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+    getRedactedFields();
     visitor = new RedactionStoredFieldVisitor(visitor, fieldRedactionsMap);
     in.document(docID, visitor);
   }
 
   @Override
   protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+    getRedactedFields();
     return new RedactedFieldReader(reader, fieldRedactionsMap);
   }
 
@@ -58,5 +63,19 @@ class RedactionLeafReader extends SequentialStoredFieldsLeafReader {
   @Override
   protected void doClose() throws IOException {
     super.doClose();
+  }
+
+  // We want to put the ZK store into a hashmap (low-cost lookups for redacted fields).
+  // Because we do not have a listener on the ZK store, we want to put the values into the map
+  // per-search, which happens when document() or doGetSequentialStoredFieldsReader() is called.
+  protected void getRedactedFields() {
+    if (this.fieldRedactionMetadataStore != null) {
+      fieldRedactionMetadataStore
+          .listSync()
+          .forEach(
+              redaction -> {
+                fieldRedactionsMap.put(redaction.getName(), redaction);
+              });
+    }
   }
 }

--- a/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionSubReaderWrapper.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/fieldRedaction/RedactionSubReaderWrapper.java
@@ -1,8 +1,6 @@
 package com.slack.astra.logstore.search.fieldRedaction;
 
-import com.slack.astra.metadata.fieldredaction.FieldRedactionMetadata;
 import com.slack.astra.metadata.fieldredaction.FieldRedactionMetadataStore;
-import java.util.HashMap;
 import org.apache.lucene.index.FilterDirectoryReader;
 import org.apache.lucene.index.LeafReader;
 
@@ -11,22 +9,14 @@ import org.apache.lucene.index.LeafReader;
  * reader, and creates a RedactionLeafReader.
  */
 class RedactionSubReaderWrapper extends FilterDirectoryReader.SubReaderWrapper {
-  private final HashMap<String, FieldRedactionMetadata> fieldRedactionsMap;
+  private final FieldRedactionMetadataStore fieldRedactionMetadataStore;
 
   public RedactionSubReaderWrapper(FieldRedactionMetadataStore fieldRedactionMetadataStore) {
-    this.fieldRedactionsMap = new HashMap<>();
-    if (fieldRedactionMetadataStore != null) {
-      fieldRedactionMetadataStore
-          .listSync()
-          .forEach(
-              redaction -> {
-                fieldRedactionsMap.put(redaction.getName(), redaction);
-              });
-    }
+    this.fieldRedactionMetadataStore = fieldRedactionMetadataStore;
   }
 
   @Override
   public LeafReader wrap(LeafReader reader) {
-    return new RedactionLeafReader(reader, this.fieldRedactionsMap);
+    return new RedactionLeafReader(reader, this.fieldRedactionMetadataStore);
   }
 }

--- a/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
@@ -136,17 +136,15 @@ public class LogIndexSearcherImplTest {
               .build();
 
       // add redaction between log being added and searched to test that the redaction map gets
-      // updated
-      // a previous change passed this test when the redaction was added before the DirectoryReader
-      // was created and redaction still did not work
+      // updated a previous change passed this test when the redaction was added before the
+      // DirectoryReade rwas created and redaction still did not work
       fieldRedactionMetadataStore.createSync(
           new FieldRedactionMetadata(redactionName, fieldName, start, end));
 
-            await()
-                    .until(
-                            () ->
-
-       AstraMetadataTestUtils.listSyncUncached(fieldRedactionMetadataStore).size() == 1);
+      await()
+          .until(
+              () ->
+                  AstraMetadataTestUtils.listSyncUncached(fieldRedactionMetadataStore).size() == 1);
 
       List<LogMessage> messages =
           featureFlagEnabledStrictLogStore.logSearcher.search(

--- a/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
@@ -110,20 +110,9 @@ public class LogIndexSearcherImplTest {
       long start = Instant.now().minus(1, ChronoUnit.DAYS).toEpochMilli();
       long end = Instant.now().plus(2, ChronoUnit.DAYS).toEpochMilli();
 
-      //      await()
-      //              .until(
-      //                      () ->
-      //
-      // AstraMetadataTestUtils.listSyncUncached(fieldRedactionMetadataStore).size() == 0);
       // search
       TemporaryLogStoreAndSearcherExtension featureFlagEnabledStrictLogStore =
           new TemporaryLogStoreAndSearcherExtension(true, fieldRedactionMetadataStore);
-
-      //      await()
-      //              .until(
-      //                      () ->
-      //
-      // AstraMetadataTestUtils.listSyncUncached(fieldRedactionMetadataStore).size() == 1);
 
       Instant time = Instant.now();
       featureFlagEnabledStrictLogStore.logStore.addMessage(SpanUtil.makeSpan(1, time));
@@ -152,6 +141,12 @@ public class LogIndexSearcherImplTest {
       // was created and redaction still did not work
       fieldRedactionMetadataStore.createSync(
           new FieldRedactionMetadata(redactionName, fieldName, start, end));
+
+            await()
+                    .until(
+                            () ->
+
+       AstraMetadataTestUtils.listSyncUncached(fieldRedactionMetadataStore).size() == 1);
 
       List<LogMessage> messages =
           featureFlagEnabledStrictLogStore.logSearcher.search(

--- a/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
@@ -136,8 +136,9 @@ public class LogIndexSearcherImplTest {
               .build();
 
       // add redaction between log being added and searched to test that the redaction map gets
-      // updated a previous change passed this test when the redaction was added before the
-      // DirectoryReade rwas created and redaction still did not work
+      // updated
+      // a previous change passed this test when the redaction was added before the
+      // DirectoryReader was created and redaction still did not work
       fieldRedactionMetadataStore.createSync(
           new FieldRedactionMetadata(redactionName, fieldName, start, end));
 


### PR DESCRIPTION
###  Summary

The previous PR https://github.com/slackhq/astra/pull/1238 passed all the tests but was putting the ZK store into a hashmap at the reader level, not per-search, so any redactions added after a node was already up were not taking affect. This PR creates the hashmap at a per-search level and updates a test to handle that case. 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
