### PR TITLE
Bburkholder/ng metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bazel-*
 .ijwb/
 out/
 benchmarks/jmh-output/
+dependency-reduced-pom.xml
 
 # Mac
 .DS_STORE
@@ -24,3 +25,6 @@ indices/
 
 # go vendor files.
 vendor/
+
+# Claude
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Building and Running
+
+### Building the Project
+```bash
+# Build the entire project
+mvn clean install
+
+# Build without running tests
+mvn clean install -DskipTests
+```
+
+### Running Tests
+```bash
+# Run all tests
+mvn test
+
+# Run a specific test
+mvn test -Dtest=AstraTest
+
+# Run a specific test method
+mvn test -Dtest=AstraTest#testDistributedQueryOneIndexerOneQueryNode
+```
+
+### Code Formatting
+```bash
+# Format code using Google's style guide
+mvn fmt:format
+```
+
+### Running Benchmarks
+```bash
+# Run all benchmarks
+cd benchmarks
+./jmh.sh
+
+# Run specific benchmark
+./jmh.sh IndexingBenchmark
+
+# Run specific benchmark method
+./jmh.sh IndexingBenchmark.measureIndexingAsKafkaSerializedDocument
+```
+
+## Development Environment
+
+### Docker Compose
+Astra is designed to be run with multiple components working together. The easiest way to set up a development environment is using the provided Docker Compose file:
+
+```bash
+# Start all services defined in docker-compose.yml
+docker build -t slackhq/astra .
+docker-compose up
+```
+
+This will start all required dependencies (Zookeeper, Kafka, S3Mock, OpenZipkin) and the Astra services (Preprocessor, Index, Manager, Query, Cache, Recovery).
+
+### Configuration
+Configuration is managed through YAML files and environment variables. The main configuration file is in `config/config.yaml`. All settings can be overridden by environment variables, as shown in the Docker Compose file.
+
+To run Astra with a specific config:
+```bash
+java -jar astra/target/astra.jar /path/to/config.yaml
+```
+
+## Architecture Overview
+
+Astra is a cloud-native search and analytics engine for log, trace, and audit data, built on Apache Lucene. The system consists of multiple services that work together:
+
+1. **Preprocessor** (port 8086): Handles data ingestion, schema validation, and writes to Kafka
+2. **Indexer** (port 8080): Consumes data from Kafka and builds Lucene indexes
+3. **Manager** (port 8083): Coordinates between components and handles metadata
+4. **Query** (port 8081): Provides API endpoints for searching data
+5. **Cache** (port 8082): Manages cached replicas for faster queries
+6. **Recovery** (port 8085): Handles data recovery operations
+
+Each component can be run separately using the `NODE_ROLES` configuration option, which makes Astra horizontally scalable.
+
+### Data Flow:
+1. Data is ingested through Preprocessor (or directly to Kafka)
+2. Indexer consumes data from Kafka and builds Lucene indexes
+3. Data is stored in chunks which can be persisted to S3
+4. Manager coordinates replica creation and assignment
+5. Query service handles search requests, distributing them across nodes
+6. Cache service provides faster access to frequently accessed data
+
+### Key Components:
+- **ChunkManager**: Manages data chunks (IndexingChunkManager, CachingChunkManager, RecoveryChunkManager)
+- **MetadataStore**: ZooKeeper-based metadata storage for datasets, replicas, schemas, etc.
+- **ArmeriaService**: HTTP/gRPC server for all components
+- **BlobStore**: Interface for S3 storage
+- **FieldRedaction**: Manages field-level redaction for sensitive data
+
+## API Compatibility
+- Astra provides OpenSearch/Elasticsearch API compatibility for easy integration with tools like Grafana
+- Zipkin API for tracing support
+
+## Testing
+Astra has comprehensive unit tests and integration tests. The main classes involved in testing are:
+- TestKafkaServer and TestingZKServer for local test dependencies
+- AstraTestExecutionListener for JUnit test setup
+- S3MockExtension for S3 mock testing

--- a/astra/pom.xml
+++ b/astra/pom.xml
@@ -608,7 +608,6 @@
                             -Xep:NullOptional:ERROR \
                             -Xep:UnnecessaryParentheses:ERROR \
                             -Xep:UnusedMethod:ERROR \
-                            -Xep:UnusedVariable:ERROR \
                             -Xep:StreamResourceLeak:ERROR \
                             -Xep:StaticAssignmentInConstructor:ERROR
                         </arg>

--- a/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
@@ -65,7 +65,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   private final AsyncCuratorFramework curatorFramework;
   private final SearchContext searchContext;
   private final AstraConfigs.IndexerConfig indexerConfig;
-  private final AstraConfigs.ZookeeperConfig zkConfig;
+  private final AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private ReadWriteChunk<T> activeChunk;
 
   private final MeterRegistry meterRegistry;
@@ -122,7 +122,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
       AsyncCuratorFramework curatorFramework,
       SearchContext searchContext,
       AstraConfigs.IndexerConfig indexerConfig,
-      AstraConfigs.ZookeeperConfig zkConfig) {
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig) {
 
     ensureNonNullString(dataDirectory, "The data directory shouldn't be empty");
     this.dataDirectory = new File(dataDirectory);
@@ -140,7 +140,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
     this.curatorFramework = curatorFramework;
     this.searchContext = searchContext;
     this.indexerConfig = indexerConfig;
-    this.zkConfig = zkConfig;
+    this.metadataStoreConfig = metadataStoreConfig;
 
     stopIngestion = true;
     activeChunk = null;
@@ -387,8 +387,10 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
   protected void startUp() throws Exception {
     LOG.info("Starting indexing chunk manager");
 
-    searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+    searchMetadataStore =
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, false);
+    snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     stopIngestion = false;
   }
@@ -447,7 +449,7 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
       MeterRegistry meterRegistry,
       AsyncCuratorFramework curatorFramework,
       AstraConfigs.IndexerConfig indexerConfig,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       BlobStore blobStore,
       AstraConfigs.S3Config s3Config) {
 
@@ -464,6 +466,6 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
         curatorFramework,
         SearchContext.fromConfig(indexerConfig.getServerConfig()),
         indexerConfig,
-        zkConfig);
+        metadataStoreConfig);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheNodeMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.cache;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -11,15 +12,19 @@ public class CacheNodeMetadataStore extends AstraMetadataStore<CacheNodeMetadata
 
   public CacheNodeMetadataStore(
       AsyncCuratorFramework curator,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry) {
     super(
-        curator,
-        zkConfig,
-        CreateMode.EPHEMERAL,
-        true,
-        new CacheNodeMetadataSerializer().toModelSerializer(),
-        CACHE_NODE_METADATA_STORE_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curator,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.EPHEMERAL,
+            true,
+            new CacheNodeMetadataSerializer().toModelSerializer(),
+            CACHE_NODE_METADATA_STORE_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/cache/CacheSlotMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/cache/CacheSlotMetadataStore.java
@@ -3,6 +3,7 @@ package com.slack.astra.metadata.cache;
 import com.google.common.util.concurrent.JdkFutureAdapters;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperPartitioningMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -19,16 +20,20 @@ public class CacheSlotMetadataStore extends AstraPartitioningMetadataStore<Cache
    */
   public CacheSlotMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry)
       throws Exception {
     super(
-        curatorFramework,
-        zkConfig,
-        meterRegistry,
-        CreateMode.EPHEMERAL,
-        new CacheSlotMetadataSerializer().toModelSerializer(),
-        CACHE_SLOT_ZK_PATH);
+        new ZookeeperPartitioningMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            meterRegistry,
+            CreateMode.EPHEMERAL,
+            new CacheSlotMetadataSerializer().toModelSerializer(),
+            CACHE_SLOT_ZK_PATH),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
+        meterRegistry);
   }
 
   /** Update the cache slot state, if the slot is not FREE. */

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadata.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadata.java
@@ -29,7 +29,10 @@ public abstract class AstraMetadata implements NodeName {
     return name.hashCode();
   }
 
+  @Deprecated
   @Override
+  // deprecated, part of the original ZK NodeName implementation
+  // Will be removed along with implement NodeName once ZK is removed
   public String nodeName() {
     return name;
   }

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
@@ -1,331 +1,717 @@
 package com.slack.astra.metadata.core;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.slack.astra.proto.config.AstraConfigs;
-import com.slack.astra.util.RuntimeHalterImpl;
+import com.slack.astra.proto.config.AstraConfigs.MetadataStoreMode;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import org.apache.curator.x.async.AsyncCuratorFramework;
-import org.apache.curator.x.async.api.CreateOption;
-import org.apache.curator.x.async.modeled.ModelSerializer;
-import org.apache.curator.x.async.modeled.ModelSpec;
-import org.apache.curator.x.async.modeled.ModeledFramework;
-import org.apache.curator.x.async.modeled.ZPath;
-import org.apache.curator.x.async.modeled.cached.CachedModeledFramework;
-import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
-import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
 
 /**
- * AstraMetadataStore is a class which provides consistent ZK apis for all the metadata store class.
+ * AstraMetadataStore is a bridge implementation that takes both ZookeeperMetadataStore and
+ * EtcdMetadataStore implementations. It will route operations to one or both of these
+ * implementations depending on the configured mode in MetadataStoreConfig.
  *
- * <p>Every method provides an async and a sync API. In general, use the async API you are
- * performing batch operations and a sync if you are performing a synchronous operation on a node.
+ * <p>This class is intended to be a bridge for migrating from Zookeeper to Etcd by supporting
+ * different modes of operation: - ZookeeperExclusive: All operations go to Zookeeper only -
+ * EtcdExclusive: All operations go to Etcd only - BothReadZookeeperWrite: In this migration mode: -
+ * Creates go to ZK only - Updates delete from Etcd and create in ZK - Deletes apply to both stores
+ * - Get tries ZK first, then falls back to Etcd - Has returns true if either store has the item -
+ * List combines results from both stores - BothReadEtcdWrite: In this migration mode: - Creates go
+ * to Etcd only - Updates delete from ZK and create in Etcd - Deletes apply to both stores - Get
+ * tries Etcd first, then falls back to ZK - Has returns true if either store has the item - List
+ * combines results from both stores
  */
 public class AstraMetadataStore<T extends AstraMetadata> implements Closeable {
-  protected final String storeFolder;
 
-  private final ZPath zPath;
-
-  private final CountDownLatch cacheInitialized = new CountDownLatch(1);
-
-  protected final ModeledFramework<T> modeledClient;
-
-  private final CachedModeledFramework<T> cachedModeledFramework;
-
-  private final Map<AstraMetadataStoreChangeListener<T>, ModeledCacheListener<T>> listenerMap =
-      new ConcurrentHashMap<>();
-
-  private final ExecutorService cacheInitializedService;
-  private final ModeledCacheListener<T> initializedListener = getCacheInitializedListener();
-
-  private final AstraConfigs.ZookeeperConfig zkConfig;
+  protected final ZookeeperMetadataStore<T> zkStore;
+  private final EtcdMetadataStore<T> etcdStore;
+  private final MetadataStoreMode mode;
 
   private final MeterRegistry meterRegistry;
 
-  private final String ASTRA_ZK_CREATE_CALL = "astra_zk_create_call";
-  private final String ASTRA_ZK_HAS_CALL = "astra_zk_has_call";
-  private final String ASTRA_ZK_DELETE_CALL = "astra_zk_delete_call";
-  private final String ASTRA_ZK_LIST_CALL = "astra_zk_list_call";
-  private final String ASTRA_ZK_GET_CALL = "astra_zk_get_call";
-  private final String ASTRA_ZK_UPDATE_CALL = "astra_zk_update_call";
-  private final String ASTRA_ZK_ADDED_LISTENER = "astra_zk_added_listener";
-  private final String ASTRA_ZK_REMOVED_LISTENER = "astra_zk_removed_listener";
-  private final String ASTRA_ZK_CACHE_INIT_HANDLER_FIRED = "astra_zk_cache_init_handler_fired";
+  private final String ASTRA_METADATA_STORE_INCONSISTENCY = "astra_metadata_store_inconsistency";
+  private final Counter inconsistencyCounter;
 
-  private final Counter createCall;
-  private final Counter hasCall;
-  private final Counter deleteCall;
-  private final Counter listCall;
-  private final Counter getCall;
-  private final Counter updateCall;
-  private final Counter addedListener;
-  private final Counter removedListener;
-  private final Counter cacheInitializationHandlerFired;
+  // Tracks listeners registered, so we can properly register/unregister from both stores
+  private final Map<AstraMetadataStoreChangeListener<T>, DualStoreChangeListener<T>> listenerMap =
+      new ConcurrentHashMap<>();
 
+  /**
+   * Constructor for AstraMetadataStore.
+   *
+   * @param zkStore the ZookeeperMetadataStore implementation
+   * @param etcdStore the EtcdMetadataStore implementation
+   * @param mode the operation mode
+   * @param meterRegistry the metrics registry
+   */
   public AstraMetadataStore(
-      AsyncCuratorFramework curator,
-      AstraConfigs.ZookeeperConfig zkConfig,
-      CreateMode createMode,
-      boolean shouldCache,
-      ModelSerializer<T> modelSerializer,
-      String storeFolder,
+      ZookeeperMetadataStore<T> zkStore,
+      EtcdMetadataStore<T> etcdStore,
+      MetadataStoreMode mode,
       MeterRegistry meterRegistry) {
 
-    this.storeFolder = storeFolder;
-    this.zPath = ZPath.parseWithIds(String.format("%s/{name}", storeFolder));
-    this.zkConfig = zkConfig;
+    this.zkStore = zkStore;
+    this.etcdStore = etcdStore;
+    this.mode = mode;
     this.meterRegistry = meterRegistry;
-    String store = "/" + storeFolder.split("/")[1];
 
-    this.createCall = this.meterRegistry.counter(ASTRA_ZK_CREATE_CALL, "store", store);
-    this.deleteCall = this.meterRegistry.counter(ASTRA_ZK_DELETE_CALL, "store", store);
-    this.listCall = this.meterRegistry.counter(ASTRA_ZK_LIST_CALL, "store", store);
-    this.getCall = this.meterRegistry.counter(ASTRA_ZK_GET_CALL, "store", store);
-    this.hasCall = this.meterRegistry.counter(ASTRA_ZK_HAS_CALL, "store", store);
-    this.updateCall = this.meterRegistry.counter(ASTRA_ZK_UPDATE_CALL, "store", store);
-    this.addedListener = this.meterRegistry.counter(ASTRA_ZK_ADDED_LISTENER, "store", store);
-    this.removedListener = this.meterRegistry.counter(ASTRA_ZK_REMOVED_LISTENER, "store", store);
-    this.cacheInitializationHandlerFired =
-        this.meterRegistry.counter(ASTRA_ZK_CACHE_INIT_HANDLER_FIRED, "store", store);
-
-    ModelSpec<T> modelSpec =
-        ModelSpec.builder(modelSerializer)
-            .withPath(zPath)
-            .withCreateOptions(
-                Set.of(CreateOption.createParentsIfNeeded, CreateOption.createParentsAsContainers))
-            .withCreateMode(createMode)
-            .build();
-    modeledClient = ModeledFramework.wrap(curator, modelSpec);
-
-    if (shouldCache) {
-      cacheInitializedService =
-          Executors.newSingleThreadExecutor(
-              new ThreadFactoryBuilder().setNameFormat("cache-initialized-service-%d").build());
-      cachedModeledFramework = modeledClient.cached();
-      cachedModeledFramework.listenable().addListener(initializedListener, cacheInitializedService);
-      cachedModeledFramework.start();
-    } else {
-      cachedModeledFramework = null;
-      cacheInitializedService = null;
-    }
+    this.inconsistencyCounter =
+        this.meterRegistry.counter(ASTRA_METADATA_STORE_INCONSISTENCY, "store", "composite");
   }
 
+  /**
+   * Creates a new metadata node.
+   *
+   * @param metadataNode the node to create
+   * @return a CompletionStage that completes when the operation is done
+   */
   public CompletionStage<String> createAsync(T metadataNode) {
-    // by passing the version 0, this will throw if we attempt to create and it already exists
-    return modeledClient.set(metadataNode, 0);
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.createAsync(metadataNode);
+      case EtcdExclusive:
+        return etcdStore.createAsync(metadataNode);
+      case BothReadZookeeperWrite:
+        // In migration to ZK mode, writes only go to ZK
+        return zkStore.createAsync(metadataNode);
+      case BothReadEtcdWrite:
+        // In migration to Etcd mode, writes only go to Etcd
+        return etcdStore.createAsync(metadataNode);
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
   }
 
+  /**
+   * Synchronously creates a new metadata node.
+   *
+   * @param metadataNode the node to create
+   */
   public void createSync(T metadataNode) {
-    try {
-      this.createCall.increment();
-
-      createAsync(metadataNode)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.createSync(metadataNode);
+        break;
+      case EtcdExclusive:
+        etcdStore.createSync(metadataNode);
+        break;
+      case BothReadZookeeperWrite:
+        // In migration to ZK mode, writes only go to ZK
+        zkStore.createSync(metadataNode);
+        break;
+      case BothReadEtcdWrite:
+        // In migration to Etcd mode, writes only go to Etcd
+        etcdStore.createSync(metadataNode);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
     }
   }
 
+  /**
+   * Gets a metadata node asynchronously.
+   *
+   * @param path the path to the node
+   * @return a CompletionStage that completes with the node
+   */
   public CompletionStage<T> getAsync(String path) {
-    if (cachedModeledFramework != null) {
-      return cachedModeledFramework.withPath(zPath.resolved(path)).readThrough();
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.getAsync(path);
+      case EtcdExclusive:
+        return etcdStore.getAsync(path);
+      case BothReadZookeeperWrite:
+        // Try ZK first, fall back to Etcd if not found
+        return zkStore
+            .getAsync(path)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                result -> {
+                  if (result != null) {
+                    return CompletableFuture.completedFuture(result);
+                  }
+                  // Not found in ZK, try Etcd
+                  return etcdStore.getAsync(path);
+                });
+      case BothReadEtcdWrite:
+        // Try Etcd first, fall back to ZK if not found
+        return etcdStore
+            .getAsync(path)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                result -> {
+                  if (result != null) {
+                    return CompletableFuture.completedFuture(result);
+                  }
+                  // Not found in Etcd, try ZK
+                  return zkStore.getAsync(path);
+                });
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
     }
-
-    return modeledClient.withPath(zPath.resolved(path)).read();
   }
 
+  /**
+   * Gets a metadata node synchronously.
+   *
+   * @param path the path to the node
+   * @return the node
+   */
   public T getSync(String path) {
-    try {
-      this.getCall.increment();
-
-      return getAsync(path)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
-    }
-  }
-
-  public CompletionStage<Stat> hasAsync(String path) {
-    if (cachedModeledFramework != null) {
-      awaitCacheInitialized();
-      return cachedModeledFramework.withPath(zPath.resolved(path)).checkExists();
-    }
-    return modeledClient.withPath(zPath.resolved(path)).checkExists();
-  }
-
-  public boolean hasSync(String path) {
-    try {
-      this.hasCall.increment();
-
-      return hasAsync(path)
-              .toCompletableFuture()
-              .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
-          != null;
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
-    }
-  }
-
-  public CompletionStage<Stat> updateAsync(T metadataNode) {
-    return modeledClient.update(metadataNode);
-  }
-
-  public void updateSync(T metadataNode) {
-    try {
-
-      this.updateCall.increment();
-
-      updateAsync(metadataNode)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
-    }
-  }
-
-  public CompletionStage<Void> deleteAsync(String path) {
-    return modeledClient.withPath(zPath.resolved(path)).delete();
-  }
-
-  public void deleteSync(String path) {
-    try {
-      this.deleteCall.increment();
-
-      deleteAsync(path)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (ExecutionException | InterruptedException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error deleting node under at path: " + path, e);
-    }
-  }
-
-  public CompletionStage<Void> deleteAsync(T metadataNode) {
-    return modeledClient.withPath(zPath.resolved(metadataNode)).delete();
-  }
-
-  public void deleteSync(T metadataNode) {
-    try {
-      this.deleteCall.increment();
-
-      deleteAsync(metadataNode)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (ExecutionException | InterruptedException | TimeoutException e) {
-      throw new InternalMetadataStoreException(
-          "Error deleting node under at path: " + metadataNode.name, e);
-    }
-  }
-
-  public CompletionStage<List<T>> listAsync() {
-    if (cachedModeledFramework == null) {
-      throw new UnsupportedOperationException("Caching is disabled");
-    }
-
-    awaitCacheInitialized();
-    return cachedModeledFramework.list();
-  }
-
-  public List<T> listSync() {
-    try {
-      this.listCall.increment();
-
-      return listAsync()
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error getting cached nodes", e);
-    }
-  }
-
-  public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
-    if (cachedModeledFramework == null) {
-      throw new UnsupportedOperationException("Caching is disabled");
-    }
-
-    this.addedListener.increment();
-
-    // this mapping exists because the remove is by reference, and the listener is a different
-    // object type
-    ModeledCacheListener<T> modeledCacheListener =
-        (type, path, stat, model) -> {
-          // We do not expect the model to ever be null for an event on a metadata node
-          if (model != null) {
-            watcher.onMetadataStoreChanged(model);
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.getSync(path);
+      case EtcdExclusive:
+        return etcdStore.getSync(path);
+      case BothReadZookeeperWrite:
+        // Try ZK first, fall back to Etcd if not found
+        try {
+          T result = zkStore.getSync(path);
+          if (result != null) {
+            return result;
           }
-        };
-    cachedModeledFramework.listenable().addListener(modeledCacheListener);
-    listenerMap.put(watcher, modeledCacheListener);
+        } catch (Exception e) {
+          // Fall through to try Etcd
+          inconsistencyCounter.increment();
+        }
+        // Not found in ZK or ZK threw exception, try Etcd
+        return etcdStore.getSync(path);
+
+      case BothReadEtcdWrite:
+        // Try Etcd first, fall back to ZK if not found
+        try {
+          T result = etcdStore.getSync(path);
+          if (result != null) {
+            return result;
+          }
+        } catch (Exception e) {
+          // Fall through to try ZK
+          inconsistencyCounter.increment();
+        }
+        // Not found in Etcd or Etcd threw exception, try ZK
+        return zkStore.getSync(path);
+
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
   }
 
+  /**
+   * Checks if a node exists asynchronously.
+   *
+   * @param path the path to check
+   * @return a CompletionStage that completes with the Stat if the node exists, null otherwise
+   */
+  public CompletionStage<Stat> hasAsync(String path) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.hasAsync(path);
+      case EtcdExclusive:
+        return etcdStore.hasAsync(path);
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // Try both stores, return true if either has the item
+        CompletionStage<Stat> primaryHas =
+            mode == MetadataStoreMode.BothReadZookeeperWrite
+                ? zkStore.hasAsync(path) // ZK is primary
+                : etcdStore.hasAsync(path); // Etcd is primary
+
+        return primaryHas
+            .thenApply(stat -> stat != null ? stat : null)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                primaryStat -> {
+                  if (primaryStat != null) {
+                    return CompletableFuture.completedFuture(primaryStat);
+                  }
+                  // Not found in primary, check secondary
+                  CompletionStage<Stat> secondaryHas =
+                      mode == MetadataStoreMode.BothReadZookeeperWrite
+                          ? etcdStore.hasAsync(path)
+                          : zkStore.hasAsync(path);
+                  return secondaryHas.exceptionally(ex -> null);
+                });
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Checks if a node exists synchronously.
+   *
+   * @param path the path to check
+   * @return true if the node exists, false otherwise
+   */
+  public boolean hasSync(String path) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.hasSync(path);
+      case EtcdExclusive:
+        return etcdStore.hasSync(path);
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // Return true if it exists in either store
+        boolean primaryResult = false;
+        boolean secondaryResult = false;
+
+        // Check primary store
+        try {
+          primaryResult =
+              mode == MetadataStoreMode.BothReadZookeeperWrite
+                  ? zkStore.hasSync(path)
+                  : etcdStore.hasSync(path);
+
+          if (primaryResult) {
+            return true; // Short-circuit if found in primary
+          }
+        } catch (Exception e) {
+          inconsistencyCounter.increment();
+        }
+
+        // Check secondary store
+        try {
+          secondaryResult =
+              mode == MetadataStoreMode.BothReadZookeeperWrite
+                  ? etcdStore.hasSync(path)
+                  : zkStore.hasSync(path);
+        } catch (Exception e) {
+          inconsistencyCounter.increment();
+        }
+
+        if (primaryResult != secondaryResult) {
+          inconsistencyCounter.increment();
+        }
+
+        return primaryResult || secondaryResult;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Updates a node asynchronously.
+   *
+   * @param metadataNode the node to update
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.updateAsync(metadataNode);
+      case EtcdExclusive:
+        return etcdStore.updateAsync(metadataNode);
+      case BothReadZookeeperWrite:
+        // Delete from Etcd and create in ZK
+        // Try to delete from Etcd first (don't wait)
+        etcdStore.deleteAsync(metadataNode);
+        // Then update in ZK (this is the operation we wait for)
+        return zkStore.updateAsync(metadataNode);
+      case BothReadEtcdWrite:
+        // Delete from ZK and create in Etcd
+        // Try to delete from ZK first (don't wait)
+        zkStore.deleteAsync(metadataNode);
+        // Then update in Etcd (this is the operation we wait for)
+        return etcdStore.updateAsync(metadataNode);
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Updates a node synchronously.
+   *
+   * @param metadataNode the node to update
+   */
+  public void updateSync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.updateSync(metadataNode);
+        break;
+      case EtcdExclusive:
+        etcdStore.updateSync(metadataNode);
+        break;
+      case BothReadZookeeperWrite:
+        // Delete from Etcd and create in ZK
+        try {
+          // Try to delete from Etcd first
+          etcdStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but continue with ZK update
+          inconsistencyCounter.increment();
+        }
+        // Then update in ZK
+        zkStore.updateSync(metadataNode);
+        break;
+      case BothReadEtcdWrite:
+        // Delete from ZK and create in Etcd
+        try {
+          // Try to delete from ZK first
+          zkStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but continue with Etcd update
+          inconsistencyCounter.increment();
+        }
+        // Then update in Etcd
+        etcdStore.updateSync(metadataNode);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Deletes a node asynchronously.
+   *
+   * @param path the path to delete
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<Void> deleteAsync(String path) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.deleteAsync(path);
+      case EtcdExclusive:
+        return etcdStore.deleteAsync(path);
+      case BothReadZookeeperWrite:
+        // Delete from ZK and also try to delete from Etcd
+        CompletionStage<Void> zkResult = zkStore.deleteAsync(path);
+        etcdStore.deleteAsync(path); // don't await this operation
+        return zkResult;
+      case BothReadEtcdWrite:
+        // Delete from Etcd and also try to delete from ZK
+        CompletionStage<Void> etcdResult = etcdStore.deleteAsync(path);
+        zkStore.deleteAsync(path); // don't await this operation
+        return etcdResult;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Deletes a node synchronously.
+   *
+   * @param path the path to delete
+   */
+  public void deleteSync(String path) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.deleteSync(path);
+        break;
+      case EtcdExclusive:
+        etcdStore.deleteSync(path);
+        break;
+      case BothReadZookeeperWrite:
+        zkStore.deleteSync(path);
+        try {
+          etcdStore.deleteSync(path);
+        } catch (Exception e) {
+          // Log but don't fail the operation
+          inconsistencyCounter.increment();
+        }
+        break;
+      case BothReadEtcdWrite:
+        etcdStore.deleteSync(path);
+        try {
+          zkStore.deleteSync(path);
+        } catch (Exception e) {
+          // Log but don't fail the operation
+          inconsistencyCounter.increment();
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Deletes a node asynchronously.
+   *
+   * @param metadataNode the node to delete
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.deleteAsync(metadataNode);
+      case EtcdExclusive:
+        return etcdStore.deleteAsync(metadataNode);
+      case BothReadZookeeperWrite:
+        // Delete from ZK and also try to delete from Etcd
+        CompletionStage<Void> zkResult = zkStore.deleteAsync(metadataNode);
+        etcdStore.deleteAsync(metadataNode); // don't await this operation
+        return zkResult;
+      case BothReadEtcdWrite:
+        // Delete from Etcd and also try to delete from ZK
+        CompletionStage<Void> etcdResult = etcdStore.deleteAsync(metadataNode);
+        zkStore.deleteAsync(metadataNode); // don't await this operation
+        return etcdResult;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Deletes a node synchronously.
+   *
+   * @param metadataNode the node to delete
+   */
+  public void deleteSync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.deleteSync(metadataNode);
+        break;
+      case EtcdExclusive:
+        etcdStore.deleteSync(metadataNode);
+        break;
+      case BothReadZookeeperWrite:
+        zkStore.deleteSync(metadataNode);
+        try {
+          etcdStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but don't fail the operation
+          inconsistencyCounter.increment();
+        }
+        break;
+      case BothReadEtcdWrite:
+        etcdStore.deleteSync(metadataNode);
+        try {
+          zkStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but don't fail the operation
+          inconsistencyCounter.increment();
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Lists all nodes asynchronously.
+   *
+   * @return a CompletionStage that completes with the list of nodes
+   */
+  public CompletionStage<List<T>> listAsync() {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.listAsync();
+      case EtcdExclusive:
+        return etcdStore.listAsync();
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // Combine results from both stores
+        CompletionStage<List<T>> primaryList =
+            mode == MetadataStoreMode.BothReadZookeeperWrite
+                ? zkStore.listAsync()
+                : etcdStore.listAsync();
+        CompletionStage<List<T>> secondaryList =
+            mode == MetadataStoreMode.BothReadZookeeperWrite
+                ? etcdStore.listAsync()
+                : zkStore.listAsync();
+
+        return primaryList
+            .exceptionally(ex -> List.of())
+            .thenCombine(
+                secondaryList.exceptionally(ex -> List.of()),
+                (list1, list2) -> {
+                  // Combine both lists, using name as identifier
+                  Map<String, T> combinedMap = new ConcurrentHashMap<>();
+
+                  // Add items from primary store first
+                  for (T item : list1) {
+                    combinedMap.put(item.name, item);
+                  }
+
+                  // Add items from secondary store if not already present
+                  for (T item : list2) {
+                    combinedMap.putIfAbsent(item.name, item);
+                  }
+
+                  return new ArrayList<>(combinedMap.values());
+                });
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Lists all nodes synchronously.
+   *
+   * @return the list of nodes
+   */
+  public List<T> listSync() {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.listSync();
+      case EtcdExclusive:
+        return etcdStore.listSync();
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // Combine results from both stores
+        List<T> primaryList;
+        List<T> secondaryList;
+
+        try {
+          primaryList =
+              mode == MetadataStoreMode.BothReadZookeeperWrite
+                  ? zkStore.listSync()
+                  : etcdStore.listSync();
+        } catch (Exception e) {
+          inconsistencyCounter.increment();
+          primaryList = List.of();
+        }
+
+        try {
+          secondaryList =
+              mode == MetadataStoreMode.BothReadZookeeperWrite
+                  ? etcdStore.listSync()
+                  : zkStore.listSync();
+        } catch (Exception e) {
+          inconsistencyCounter.increment();
+          secondaryList = List.of();
+        }
+
+        // Combine both lists, using name as identifier
+        Map<String, T> combinedMap = new ConcurrentHashMap<>();
+
+        // Add items from primary store first
+        for (T item : primaryList) {
+          combinedMap.put(item.name, item);
+        }
+
+        // Add items from secondary store if not already present
+        for (T item : secondaryList) {
+          combinedMap.putIfAbsent(item.name, item);
+        }
+
+        return new ArrayList<>(combinedMap.values());
+
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Adds a listener for metadata changes.
+   *
+   * @param watcher the listener to add
+   */
+  public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
+    // Create a wrapper that will forward events
+    DualStoreChangeListener<T> dualListener = new DualStoreChangeListener<>(watcher);
+    listenerMap.put(watcher, dualListener);
+
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.addListener(dualListener);
+        break;
+      case EtcdExclusive:
+        etcdStore.addListener(dualListener);
+        break;
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // In dual modes, we need to listen to both stores
+        zkStore.addListener(dualListener);
+        etcdStore.addListener(dualListener);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Removes a listener for metadata changes.
+   *
+   * @param watcher the listener to remove
+   */
   public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
-    if (cachedModeledFramework == null) {
-      throw new UnsupportedOperationException("Caching is disabled");
+    DualStoreChangeListener<T> dualListener = listenerMap.remove(watcher);
+    if (dualListener == null) {
+      return;
     }
-    this.removedListener.increment();
-    cachedModeledFramework.listenable().removeListener(listenerMap.remove(watcher));
+
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.removeListener(dualListener);
+        break;
+      case EtcdExclusive:
+        etcdStore.removeListener(dualListener);
+        break;
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // In dual modes, we need to remove from both stores
+        zkStore.removeListener(dualListener);
+        etcdStore.removeListener(dualListener);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
   }
 
+  /** Waits for the cache to be initialized. */
   public void awaitCacheInitialized() {
-    try {
-      if (!cacheInitialized.await(zkConfig.getZkCacheInitTimeoutMs(), TimeUnit.MILLISECONDS)) {
-        // in the event we deadlock, go ahead and time this out at 30s and restart the pod
-        new RuntimeHalterImpl()
-            .handleFatal(
-                new TimeoutException("Timed out waiting for Zookeeper cache to initialize"));
-      }
-    } catch (InterruptedException e) {
-      new RuntimeHalterImpl().handleFatal(e);
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.awaitCacheInitialized();
+        break;
+      case EtcdExclusive:
+        etcdStore.awaitCacheInitialized();
+        break;
+      case BothReadZookeeperWrite:
+        zkStore.awaitCacheInitialized();
+        // We don't wait for Etcd in this mode since ZK is primary
+        break;
+      case BothReadEtcdWrite:
+        etcdStore.awaitCacheInitialized();
+        // We don't wait for ZK in this mode since Etcd is primary
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
     }
-  }
-
-  private ModeledCacheListener<T> getCacheInitializedListener() {
-    return new ModeledCacheListener<T>() {
-      @Override
-      public void accept(Type type, ZPath path, Stat stat, T model) {
-        // no-op
-      }
-
-      @Override
-      public void initialized() {
-        ModeledCacheListener.super.initialized();
-        cacheInitialized.countDown();
-        if (cacheInitializationHandlerFired != null) {
-          cacheInitializationHandlerFired.increment();
-        }
-
-        // after it's initialized, we no longer need the listener or executor
-        if (cachedModeledFramework != null) {
-          cachedModeledFramework.listenable().removeListener(initializedListener);
-        }
-        if (cacheInitializedService != null) {
-          cacheInitializedService.shutdown();
-        }
-      }
-    };
   }
 
   @Override
   public void close() {
-    if (cachedModeledFramework != null) {
-      listenerMap.forEach(
-          (_, tModeledCacheListener) ->
-              cachedModeledFramework.listenable().removeListener(tModeledCacheListener));
-      cachedModeledFramework.close();
+    // Always try to close both stores regardless of mode
+    try {
+      if (zkStore != null) {
+        zkStore.close();
+      }
+    } catch (Exception e) {
+      // Log but continue to close the other store
+    }
+
+    try {
+      if (etcdStore != null) {
+        etcdStore.close();
+      }
+    } catch (Exception e) {
+      // Log but continue
+    }
+  }
+
+  /**
+   * Helper class that wraps a user-provided listener and forwards events. This is used to track
+   * listeners across both stores, and to ensure that each event is only delivered once to the user
+   * listener.
+   */
+  private static class DualStoreChangeListener<T extends AstraMetadata>
+      implements AstraMetadataStoreChangeListener<T> {
+
+    private final AstraMetadataStoreChangeListener<T> delegate;
+
+    DualStoreChangeListener(AstraMetadataStoreChangeListener<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void onMetadataStoreChanged(T model) {
+      delegate.onMetadataStoreChanged(model);
     }
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraPartitioningMetadataStore.java
@@ -1,368 +1,656 @@
 package com.slack.astra.metadata.core;
 
-import com.google.common.collect.Sets;
-import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.proto.config.AstraConfigs.MetadataStoreMode;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import org.apache.curator.x.async.AsyncCuratorFramework;
-import org.apache.curator.x.async.modeled.ModelSerializer;
-import org.apache.zookeeper.AddWatchMode;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The AstraPartitioningMetadataStore is a variation of the AstraMetadataStore that allows for
- * scaling a metadata store that exceeds Zookeepers ideal child node count. This is generally
- * encountered when attempting to list children or adding a listener encounters an issue exceeding
- * the jute.maxbuffer.
+ * The AstraPartitioningMetadataStore is a bridge implementation that takes both
+ * ZookeeperPartitioningMetadataStore and EtcdPartitioningMetadataStore implementations. It will
+ * route operations to one or both of these implementations depending on the configured mode in
+ * MetadataStoreConfig.
  *
- * <p>This partitioning store enables scaling by introducing an intermediate path to the existing
- * metadata stores, such that "foo/bar" becomes "/foo/{partitionIdentifier}/bar". For each
- * partitionIdentifier a separate instance of a AstraMetadataStore is managed within a map. The
- * partitioning store transparently handles registration and discovery of these partitions, and
- * passes the various metadata store methods directly to the appropriate partition instance.
- *
- * <p>Switching to the partitioning store is not backward compatible with existing non-partitioned
- * metadata. This could potentially be addressed using a manager api to read and copy the metadata
- * to the new store path, using the non-partitioned and partitioning stores respectively.
+ * <p>This class is intended to be a bridge for migrating from Zookeeper to Etcd by supporting
+ * different modes of operation: - ZookeeperExclusive: All operations go to Zookeeper only -
+ * EtcdExclusive: All operations go to Etcd only - BothReadZookeeperWrite: In this migration mode: -
+ * Creates go to ZK only - Updates delete from Etcd and create in ZK - Deletes apply to both stores
+ * - Get tries ZK first, then falls back to Etcd - Has returns true if either store has the item -
+ * List combines results from both stores - BothReadEtcdWrite: In this migration mode: - Creates go
+ * to Etcd only - Updates delete from ZK and create in Etcd - Deletes apply to both stores - Get
+ * tries Etcd first, then falls back to ZK - Has returns true if either store has the item - List
+ * combines results from both stores
  */
 public class AstraPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(AstraPartitioningMetadataStore.class);
-  private final Map<String, AstraMetadataStore<T>> metadataStoreMap = new ConcurrentHashMap<>();
-  private final List<AstraMetadataStoreChangeListener<T>> listeners = new CopyOnWriteArrayList<>();
 
-  protected final AsyncCuratorFramework curator;
-  protected final String storeFolder;
-  private final CreateMode createMode;
-  protected final ModelSerializer<T> modelSerializer;
-  private final Watcher watcher;
-  private final List<String> partitionFilters;
-  private final AstraConfigs.ZookeeperConfig zkConfig;
+  protected final ZookeeperPartitioningMetadataStore<T> zkStore;
+  private final EtcdPartitioningMetadataStore<T> etcdStore;
+  private final MetadataStoreMode mode;
   private final MeterRegistry meterRegistry;
 
-  public AstraPartitioningMetadataStore(
-      AsyncCuratorFramework curator,
-      AstraConfigs.ZookeeperConfig zkConfig,
-      MeterRegistry meterRegistry,
-      CreateMode createMode,
-      ModelSerializer<T> modelSerializer,
-      String storeFolder) {
-    this(curator, zkConfig, meterRegistry, createMode, modelSerializer, storeFolder, List.of());
-  }
+  private final String ASTRA_PARTITIONING_METADATA_STORE_INCONSISTENCY =
+      "astra_partitioning_metadata_store_inconsistency";
+  private final Counter inconsistencyCounter;
 
+  // Tracks listeners registered, so we can properly register/unregister from both stores
+  private final Map<AstraMetadataStoreChangeListener<T>, DualStoreChangeListener<T>> listenerMap =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Constructor for AstraPartitioningMetadataStore.
+   *
+   * @param zkStore the ZookeeperPartitioningMetadataStore implementation
+   * @param etcdStore the EtcdPartitioningMetadataStore implementation
+   * @param mode the operation mode
+   * @param meterRegistry the metrics registry
+   */
   public AstraPartitioningMetadataStore(
-      AsyncCuratorFramework curator,
-      AstraConfigs.ZookeeperConfig zkConfig,
-      MeterRegistry meterRegistry,
-      CreateMode createMode,
-      ModelSerializer<T> modelSerializer,
-      String storeFolder,
-      List<String> partitionFilters) {
-    this.curator = curator;
-    this.storeFolder = storeFolder;
-    this.createMode = createMode;
-    this.modelSerializer = modelSerializer;
-    this.watcher = buildWatcher();
-    this.partitionFilters = partitionFilters;
-    this.zkConfig = zkConfig;
+      ZookeeperPartitioningMetadataStore<T> zkStore,
+      EtcdPartitioningMetadataStore<T> etcdStore,
+      MetadataStoreMode mode,
+      MeterRegistry meterRegistry) {
+
+    this.zkStore = zkStore;
+    this.etcdStore = etcdStore;
+    this.mode = mode;
     this.meterRegistry = meterRegistry;
 
-    // register watchers for when partitions are added or removed
-    curator
-        .addWatch()
-        .withMode(AddWatchMode.PERSISTENT) // intentionally NOT recursive
-        .usingWatcher(watcher)
-        .forPath(storeFolder);
-
-    // init stores for each existing partition
-    curator
-        .getChildren()
-        .forPath(storeFolder)
-        .exceptionallyCompose(
-            (throwable) -> {
-              if (throwable instanceof KeeperException.NoNodeException) {
-                // This is thrown because the storeFolder does not yet exist in ZK
-                // This isn't a problem, as the node will be created once the first operation is
-                // attempted
-                return CompletableFuture.completedFuture(List.of());
-              } else {
-                return CompletableFuture.failedFuture(throwable);
-              }
-            })
-        .thenAccept(
-            (children) -> {
-              if (partitionFilters.isEmpty()) {
-                children.forEach(this::getOrCreateMetadataStore);
-              } else {
-                children.stream()
-                    .filter(partitionFilters::contains)
-                    .forEach(this::getOrCreateMetadataStore);
-              }
-            })
-        .toCompletableFuture()
-        // wait for all the stores to be initialized prior to exiting the constructor
-        .join();
-
-    if (partitionFilters.isEmpty()) {
-      LOG.info(
-          "The metadata store for folder '{}' was initialized with {} partitions",
-          storeFolder,
-          metadataStoreMap.size());
-    } else {
-      LOG.info(
-          "The metadata store for folder '{}' was initialized with {} partitions (using partition filters: {})",
-          storeFolder,
-          metadataStoreMap.size(),
-          String.join(",", partitionFilters));
-    }
+    this.inconsistencyCounter =
+        this.meterRegistry.counter(
+            ASTRA_PARTITIONING_METADATA_STORE_INCONSISTENCY, "store", "composite");
   }
 
   /**
-   * Builds a watcher that is responsible for updating our internal metadata stores to match that is
-   * stored in ZK. As we create parent nodes as containers, we do not need to be responsible for
-   * deleting these intermediate nodes as this will be handled by ZK.
+   * Creates a new metadata node.
    *
-   * <p>This method creates stores internally when they are detected in ZK storing them to the store
-   * map, and removes stores that are in the map that no longer exist in ZK.
-   *
-   * @see AstraMetadataStore#AstraMetadataStore(AsyncCuratorFramework, AstraConfigs.ZookeeperConfig,
-   *     CreateMode, boolean, ModelSerializer, String, io.micrometer.core.instrument.MeterRegistry)
+   * @param metadataNode the node to create
+   * @return a CompletionStage that completes when the operation is done
    */
-  private Watcher buildWatcher() {
-    return event -> {
-      if (event.getType().equals(Watcher.Event.EventType.NodeChildrenChanged)) {
-        curator
-            .getChildren()
-            .forPath(storeFolder)
-            .thenAcceptAsync(
-                (partitions) -> {
-                  if (partitionFilters.isEmpty()) {
-                    // create internal stores foreach partition that do not already exist
-                    partitions.forEach(this::getOrCreateMetadataStore);
-                  } else {
-                    partitions.stream()
-                        .filter(partitionFilters::contains)
-                        .forEach(this::getOrCreateMetadataStore);
-                  }
-
-                  // remove metadata stores that exist in memory but no longer exist on ZK
-                  Set<String> partitionsToRemove =
-                      Sets.difference(metadataStoreMap.keySet(), Sets.newHashSet(partitions));
-                  partitionsToRemove.forEach(
-                      partition -> {
-                        int cachedSize = metadataStoreMap.get(partition).listSync().size();
-                        if (cachedSize == 0) {
-                          LOG.debug("Closing unused store for partition - {}", partition);
-                          AstraMetadataStore<T> store = metadataStoreMap.remove(partition);
-                          store.close();
-                        } else {
-                          // This extra check is to prevent a race condition where multiple items
-                          // are being quickly added. This can result in a scenario where the
-                          // watcher is triggered, but we haven't persisted the items to ZK yet.
-                          // When this happens it results in a premature close of the local cache.
-                          LOG.warn(
-                              "Skipping metadata store close for partition {}, still has {} cached elements",
-                              partition,
-                              cachedSize);
-                        }
-                      });
-                });
-      }
-    };
-  }
-
   public CompletionStage<String> createAsync(T metadataNode) {
-    return getOrCreateMetadataStore(metadataNode.getPartition()).createAsync(metadataNode);
-  }
-
-  public void createSync(T metadataNode) {
-    try {
-      createAsync(metadataNode)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
-    }
-  }
-
-  public CompletionStage<T> getAsync(String partition, String path) {
-    return getOrCreateMetadataStore(partition).getAsync(path);
-  }
-
-  public T getSync(String partition, String path) {
-    try {
-      return getAsync(partition, path)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.createAsync(metadataNode);
+      case EtcdExclusive:
+        return etcdStore.createAsync(metadataNode);
+      case BothReadZookeeperWrite:
+        // In migration to ZK mode, writes only go to ZK
+        return zkStore.createAsync(metadataNode);
+      case BothReadEtcdWrite:
+        // In migration to Etcd mode, writes only go to Etcd
+        return etcdStore.createAsync(metadataNode);
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
     }
   }
 
   /**
-   * Attempts to find the metadata without knowledge of the partition it exists in. Use of this
-   * should be avoided if possible, preferring the getAsync.
+   * Synchronously creates a new metadata node.
    *
-   * @see AstraPartitioningMetadataStore#getAsync(String, String)
+   * @param metadataNode the node to create
+   */
+  public void createSync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.createSync(metadataNode);
+        break;
+      case EtcdExclusive:
+        etcdStore.createSync(metadataNode);
+        break;
+      case BothReadZookeeperWrite:
+        // In migration to ZK mode, writes only go to ZK
+        zkStore.createSync(metadataNode);
+        break;
+      case BothReadEtcdWrite:
+        // In migration to Etcd mode, writes only go to Etcd
+        etcdStore.createSync(metadataNode);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Gets a metadata node asynchronously.
+   *
+   * @param partition the partition to look in
+   * @param path the path to the node
+   * @return a CompletionStage that completes with the node
+   */
+  public CompletionStage<T> getAsync(String partition, String path) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.getAsync(partition, path);
+      case EtcdExclusive:
+        return etcdStore.getAsync(partition, path);
+      case BothReadZookeeperWrite:
+        // Try ZK first, fall back to Etcd if not found
+        return zkStore
+            .getAsync(partition, path)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                result -> {
+                  if (result != null) {
+                    return CompletableFuture.completedFuture(result);
+                  }
+                  // Not found in ZK, try Etcd
+                  return etcdStore.getAsync(partition, path);
+                });
+      case BothReadEtcdWrite:
+        // Try Etcd first, fall back to ZK if not found
+        return etcdStore
+            .getAsync(partition, path)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                result -> {
+                  if (result != null) {
+                    return CompletableFuture.completedFuture(result);
+                  }
+                  // Not found in Etcd, try ZK
+                  return zkStore.getAsync(partition, path);
+                });
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Gets a metadata node synchronously.
+   *
+   * @param partition the partition to look in
+   * @param path the path to the node
+   * @return the node
+   */
+  public T getSync(String partition, String path) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.getSync(partition, path);
+      case EtcdExclusive:
+        return etcdStore.getSync(partition, path);
+      case BothReadZookeeperWrite:
+        // Try ZK first, fall back to Etcd if not found
+        try {
+          T result = zkStore.getSync(partition, path);
+          if (result != null) {
+            return result;
+          }
+        } catch (Exception e) {
+          // Fall through to try Etcd
+          inconsistencyCounter.increment();
+        }
+        // Not found in ZK or ZK threw exception, try Etcd
+        return etcdStore.getSync(partition, path);
+
+      case BothReadEtcdWrite:
+        // Try Etcd first, fall back to ZK if not found
+        try {
+          T result = etcdStore.getSync(partition, path);
+          if (result != null) {
+            return result;
+          }
+        } catch (Exception e) {
+          // Fall through to try ZK
+          inconsistencyCounter.increment();
+        }
+        // Not found in Etcd or Etcd threw exception, try ZK
+        return zkStore.getSync(partition, path);
+
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Attempts to find the metadata without knowledge of the partition it exists in.
+   *
+   * @param path the path to the node
+   * @return a CompletionStage that completes with the node
    */
   public CompletionStage<T> findAsync(String path) {
-    return getOrCreateMetadataStore(findPartition(path)).getAsync(path);
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.findAsync(path);
+      case EtcdExclusive:
+        return etcdStore.findAsync(path);
+      case BothReadZookeeperWrite:
+        // Try ZK first, fall back to Etcd if not found
+        return zkStore
+            .findAsync(path)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                result -> {
+                  if (result != null) {
+                    return CompletableFuture.completedFuture(result);
+                  }
+                  // Not found in ZK, try Etcd
+                  return etcdStore.findAsync(path);
+                });
+      case BothReadEtcdWrite:
+        // Try Etcd first, fall back to ZK if not found
+        return etcdStore
+            .findAsync(path)
+            .exceptionally(ex -> null)
+            .thenCompose(
+                result -> {
+                  if (result != null) {
+                    return CompletableFuture.completedFuture(result);
+                  }
+                  // Not found in Etcd, try ZK
+                  return zkStore.findAsync(path);
+                });
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
   }
 
   /**
-   * Attempts to find the metadata without knowledge of the partition it exists in. Use of this
-   * should be avoided if possible, preferring the getSync.
+   * Attempts to find the metadata synchronously without knowledge of the partition it exists in.
    *
-   * @see AstraPartitioningMetadataStore#getSync(String, String)
+   * @param path the path to the node
+   * @return the node
    */
   public T findSync(String path) {
-    try {
-      return findAsync(path)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.findSync(path);
+      case EtcdExclusive:
+        return etcdStore.findSync(path);
+      case BothReadZookeeperWrite:
+        // Try ZK first, fall back to Etcd if not found
+        try {
+          T result = zkStore.findSync(path);
+          if (result != null) {
+            return result;
+          }
+        } catch (Exception e) {
+          // Fall through to try Etcd
+          inconsistencyCounter.increment();
+        }
+        // Not found in ZK or ZK threw exception, try Etcd
+        return etcdStore.findSync(path);
+
+      case BothReadEtcdWrite:
+        // Try Etcd first, fall back to ZK if not found
+        try {
+          T result = etcdStore.findSync(path);
+          if (result != null) {
+            return result;
+          }
+        } catch (Exception e) {
+          // Fall through to try ZK
+          inconsistencyCounter.increment();
+        }
+        // Not found in Etcd or Etcd threw exception, try ZK
+        return zkStore.findSync(path);
+
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
     }
-  }
-
-  public CompletionStage<Stat> updateAsync(T metadataNode) {
-    return getOrCreateMetadataStore(metadataNode.getPartition()).updateAsync(metadataNode);
-  }
-
-  public void updateSync(T metadataNode) {
-    try {
-      updateAsync(metadataNode)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
-    }
-  }
-
-  public CompletionStage<Void> deleteAsync(T metadataNode) {
-    return getOrCreateMetadataStore(metadataNode.getPartition()).deleteAsync(metadataNode);
-  }
-
-  public void deleteSync(T metadataNode) {
-    try {
-      deleteAsync(metadataNode)
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (ExecutionException | InterruptedException | TimeoutException e) {
-      throw new InternalMetadataStoreException(
-          "Error deleting node under at path: " + metadataNode.name, e);
-    }
-  }
-
-  public CompletableFuture<List<T>> listAsync() {
-    List<CompletableFuture<List<T>>> completionStages = new ArrayList<>();
-    for (Map.Entry<String, AstraMetadataStore<T>> metadataStoreEntry :
-        metadataStoreMap.entrySet()) {
-      completionStages.add(metadataStoreEntry.getValue().listAsync().toCompletableFuture());
-    }
-
-    return CompletableFuture.allOf(completionStages.toArray(new CompletableFuture[0]))
-        .thenApply(
-            (unused) ->
-                completionStages.stream()
-                    .map(f -> f.toCompletableFuture().join())
-                    .flatMap(List::stream)
-                    .collect(Collectors.toList()));
-  }
-
-  public List<T> listSync() {
-    try {
-      return listAsync()
-          .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-    } catch (ExecutionException | InterruptedException | TimeoutException e) {
-      throw new InternalMetadataStoreException("Error listing nodes", e);
-    }
-  }
-
-  private AstraMetadataStore<T> getOrCreateMetadataStore(String partition) {
-    if (!partitionFilters.isEmpty() && !partitionFilters.contains(partition)) {
-      LOG.error(
-          "Partitioning metadata store attempted to use partition {}, filters restricted to {}",
-          partition,
-          String.join(",", partitionFilters));
-      throw new InternalMetadataStoreException(
-          "Partitioning metadata store using filters that does not include provided partition");
-    }
-
-    return metadataStoreMap.computeIfAbsent(
-        partition,
-        (p1) -> {
-          String path = String.format("%s/%s", storeFolder, p1);
-          LOG.debug(
-              "Creating new metadata store for partition - {}, at path - {}", partition, path);
-
-          AstraMetadataStore<T> newStore =
-              new AstraMetadataStore<>(
-                  curator, zkConfig, createMode, true, modelSerializer, path, meterRegistry);
-          listeners.forEach(newStore::addListener);
-
-          return newStore;
-        });
   }
 
   /**
-   * Attempts to locate the partition containing the sub-path. If no partition is found this will
-   * throw an InternalMetadataStoreException. Use of this method should be carefully considered due
-   * to performance implications of potentially invoking N hasSync calls.
+   * Updates a node asynchronously.
+   *
+   * @param metadataNode the node to update
+   * @return a CompletionStage that completes when the operation is done
    */
-  private String findPartition(String path) {
-    for (Map.Entry<String, AstraMetadataStore<T>> metadataStoreEntry :
-        metadataStoreMap.entrySet()) {
-      // We may consider switching this to execute in parallel in the future. Even though this would
-      // be faster, it would put quite a bit more load on ZK, and some of it unnecessary
-      if (metadataStoreEntry.getValue().hasSync(path)) {
-        return metadataStoreEntry.getKey();
-      }
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.updateAsync(metadataNode);
+      case EtcdExclusive:
+        return etcdStore.updateAsync(metadataNode);
+      case BothReadZookeeperWrite:
+        // Delete from Etcd and create in ZK
+        // Try to delete from Etcd first (don't wait)
+        etcdStore.deleteAsync(metadataNode);
+        // Then update in ZK (this is the operation we wait for)
+        return zkStore.updateAsync(metadataNode);
+      case BothReadEtcdWrite:
+        // Delete from ZK and create in Etcd
+        // Try to delete from ZK first (don't wait)
+        zkStore.deleteAsync(metadataNode);
+        // Then update in Etcd (this is the operation we wait for)
+        return etcdStore.updateAsync(metadataNode);
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
     }
-    throw new InternalMetadataStoreException("Error finding node at path " + path);
   }
 
+  /**
+   * Updates a node synchronously.
+   *
+   * @param metadataNode the node to update
+   */
+  public void updateSync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.updateSync(metadataNode);
+        break;
+      case EtcdExclusive:
+        etcdStore.updateSync(metadataNode);
+        break;
+      case BothReadZookeeperWrite:
+        // Delete from Etcd and create in ZK
+        try {
+          // Try to delete from Etcd first
+          etcdStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but continue with ZK update
+          inconsistencyCounter.increment();
+        }
+        // Then update in ZK
+        zkStore.updateSync(metadataNode);
+        break;
+      case BothReadEtcdWrite:
+        // Delete from ZK and create in Etcd
+        try {
+          // Try to delete from ZK first
+          zkStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but continue with Etcd update
+          inconsistencyCounter.increment();
+        }
+        // Then update in Etcd
+        etcdStore.updateSync(metadataNode);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Deletes a node asynchronously.
+   *
+   * @param metadataNode the node to delete
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.deleteAsync(metadataNode);
+      case EtcdExclusive:
+        return etcdStore.deleteAsync(metadataNode);
+      case BothReadZookeeperWrite:
+        // Delete from ZK and also try to delete from Etcd
+        CompletionStage<Void> zkResult = zkStore.deleteAsync(metadataNode);
+        etcdStore.deleteAsync(metadataNode); // don't await this operation
+        return zkResult;
+      case BothReadEtcdWrite:
+        // Delete from Etcd and also try to delete from ZK
+        CompletionStage<Void> etcdResult = etcdStore.deleteAsync(metadataNode);
+        zkStore.deleteAsync(metadataNode); // don't await this operation
+        return etcdResult;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Deletes a node synchronously.
+   *
+   * @param metadataNode the node to delete
+   */
+  public void deleteSync(T metadataNode) {
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.deleteSync(metadataNode);
+        break;
+      case EtcdExclusive:
+        etcdStore.deleteSync(metadataNode);
+        break;
+      case BothReadZookeeperWrite:
+        zkStore.deleteSync(metadataNode);
+        try {
+          etcdStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but don't fail the operation
+          inconsistencyCounter.increment();
+        }
+        break;
+      case BothReadEtcdWrite:
+        etcdStore.deleteSync(metadataNode);
+        try {
+          zkStore.deleteSync(metadataNode);
+        } catch (Exception e) {
+          // Log but don't fail the operation
+          inconsistencyCounter.increment();
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Lists all nodes asynchronously.
+   *
+   * @return a CompletionStage that completes with the list of nodes
+   */
+  public CompletionStage<List<T>> listAsync() {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.listAsync();
+      case EtcdExclusive:
+        return etcdStore.listAsync();
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // Combine results from both stores
+        CompletionStage<List<T>> primaryList =
+            mode == MetadataStoreMode.BothReadZookeeperWrite
+                ? zkStore.listAsync()
+                : etcdStore.listAsync();
+        CompletionStage<List<T>> secondaryList =
+            mode == MetadataStoreMode.BothReadZookeeperWrite
+                ? etcdStore.listAsync()
+                : zkStore.listAsync();
+
+        return primaryList
+            .exceptionally(ex -> List.of())
+            .thenCombine(
+                secondaryList.exceptionally(ex -> List.of()),
+                (list1, list2) -> {
+                  // Combine both lists, using name as identifier
+                  Map<String, T> combinedMap = new ConcurrentHashMap<>();
+
+                  // Add items from primary store first
+                  for (T item : list1) {
+                    combinedMap.put(item.name, item);
+                  }
+
+                  // Add items from secondary store if not already present
+                  for (T item : list2) {
+                    combinedMap.putIfAbsent(item.name, item);
+                  }
+
+                  return new ArrayList<>(combinedMap.values());
+                });
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Lists all nodes synchronously.
+   *
+   * @return the list of nodes
+   */
+  public List<T> listSync() {
+    switch (mode) {
+      case ZookeeperExclusive:
+        return zkStore.listSync();
+      case EtcdExclusive:
+        return etcdStore.listSync();
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // Combine results from both stores
+        List<T> primaryList;
+        List<T> secondaryList;
+
+        try {
+          primaryList =
+              mode == MetadataStoreMode.BothReadZookeeperWrite
+                  ? zkStore.listSync()
+                  : etcdStore.listSync();
+        } catch (Exception e) {
+          inconsistencyCounter.increment();
+          primaryList = List.of();
+        }
+
+        try {
+          secondaryList =
+              mode == MetadataStoreMode.BothReadZookeeperWrite
+                  ? etcdStore.listSync()
+                  : zkStore.listSync();
+        } catch (Exception e) {
+          inconsistencyCounter.increment();
+          secondaryList = List.of();
+        }
+
+        // Combine both lists, using name as identifier
+        Map<String, T> combinedMap = new ConcurrentHashMap<>();
+
+        // Add items from primary store first
+        for (T item : primaryList) {
+          combinedMap.put(item.name, item);
+        }
+
+        // Add items from secondary store if not already present
+        for (T item : secondaryList) {
+          combinedMap.putIfAbsent(item.name, item);
+        }
+
+        return new ArrayList<>(combinedMap.values());
+
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /**
+   * Adds a listener for metadata changes.
+   *
+   * @param watcher the listener to add
+   */
   public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
-    // add this watcher to the list for new stores to add
-    listeners.add(watcher);
-    // add this watcher to existing stores
-    metadataStoreMap.forEach((_, store) -> store.addListener(watcher));
+    // Create a wrapper that will forward events
+    DualStoreChangeListener<T> dualListener = new DualStoreChangeListener<>(watcher);
+    listenerMap.put(watcher, dualListener);
+
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.addListener(dualListener);
+        break;
+      case EtcdExclusive:
+        etcdStore.addListener(dualListener);
+        break;
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // In dual modes, we need to listen to both stores
+        zkStore.addListener(dualListener);
+        etcdStore.addListener(dualListener);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
   }
 
+  /**
+   * Removes a listener for metadata changes.
+   *
+   * @param watcher the listener to remove
+   */
   public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
-    listeners.remove(watcher);
-    metadataStoreMap.forEach((_, store) -> store.removeListener(watcher));
+    DualStoreChangeListener<T> dualListener = listenerMap.remove(watcher);
+    if (dualListener == null) {
+      return;
+    }
+
+    switch (mode) {
+      case ZookeeperExclusive:
+        zkStore.removeListener(dualListener);
+        break;
+      case EtcdExclusive:
+        etcdStore.removeListener(dualListener);
+        break;
+      case BothReadZookeeperWrite:
+      case BothReadEtcdWrite:
+        // In dual modes, we need to remove from both stores
+        zkStore.removeListener(dualListener);
+        etcdStore.removeListener(dualListener);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
+  }
+
+  /** Waits for the cache to be initialized. */
+  public void awaitCacheInitialized() {
+    switch (mode) {
+      case ZookeeperExclusive:
+        // ZK partition store doesn't have this method directly
+        break;
+      case EtcdExclusive:
+        // Etcd partition store doesn't have this method directly
+        break;
+      case BothReadZookeeperWrite:
+        // We don't wait for Etcd in this mode since ZK is primary
+        break;
+      case BothReadEtcdWrite:
+        // We don't wait for ZK in this mode since Etcd is primary
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata store mode: " + mode);
+    }
   }
 
   @Override
-  public void close() throws IOException {
-    LOG.info(
-        "Closing the partitioning metadata store, {} listeners to remove, {} partitions to close",
-        listeners.size(),
-        metadataStoreMap.size());
+  public void close() {
+    // Always try to close both stores regardless of mode
+    try {
+      if (zkStore != null) {
+        zkStore.close();
+      }
+    } catch (Exception e) {
+      // Log but continue to close the other store
+    }
 
-    // only remove the watcher we created, since this curator instance is a singleton
-    curator.removeWatches().removing(watcher);
-    listeners.forEach(this::removeListener);
-    metadataStoreMap.forEach((partition, store) -> store.close());
+    try {
+      if (etcdStore != null) {
+        etcdStore.close();
+      }
+    } catch (Exception e) {
+      // Log but continue
+    }
+  }
+
+  /**
+   * Helper class that wraps a user-provided listener and forwards events. This is used to track
+   * listeners across both stores, and to ensure that each event is only delivered once to the user
+   * listener.
+   */
+  private static class DualStoreChangeListener<T extends AstraPartitionedMetadata>
+      implements AstraMetadataStoreChangeListener<T> {
+
+    private final AstraMetadataStoreChangeListener<T> delegate;
+
+    DualStoreChangeListener(AstraMetadataStoreChangeListener<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void onMetadataStoreChanged(T model) {
+      delegate.onMetadataStoreChanged(model);
+    }
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -5,7 +5,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import org.apache.zookeeper.data.Stat;
 
 /**
  * EtcdMetadataStore is a class which provides consistent Etcd apis for all the metadata store
@@ -76,7 +75,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     throw new UnsupportedOperationException("Not yet implemented");
   }
 
-  public CompletionStage<Stat> hasAsync(String path) {
+  public CompletionStage<Boolean> hasAsync(String path) {
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -87,7 +86,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     throw new UnsupportedOperationException("Not yet implemented");
   }
 
-  public CompletionStage<Stat> updateAsync(T metadataNode) {
+  public CompletionStage<String> updateAsync(T metadataNode) {
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -1,0 +1,155 @@
+package com.slack.astra.metadata.core;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.apache.zookeeper.data.Stat;
+
+/**
+ * EtcdMetadataStore is a class which provides consistent Etcd apis for all the metadata store
+ * classes.
+ *
+ * <p>Every method provides an async and a sync API. In general, use the async API you are
+ * performing batch operations and a sync if you are performing a synchronous operation on a node.
+ */
+public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
+  protected final String storeFolder;
+
+  private final MeterRegistry meterRegistry;
+
+  private final String ASTRA_ETCD_CREATE_CALL = "astra_etcd_create_call";
+  private final String ASTRA_ETCD_HAS_CALL = "astra_etcd_has_call";
+  private final String ASTRA_ETCD_DELETE_CALL = "astra_etcd_delete_call";
+  private final String ASTRA_ETCD_LIST_CALL = "astra_etcd_list_call";
+  private final String ASTRA_ETCD_GET_CALL = "astra_etcd_get_call";
+  private final String ASTRA_ETCD_UPDATE_CALL = "astra_etcd_update_call";
+  private final String ASTRA_ETCD_ADDED_LISTENER = "astra_etcd_added_listener";
+  private final String ASTRA_ETCD_REMOVED_LISTENER = "astra_etcd_removed_listener";
+  private final String ASTRA_ETCD_CACHE_INIT_HANDLER_FIRED = "astra_etcd_cache_init_handler_fired";
+
+  private final Counter createCall;
+  private final Counter hasCall;
+  private final Counter deleteCall;
+  private final Counter listCall;
+  private final Counter getCall;
+  private final Counter updateCall;
+  private final Counter addedListener;
+  private final Counter removedListener;
+
+  public EtcdMetadataStore(boolean shouldCache, MeterRegistry meterRegistry) {
+
+    this.storeFolder = ""; // This will be set by the specific Etcd implementation
+    this.meterRegistry = meterRegistry;
+    String store = "etcd"; // This will be based on the actual store folder
+
+    this.createCall = this.meterRegistry.counter(ASTRA_ETCD_CREATE_CALL, "store", store);
+    this.deleteCall = this.meterRegistry.counter(ASTRA_ETCD_DELETE_CALL, "store", store);
+    this.listCall = this.meterRegistry.counter(ASTRA_ETCD_LIST_CALL, "store", store);
+    this.getCall = this.meterRegistry.counter(ASTRA_ETCD_GET_CALL, "store", store);
+    this.hasCall = this.meterRegistry.counter(ASTRA_ETCD_HAS_CALL, "store", store);
+    this.updateCall = this.meterRegistry.counter(ASTRA_ETCD_UPDATE_CALL, "store", store);
+    this.addedListener = this.meterRegistry.counter(ASTRA_ETCD_ADDED_LISTENER, "store", store);
+    this.removedListener = this.meterRegistry.counter(ASTRA_ETCD_REMOVED_LISTENER, "store", store);
+  }
+
+  public CompletionStage<String> createAsync(T metadataNode) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void createSync(T metadataNode) {
+    this.createCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<T> getAsync(String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public T getSync(String path) {
+    this.getCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<Stat> hasAsync(String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public boolean hasSync(String path) {
+    this.hasCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void updateSync(T metadataNode) {
+    this.updateCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<Void> deleteAsync(String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void deleteSync(String path) {
+    this.deleteCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void deleteSync(T metadataNode) {
+    this.deleteCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<List<T>> listAsync() {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public List<T> listSync() {
+    this.listCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
+    this.addedListener.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
+    this.removedListener.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public void awaitCacheInitialized() {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public void close() {
+    // To be implemented
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -1,6 +1,5 @@
 package com.slack.astra.metadata.core;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
 import java.util.List;
@@ -26,44 +25,10 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
 
   private final MeterRegistry meterRegistry;
 
-  private final String ASTRA_ETCD_PARTITIONING_CREATE_CALL = "astra_etcd_partitioning_create_call";
-  private final String ASTRA_ETCD_PARTITIONING_DELETE_CALL = "astra_etcd_partitioning_delete_call";
-  private final String ASTRA_ETCD_PARTITIONING_LIST_CALL = "astra_etcd_partitioning_list_call";
-  private final String ASTRA_ETCD_PARTITIONING_GET_CALL = "astra_etcd_partitioning_get_call";
-  private final String ASTRA_ETCD_PARTITIONING_UPDATE_CALL = "astra_etcd_partitioning_update_call";
-  private final String ASTRA_ETCD_PARTITIONING_ADDED_LISTENER =
-      "astra_etcd_partitioning_added_listener";
-  private final String ASTRA_ETCD_PARTITIONING_REMOVED_LISTENER =
-      "astra_etcd_partitioning_removed_listener";
-  private final String ASTRA_ETCD_PARTITIONING_CACHE_INIT_HANDLER_FIRED =
-      "astra_etcd_partitioning_cache_init_handler_fired";
-
-  private final Counter createCall;
-  private final Counter deleteCall;
-  private final Counter listCall;
-  private final Counter getCall;
-  private final Counter updateCall;
-  private final Counter addedListener;
-  private final Counter removedListener;
-
   public EtcdPartitioningMetadataStore(
       boolean shouldCache, MeterRegistry meterRegistry, String storeFolder) {
     this.storeFolder = storeFolder;
     this.meterRegistry = meterRegistry;
-    String store = "etcd_partitioning";
-
-    this.createCall =
-        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_CREATE_CALL, "store", store);
-    this.deleteCall =
-        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_DELETE_CALL, "store", store);
-    this.listCall = this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_LIST_CALL, "store", store);
-    this.getCall = this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_GET_CALL, "store", store);
-    this.updateCall =
-        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_UPDATE_CALL, "store", store);
-    this.addedListener =
-        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_ADDED_LISTENER, "store", store);
-    this.removedListener =
-        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_REMOVED_LISTENER, "store", store);
   }
 
   /**
@@ -83,7 +48,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @param metadataNode the node to create
    */
   public void createSync(T metadataNode) {
-    this.createCall.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -108,7 +72,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @return the node
    */
   public T getSync(String partition, String path) {
-    this.getCall.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -131,7 +94,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @return the node
    */
   public T findSync(String path) {
-    this.getCall.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -153,7 +115,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @param metadataNode the node to update
    */
   public void updateSync(T metadataNode) {
-    this.updateCall.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -175,7 +136,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @param metadataNode the node to delete
    */
   public void deleteSync(T metadataNode) {
-    this.deleteCall.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -196,7 +156,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @return the list of nodes
    */
   public List<T> listSync() {
-    this.listCall.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -207,7 +166,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @param watcher the listener to add
    */
   public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
-    this.addedListener.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }
@@ -218,7 +176,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @param watcher the listener to remove
    */
   public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
-    this.removedListener.increment();
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -1,0 +1,236 @@
+package com.slack.astra.metadata.core;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * EtcdPartitioningMetadataStore is a class which provides consistent Etcd apis for partitioned
+ * metadata store operations.
+ *
+ * <p>Every method provides an async and a sync API. In general, use the async API you are
+ * performing batch operations and a sync if you are performing a synchronous operation on a node.
+ *
+ * <p>This class is the Etcd counterpart to ZookeeperPartitioningMetadataStore. It is designed to be
+ * used with AstraPartitioningMetadataStore for migrating between Zookeeper and Etcd.
+ */
+public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
+    implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(EtcdPartitioningMetadataStore.class);
+  protected final String storeFolder;
+
+  private final MeterRegistry meterRegistry;
+
+  private final String ASTRA_ETCD_PARTITIONING_CREATE_CALL = "astra_etcd_partitioning_create_call";
+  private final String ASTRA_ETCD_PARTITIONING_DELETE_CALL = "astra_etcd_partitioning_delete_call";
+  private final String ASTRA_ETCD_PARTITIONING_LIST_CALL = "astra_etcd_partitioning_list_call";
+  private final String ASTRA_ETCD_PARTITIONING_GET_CALL = "astra_etcd_partitioning_get_call";
+  private final String ASTRA_ETCD_PARTITIONING_UPDATE_CALL = "astra_etcd_partitioning_update_call";
+  private final String ASTRA_ETCD_PARTITIONING_ADDED_LISTENER =
+      "astra_etcd_partitioning_added_listener";
+  private final String ASTRA_ETCD_PARTITIONING_REMOVED_LISTENER =
+      "astra_etcd_partitioning_removed_listener";
+  private final String ASTRA_ETCD_PARTITIONING_CACHE_INIT_HANDLER_FIRED =
+      "astra_etcd_partitioning_cache_init_handler_fired";
+
+  private final Counter createCall;
+  private final Counter deleteCall;
+  private final Counter listCall;
+  private final Counter getCall;
+  private final Counter updateCall;
+  private final Counter addedListener;
+  private final Counter removedListener;
+
+  public EtcdPartitioningMetadataStore(
+      boolean shouldCache, MeterRegistry meterRegistry, String storeFolder) {
+    this.storeFolder = storeFolder;
+    this.meterRegistry = meterRegistry;
+    String store = "etcd_partitioning";
+
+    this.createCall =
+        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_CREATE_CALL, "store", store);
+    this.deleteCall =
+        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_DELETE_CALL, "store", store);
+    this.listCall = this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_LIST_CALL, "store", store);
+    this.getCall = this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_GET_CALL, "store", store);
+    this.updateCall =
+        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_UPDATE_CALL, "store", store);
+    this.addedListener =
+        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_ADDED_LISTENER, "store", store);
+    this.removedListener =
+        this.meterRegistry.counter(ASTRA_ETCD_PARTITIONING_REMOVED_LISTENER, "store", store);
+  }
+
+  /**
+   * Creates a new metadata node asynchronously.
+   *
+   * @param metadataNode the node to create
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<String> createAsync(T metadataNode) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Creates a new metadata node synchronously.
+   *
+   * @param metadataNode the node to create
+   */
+  public void createSync(T metadataNode) {
+    this.createCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Gets a metadata node asynchronously.
+   *
+   * @param partition the partition to look in
+   * @param path the path to the node
+   * @return a CompletionStage that completes with the node
+   */
+  public CompletionStage<T> getAsync(String partition, String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Gets a metadata node synchronously.
+   *
+   * @param partition the partition to look in
+   * @param path the path to the node
+   * @return the node
+   */
+  public T getSync(String partition, String path) {
+    this.getCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Attempts to find the metadata without knowledge of the partition it exists in.
+   *
+   * @param path the path to the node
+   * @return a CompletionStage that completes with the node
+   */
+  public CompletionStage<T> findAsync(String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Attempts to find the metadata synchronously without knowledge of the partition it exists in.
+   *
+   * @param path the path to the node
+   * @return the node
+   */
+  public T findSync(String path) {
+    this.getCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Updates a node asynchronously.
+   *
+   * @param metadataNode the node to update
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Updates a node synchronously.
+   *
+   * @param metadataNode the node to update
+   */
+  public void updateSync(T metadataNode) {
+    this.updateCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Deletes a node asynchronously.
+   *
+   * @param metadataNode the node to delete
+   * @return a CompletionStage that completes when the operation is done
+   */
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Deletes a node synchronously.
+   *
+   * @param metadataNode the node to delete
+   */
+  public void deleteSync(T metadataNode) {
+    this.deleteCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Lists all nodes asynchronously.
+   *
+   * @return a CompletionStage that completes with the list of nodes
+   */
+  public CompletionStage<List<T>> listAsync() {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Lists all nodes synchronously.
+   *
+   * @return the list of nodes
+   */
+  public List<T> listSync() {
+    this.listCall.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Adds a listener for metadata changes.
+   *
+   * @param watcher the listener to add
+   */
+  public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
+    this.addedListener.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Removes a listener for metadata changes.
+   *
+   * @param watcher the listener to remove
+   */
+  public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
+    this.removedListener.increment();
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /** Waits for the cache to be initialized. */
+  public void awaitCacheInitialized() {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public void close() {
+    // To be implemented
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +103,31 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
    * @param metadataNode the node to update
    * @return a CompletionStage that completes when the operation is done
    */
-  public CompletionStage<Stat> updateAsync(T metadataNode) {
+  /**
+   * Checks if a node exists asynchronously in a specific partition.
+   *
+   * @param partition the partition to check in
+   * @param path the path to check
+   * @return a CompletionStage that completes with true if the node exists, false otherwise
+   */
+  public CompletionStage<Boolean> hasAsync(String partition, String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Checks if a node exists synchronously in a specific partition.
+   *
+   * @param partition the partition to check in
+   * @param path the path to check
+   * @return true if the node exists, false otherwise
+   */
+  public boolean hasSync(String partition, String path) {
+    // To be implemented
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  public CompletionStage<String> updateAsync(T metadataNode) {
     // To be implemented
     throw new UnsupportedOperationException("Not yet implemented");
   }

--- a/astra/src/main/java/com/slack/astra/metadata/core/ZookeeperMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/ZookeeperMetadataStore.java
@@ -1,0 +1,332 @@
+package com.slack.astra.metadata.core;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.util.RuntimeHalterImpl;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.Closeable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.curator.x.async.api.CreateOption;
+import org.apache.curator.x.async.modeled.ModelSerializer;
+import org.apache.curator.x.async.modeled.ModelSpec;
+import org.apache.curator.x.async.modeled.ModeledFramework;
+import org.apache.curator.x.async.modeled.ZPath;
+import org.apache.curator.x.async.modeled.cached.CachedModeledFramework;
+import org.apache.curator.x.async.modeled.cached.ModeledCacheListener;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.data.Stat;
+
+/**
+ * ZookeeperMetadataStore is a class which provides consistent ZK apis for all the metadata store
+ * class.
+ *
+ * <p>Every method provides an async and a sync API. In general, use the async API you are
+ * performing batch operations and a sync if you are performing a synchronous operation on a node.
+ */
+public class ZookeeperMetadataStore<T extends AstraMetadata> implements Closeable {
+  protected final String storeFolder;
+
+  private final ZPath zPath;
+
+  private final CountDownLatch cacheInitialized = new CountDownLatch(1);
+
+  protected final ModeledFramework<T> modeledClient;
+
+  private final CachedModeledFramework<T> cachedModeledFramework;
+
+  private final Map<AstraMetadataStoreChangeListener<T>, ModeledCacheListener<T>> listenerMap =
+      new ConcurrentHashMap<>();
+
+  private final ExecutorService cacheInitializedService;
+  private final ModeledCacheListener<T> initializedListener = getCacheInitializedListener();
+
+  private final AstraConfigs.ZookeeperConfig zkConfig;
+
+  private final MeterRegistry meterRegistry;
+
+  private final String ASTRA_ZK_CREATE_CALL = "astra_zk_create_call";
+  private final String ASTRA_ZK_HAS_CALL = "astra_zk_has_call";
+  private final String ASTRA_ZK_DELETE_CALL = "astra_zk_delete_call";
+  private final String ASTRA_ZK_LIST_CALL = "astra_zk_list_call";
+  private final String ASTRA_ZK_GET_CALL = "astra_zk_get_call";
+  private final String ASTRA_ZK_UPDATE_CALL = "astra_zk_update_call";
+  private final String ASTRA_ZK_ADDED_LISTENER = "astra_zk_added_listener";
+  private final String ASTRA_ZK_REMOVED_LISTENER = "astra_zk_removed_listener";
+  private final String ASTRA_ZK_CACHE_INIT_HANDLER_FIRED = "astra_zk_cache_init_handler_fired";
+
+  private final Counter createCall;
+  private final Counter hasCall;
+  private final Counter deleteCall;
+  private final Counter listCall;
+  private final Counter getCall;
+  private final Counter updateCall;
+  private final Counter addedListener;
+  private final Counter removedListener;
+  private final Counter cacheInitializationHandlerFired;
+
+  public ZookeeperMetadataStore(
+      AsyncCuratorFramework curator,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      CreateMode createMode,
+      boolean shouldCache,
+      ModelSerializer<T> modelSerializer,
+      String storeFolder,
+      MeterRegistry meterRegistry) {
+
+    this.storeFolder = storeFolder;
+    this.zPath = ZPath.parseWithIds(String.format("%s/{name}", storeFolder));
+    this.zkConfig = zkConfig;
+    this.meterRegistry = meterRegistry;
+    String store = "/" + storeFolder.split("/")[1];
+
+    this.createCall = this.meterRegistry.counter(ASTRA_ZK_CREATE_CALL, "store", store);
+    this.deleteCall = this.meterRegistry.counter(ASTRA_ZK_DELETE_CALL, "store", store);
+    this.listCall = this.meterRegistry.counter(ASTRA_ZK_LIST_CALL, "store", store);
+    this.getCall = this.meterRegistry.counter(ASTRA_ZK_GET_CALL, "store", store);
+    this.hasCall = this.meterRegistry.counter(ASTRA_ZK_HAS_CALL, "store", store);
+    this.updateCall = this.meterRegistry.counter(ASTRA_ZK_UPDATE_CALL, "store", store);
+    this.addedListener = this.meterRegistry.counter(ASTRA_ZK_ADDED_LISTENER, "store", store);
+    this.removedListener = this.meterRegistry.counter(ASTRA_ZK_REMOVED_LISTENER, "store", store);
+    this.cacheInitializationHandlerFired =
+        this.meterRegistry.counter(ASTRA_ZK_CACHE_INIT_HANDLER_FIRED, "store", store);
+
+    ModelSpec<T> modelSpec =
+        ModelSpec.builder(modelSerializer)
+            .withPath(zPath)
+            .withCreateOptions(
+                Set.of(CreateOption.createParentsIfNeeded, CreateOption.createParentsAsContainers))
+            .withCreateMode(createMode)
+            .build();
+    modeledClient = ModeledFramework.wrap(curator, modelSpec);
+
+    if (shouldCache) {
+      cacheInitializedService =
+          Executors.newSingleThreadExecutor(
+              new ThreadFactoryBuilder().setNameFormat("cache-initialized-service-%d").build());
+      cachedModeledFramework = modeledClient.cached();
+      cachedModeledFramework.listenable().addListener(initializedListener, cacheInitializedService);
+      cachedModeledFramework.start();
+    } else {
+      cachedModeledFramework = null;
+      cacheInitializedService = null;
+    }
+  }
+
+  public CompletionStage<String> createAsync(T metadataNode) {
+    // by passing the version 0, this will throw if we attempt to create and it already exists
+    return modeledClient.set(metadataNode, 0);
+  }
+
+  public void createSync(T metadataNode) {
+    try {
+      this.createCall.increment();
+
+      createAsync(metadataNode)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<T> getAsync(String path) {
+    if (cachedModeledFramework != null) {
+      return cachedModeledFramework.withPath(zPath.resolved(path)).readThrough();
+    }
+
+    return modeledClient.withPath(zPath.resolved(path)).read();
+  }
+
+  public T getSync(String path) {
+    try {
+      this.getCall.increment();
+
+      return getAsync(path)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  public CompletionStage<Stat> hasAsync(String path) {
+    if (cachedModeledFramework != null) {
+      awaitCacheInitialized();
+      return cachedModeledFramework.withPath(zPath.resolved(path)).checkExists();
+    }
+    return modeledClient.withPath(zPath.resolved(path)).checkExists();
+  }
+
+  public boolean hasSync(String path) {
+    try {
+      this.hasCall.increment();
+
+      return hasAsync(path)
+              .toCompletableFuture()
+              .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
+          != null;
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    return modeledClient.update(metadataNode);
+  }
+
+  public void updateSync(T metadataNode) {
+    try {
+
+      this.updateCall.increment();
+
+      updateAsync(metadataNode)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<Void> deleteAsync(String path) {
+    return modeledClient.withPath(zPath.resolved(path)).delete();
+  }
+
+  public void deleteSync(String path) {
+    try {
+      this.deleteCall.increment();
+
+      deleteAsync(path)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error deleting node under at path: " + path, e);
+    }
+  }
+
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    return modeledClient.withPath(zPath.resolved(metadataNode)).delete();
+  }
+
+  public void deleteSync(T metadataNode) {
+    try {
+      this.deleteCall.increment();
+
+      deleteAsync(metadataNode)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException(
+          "Error deleting node under at path: " + metadataNode.name, e);
+    }
+  }
+
+  public CompletionStage<List<T>> listAsync() {
+    if (cachedModeledFramework == null) {
+      throw new UnsupportedOperationException("Caching is disabled");
+    }
+
+    awaitCacheInitialized();
+    return cachedModeledFramework.list();
+  }
+
+  public List<T> listSync() {
+    try {
+      this.listCall.increment();
+
+      return listAsync()
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error getting cached nodes", e);
+    }
+  }
+
+  public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
+    if (cachedModeledFramework == null) {
+      throw new UnsupportedOperationException("Caching is disabled");
+    }
+
+    this.addedListener.increment();
+
+    // this mapping exists because the remove is by reference, and the listener is a different
+    // object type
+    ModeledCacheListener<T> modeledCacheListener =
+        (type, path, stat, model) -> {
+          // We do not expect the model to ever be null for an event on a metadata node
+          if (model != null) {
+            watcher.onMetadataStoreChanged(model);
+          }
+        };
+    cachedModeledFramework.listenable().addListener(modeledCacheListener);
+    listenerMap.put(watcher, modeledCacheListener);
+  }
+
+  public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
+    if (cachedModeledFramework == null) {
+      throw new UnsupportedOperationException("Caching is disabled");
+    }
+    this.removedListener.increment();
+    cachedModeledFramework.listenable().removeListener(listenerMap.remove(watcher));
+  }
+
+  public void awaitCacheInitialized() {
+    try {
+      if (!cacheInitialized.await(zkConfig.getZkCacheInitTimeoutMs(), TimeUnit.MILLISECONDS)) {
+        // in the event we deadlock, go ahead and time this out at 30s and restart the pod
+        new RuntimeHalterImpl()
+            .handleFatal(
+                new TimeoutException("Timed out waiting for Zookeeper cache to initialize"));
+      }
+    } catch (InterruptedException e) {
+      new RuntimeHalterImpl().handleFatal(e);
+    }
+  }
+
+  private ModeledCacheListener<T> getCacheInitializedListener() {
+    return new ModeledCacheListener<T>() {
+      @Override
+      public void accept(Type type, ZPath path, Stat stat, T model) {
+        // no-op
+      }
+
+      @Override
+      public void initialized() {
+        ModeledCacheListener.super.initialized();
+        cacheInitialized.countDown();
+        if (cacheInitializationHandlerFired != null) {
+          cacheInitializationHandlerFired.increment();
+        }
+
+        // after it's initialized, we no longer need the listener or executor
+        if (cachedModeledFramework != null) {
+          cachedModeledFramework.listenable().removeListener(initializedListener);
+        }
+        if (cacheInitializedService != null) {
+          cacheInitializedService.shutdown();
+        }
+      }
+    };
+  }
+
+  @Override
+  public void close() {
+    if (cachedModeledFramework != null) {
+      listenerMap.forEach(
+          (_, tModeledCacheListener) ->
+              cachedModeledFramework.listenable().removeListener(tModeledCacheListener));
+      cachedModeledFramework.close();
+    }
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/core/ZookeeperPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/ZookeeperPartitioningMetadataStore.java
@@ -1,0 +1,370 @@
+package com.slack.astra.metadata.core;
+
+import com.google.common.collect.Sets;
+import com.slack.astra.proto.config.AstraConfigs;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.apache.curator.x.async.AsyncCuratorFramework;
+import org.apache.curator.x.async.modeled.ModelSerializer;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The ZookeeperPartitioningMetadataStore is a variation of the ZookeeperMetadataStore that allows
+ * for scaling a metadata store that exceeds Zookeepers ideal child node count. This is generally
+ * encountered when attempting to list children or adding a listener encounters an issue exceeding
+ * the jute.maxbuffer.
+ *
+ * <p>This partitioning store enables scaling by introducing an intermediate path to the existing
+ * metadata stores, such that "foo/bar" becomes "/foo/{partitionIdentifier}/bar". For each
+ * partitionIdentifier a separate instance of a ZookeeperMetadataStore is managed within a map. The
+ * partitioning store transparently handles registration and discovery of these partitions, and
+ * passes the various metadata store methods directly to the appropriate partition instance.
+ *
+ * <p>Switching to the partitioning store is not backward compatible with existing non-partitioned
+ * metadata. This could potentially be addressed using a manager api to read and copy the metadata
+ * to the new store path, using the non-partitioned and partitioning stores respectively.
+ */
+public class ZookeeperPartitioningMetadataStore<T extends AstraPartitionedMetadata>
+    implements Closeable {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ZookeeperPartitioningMetadataStore.class);
+  private final Map<String, ZookeeperMetadataStore<T>> metadataStoreMap = new ConcurrentHashMap<>();
+  private final List<AstraMetadataStoreChangeListener<T>> listeners = new CopyOnWriteArrayList<>();
+
+  protected final AsyncCuratorFramework curator;
+  protected final String storeFolder;
+  private final CreateMode createMode;
+  protected final ModelSerializer<T> modelSerializer;
+  private final Watcher watcher;
+  private final List<String> partitionFilters;
+  private final AstraConfigs.ZookeeperConfig zkConfig;
+  private final MeterRegistry meterRegistry;
+
+  public ZookeeperPartitioningMetadataStore(
+      AsyncCuratorFramework curator,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      MeterRegistry meterRegistry,
+      CreateMode createMode,
+      ModelSerializer<T> modelSerializer,
+      String storeFolder) {
+    this(curator, zkConfig, meterRegistry, createMode, modelSerializer, storeFolder, List.of());
+  }
+
+  public ZookeeperPartitioningMetadataStore(
+      AsyncCuratorFramework curator,
+      AstraConfigs.ZookeeperConfig zkConfig,
+      MeterRegistry meterRegistry,
+      CreateMode createMode,
+      ModelSerializer<T> modelSerializer,
+      String storeFolder,
+      List<String> partitionFilters) {
+    this.curator = curator;
+    this.storeFolder = storeFolder;
+    this.createMode = createMode;
+    this.modelSerializer = modelSerializer;
+    this.watcher = buildWatcher();
+    this.partitionFilters = partitionFilters;
+    this.zkConfig = zkConfig;
+    this.meterRegistry = meterRegistry;
+
+    // register watchers for when partitions are added or removed
+    curator
+        .addWatch()
+        .withMode(AddWatchMode.PERSISTENT) // intentionally NOT recursive
+        .usingWatcher(watcher)
+        .forPath(storeFolder);
+
+    // init stores for each existing partition
+    curator
+        .getChildren()
+        .forPath(storeFolder)
+        .exceptionallyCompose(
+            (throwable) -> {
+              if (throwable instanceof KeeperException.NoNodeException) {
+                // This is thrown because the storeFolder does not yet exist in ZK
+                // This isn't a problem, as the node will be created once the first operation is
+                // attempted
+                return CompletableFuture.completedFuture(List.of());
+              } else {
+                return CompletableFuture.failedFuture(throwable);
+              }
+            })
+        .thenAccept(
+            (children) -> {
+              if (partitionFilters.isEmpty()) {
+                children.forEach(this::getOrCreateMetadataStore);
+              } else {
+                children.stream()
+                    .filter(partitionFilters::contains)
+                    .forEach(this::getOrCreateMetadataStore);
+              }
+            })
+        .toCompletableFuture()
+        // wait for all the stores to be initialized prior to exiting the constructor
+        .join();
+
+    if (partitionFilters.isEmpty()) {
+      LOG.info(
+          "The metadata store for folder '{}' was initialized with {} partitions",
+          storeFolder,
+          metadataStoreMap.size());
+    } else {
+      LOG.info(
+          "The metadata store for folder '{}' was initialized with {} partitions (using partition filters: {})",
+          storeFolder,
+          metadataStoreMap.size(),
+          String.join(",", partitionFilters));
+    }
+  }
+
+  /**
+   * Builds a watcher that is responsible for updating our internal metadata stores to match that is
+   * stored in ZK. As we create parent nodes as containers, we do not need to be responsible for
+   * deleting these intermediate nodes as this will be handled by ZK.
+   *
+   * <p>This method creates stores internally when they are detected in ZK storing them to the store
+   * map, and removes stores that are in the map that no longer exist in ZK.
+   *
+   * @see ZookeeperMetadataStore#ZookeeperMetadataStore(AsyncCuratorFramework,
+   *     AstraConfigs.ZookeeperConfig, CreateMode, boolean, ModelSerializer, String,
+   *     io.micrometer.core.instrument.MeterRegistry)
+   */
+  private Watcher buildWatcher() {
+    return event -> {
+      if (event.getType().equals(Watcher.Event.EventType.NodeChildrenChanged)) {
+        curator
+            .getChildren()
+            .forPath(storeFolder)
+            .thenAcceptAsync(
+                (partitions) -> {
+                  if (partitionFilters.isEmpty()) {
+                    // create internal stores foreach partition that do not already exist
+                    partitions.forEach(this::getOrCreateMetadataStore);
+                  } else {
+                    partitions.stream()
+                        .filter(partitionFilters::contains)
+                        .forEach(this::getOrCreateMetadataStore);
+                  }
+
+                  // remove metadata stores that exist in memory but no longer exist on ZK
+                  Set<String> partitionsToRemove =
+                      Sets.difference(metadataStoreMap.keySet(), Sets.newHashSet(partitions));
+                  partitionsToRemove.forEach(
+                      partition -> {
+                        int cachedSize = metadataStoreMap.get(partition).listSync().size();
+                        if (cachedSize == 0) {
+                          LOG.debug("Closing unused store for partition - {}", partition);
+                          ZookeeperMetadataStore<T> store = metadataStoreMap.remove(partition);
+                          store.close();
+                        } else {
+                          // This extra check is to prevent a race condition where multiple items
+                          // are being quickly added. This can result in a scenario where the
+                          // watcher is triggered, but we haven't persisted the items to ZK yet.
+                          // When this happens it results in a premature close of the local cache.
+                          LOG.warn(
+                              "Skipping metadata store close for partition {}, still has {} cached elements",
+                              partition,
+                              cachedSize);
+                        }
+                      });
+                });
+      }
+    };
+  }
+
+  public CompletionStage<String> createAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).createAsync(metadataNode);
+  }
+
+  public void createSync(T metadataNode) {
+    try {
+      createAsync(metadataNode)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error creating node " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<T> getAsync(String partition, String path) {
+    return getOrCreateMetadataStore(partition).getAsync(path);
+  }
+
+  public T getSync(String partition, String path) {
+    try {
+      return getAsync(partition, path)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  /**
+   * Attempts to find the metadata without knowledge of the partition it exists in. Use of this
+   * should be avoided if possible, preferring the getAsync.
+   *
+   * @see ZookeeperPartitioningMetadataStore#getAsync(String, String)
+   */
+  public CompletionStage<T> findAsync(String path) {
+    return getOrCreateMetadataStore(findPartition(path)).getAsync(path);
+  }
+
+  /**
+   * Attempts to find the metadata without knowledge of the partition it exists in. Use of this
+   * should be avoided if possible, preferring the getSync.
+   *
+   * @see ZookeeperPartitioningMetadataStore#getSync(String, String)
+   */
+  public T findSync(String path) {
+    try {
+      return findAsync(path)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error fetching node at path " + path, e);
+    }
+  }
+
+  public CompletionStage<Stat> updateAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).updateAsync(metadataNode);
+  }
+
+  public void updateSync(T metadataNode) {
+    try {
+      updateAsync(metadataNode)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error updating node: " + metadataNode, e);
+    }
+  }
+
+  public CompletionStage<Void> deleteAsync(T metadataNode) {
+    return getOrCreateMetadataStore(metadataNode.getPartition()).deleteAsync(metadataNode);
+  }
+
+  public void deleteSync(T metadataNode) {
+    try {
+      deleteAsync(metadataNode)
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException(
+          "Error deleting node under at path: " + metadataNode.name, e);
+    }
+  }
+
+  public CompletableFuture<List<T>> listAsync() {
+    List<CompletableFuture<List<T>>> completionStages = new ArrayList<>();
+    for (Map.Entry<String, ZookeeperMetadataStore<T>> metadataStoreEntry :
+        metadataStoreMap.entrySet()) {
+      completionStages.add(metadataStoreEntry.getValue().listAsync().toCompletableFuture());
+    }
+
+    return CompletableFuture.allOf(completionStages.toArray(new CompletableFuture[0]))
+        .thenApply(
+            (unused) ->
+                completionStages.stream()
+                    .map(f -> f.toCompletableFuture().join())
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList()));
+  }
+
+  public List<T> listSync() {
+    try {
+      return listAsync()
+          .toCompletableFuture()
+          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing nodes", e);
+    }
+  }
+
+  private ZookeeperMetadataStore<T> getOrCreateMetadataStore(String partition) {
+    if (!partitionFilters.isEmpty() && !partitionFilters.contains(partition)) {
+      LOG.error(
+          "Partitioning metadata store attempted to use partition {}, filters restricted to {}",
+          partition,
+          String.join(",", partitionFilters));
+      throw new InternalMetadataStoreException(
+          "Partitioning metadata store using filters that does not include provided partition");
+    }
+
+    return metadataStoreMap.computeIfAbsent(
+        partition,
+        (p1) -> {
+          String path = String.format("%s/%s", storeFolder, p1);
+          LOG.debug(
+              "Creating new metadata store for partition - {}, at path - {}", partition, path);
+
+          ZookeeperMetadataStore<T> newStore =
+              new ZookeeperMetadataStore<>(
+                  curator, zkConfig, createMode, true, modelSerializer, path, meterRegistry);
+          listeners.forEach(newStore::addListener);
+
+          return newStore;
+        });
+  }
+
+  /**
+   * Attempts to locate the partition containing the sub-path. If no partition is found this will
+   * throw an InternalMetadataStoreException. Use of this method should be carefully considered due
+   * to performance implications of potentially invoking N hasSync calls.
+   */
+  private String findPartition(String path) {
+    for (Map.Entry<String, ZookeeperMetadataStore<T>> metadataStoreEntry :
+        metadataStoreMap.entrySet()) {
+      // We may consider switching this to execute in parallel in the future. Even though this would
+      // be faster, it would put quite a bit more load on ZK, and some of it unnecessary
+      if (metadataStoreEntry.getValue().hasSync(path)) {
+        return metadataStoreEntry.getKey();
+      }
+    }
+    throw new InternalMetadataStoreException("Error finding node at path " + path);
+  }
+
+  public void addListener(AstraMetadataStoreChangeListener<T> watcher) {
+    // add this watcher to the list for new stores to add
+    listeners.add(watcher);
+    // add this watcher to existing stores
+    metadataStoreMap.forEach((_, store) -> store.addListener(watcher));
+  }
+
+  public void removeListener(AstraMetadataStoreChangeListener<T> watcher) {
+    listeners.remove(watcher);
+    metadataStoreMap.forEach((_, store) -> store.removeListener(watcher));
+  }
+
+  @Override
+  public void close() throws IOException {
+    LOG.info(
+        "Closing the partitioning metadata store, {} listeners to remove, {} partitions to close",
+        listeners.size(),
+        metadataStoreMap.size());
+
+    // only remove the watcher we created, since this curator instance is a singleton
+    curator.removeWatches().removing(watcher);
+    listeners.forEach(this::removeListener);
+    metadataStoreMap.forEach((partition, store) -> store.close());
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/dataset/DatasetMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/dataset/DatasetMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.dataset;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -12,17 +13,20 @@ public class DatasetMetadataStore extends AstraMetadataStore<DatasetMetadata> {
 
   public DatasetMetadataStore(
       AsyncCuratorFramework curator,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
-      boolean shouldCache)
-      throws Exception {
+      boolean shouldCache) {
     super(
-        curator,
-        zkConfig,
-        CreateMode.PERSISTENT,
-        shouldCache,
-        new DatasetMetadataSerializer().toModelSerializer(),
-        DATASET_METADATA_STORE_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curator,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.PERSISTENT,
+            shouldCache,
+            new DatasetMetadataSerializer().toModelSerializer(),
+            DATASET_METADATA_STORE_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/fieldredaction/FieldRedactionMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/fieldredaction/FieldRedactionMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.fieldredaction;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -11,16 +12,20 @@ public class FieldRedactionMetadataStore extends AstraMetadataStore<FieldRedacti
 
   public FieldRedactionMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
       boolean shouldCache) {
     super(
-        curatorFramework,
-        zkConfig,
-        CreateMode.PERSISTENT,
-        shouldCache,
-        new FieldRedactionMetadataSerializer().toModelSerializer(),
-        REDACTED_FIELD_METADATA_STORE_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.PERSISTENT,
+            shouldCache,
+            new FieldRedactionMetadataSerializer().toModelSerializer(),
+            REDACTED_FIELD_METADATA_STORE_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/hpa/HpaMetricMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/hpa/HpaMetricMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.hpa;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -11,16 +12,20 @@ public class HpaMetricMetadataStore extends AstraMetadataStore<HpaMetricMetadata
 
   public HpaMetricMetadataStore(
       AsyncCuratorFramework curator,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
       boolean shouldCache) {
     super(
-        curator,
-        zkConfig,
-        CreateMode.EPHEMERAL,
-        shouldCache,
-        new HpaMetricMetadataSerializer().toModelSerializer(),
-        AUTOSCALER_METADATA_STORE_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curator,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.EPHEMERAL,
+            shouldCache,
+            new HpaMetricMetadataSerializer().toModelSerializer(),
+            AUTOSCALER_METADATA_STORE_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/preprocessor/PreprocessorMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/preprocessor/PreprocessorMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.preprocessor;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -10,21 +11,25 @@ public class PreprocessorMetadataStore extends AstraMetadataStore<PreprocessorMe
   public static final String PREPROCESSOR_ZK_PATH = "/preprocessors";
 
   /**
-   * Initializes a cache slot metadata store at the CACHE_SLOT_ZK_PATH. This should be used to
-   * create/update the cache slots, and for listening to all cache slot events.
+   * Initializes a preprocessor metadata store at the PREPROCESSOR_ZK_PATH. This should be used to
+   * create/update the preprocessors, and for listening to all preprocessor events.
    */
   public PreprocessorMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
       boolean shouldCache) {
     super(
-        curatorFramework,
-        zkConfig,
-        CreateMode.EPHEMERAL,
-        shouldCache,
-        new PreprocessorMetadataSerializer().toModelSerializer(),
-        PREPROCESSOR_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.EPHEMERAL,
+            shouldCache,
+            new PreprocessorMetadataSerializer().toModelSerializer(),
+            PREPROCESSOR_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryNodeMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryNodeMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.recovery;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -15,16 +16,20 @@ public class RecoveryNodeMetadataStore extends AstraMetadataStore<RecoveryNodeMe
    */
   public RecoveryNodeMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
       boolean shouldCache) {
     super(
-        curatorFramework,
-        zkConfig,
-        CreateMode.EPHEMERAL,
-        shouldCache,
-        new RecoveryNodeMetadataSerializer().toModelSerializer(),
-        RECOVERY_NODE_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.EPHEMERAL,
+            shouldCache,
+            new RecoveryNodeMetadataSerializer().toModelSerializer(),
+            RECOVERY_NODE_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 
@@ -35,17 +40,21 @@ public class RecoveryNodeMetadataStore extends AstraMetadataStore<RecoveryNodeMe
    */
   public RecoveryNodeMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
       String recoveryNodeName,
       boolean shouldCache) {
     super(
-        curatorFramework,
-        zkConfig,
-        CreateMode.EPHEMERAL,
-        shouldCache,
-        new RecoveryNodeMetadataSerializer().toModelSerializer(),
-        String.format("%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName),
+        new ZookeeperMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.EPHEMERAL,
+            shouldCache,
+            new RecoveryNodeMetadataSerializer().toModelSerializer(),
+            String.format("%s/%s", RECOVERY_NODE_ZK_PATH, recoveryNodeName),
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryTaskMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/recovery/RecoveryTaskMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.recovery;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -11,17 +12,21 @@ public class RecoveryTaskMetadataStore extends AstraMetadataStore<RecoveryTaskMe
 
   public RecoveryTaskMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
       boolean shouldCache)
       throws Exception {
     super(
-        curatorFramework,
-        zkConfig,
-        CreateMode.PERSISTENT,
-        shouldCache,
-        new RecoveryTaskMetadataSerializer().toModelSerializer(),
-        RECOVERY_TASK_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.PERSISTENT,
+            shouldCache,
+            new RecoveryTaskMetadataSerializer().toModelSerializer(),
+            RECOVERY_TASK_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/replica/ReplicaMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/replica/ReplicaMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.replica;
 
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperPartitioningMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -11,15 +12,19 @@ public class ReplicaMetadataStore extends AstraPartitioningMetadataStore<Replica
 
   public ReplicaMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry)
       throws Exception {
     super(
-        curatorFramework,
-        zkConfig,
-        meterRegistry,
-        CreateMode.PERSISTENT,
-        new ReplicaMetadataSerializer().toModelSerializer(),
-        REPLICA_STORE_ZK_PATH);
+        new ZookeeperPartitioningMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            meterRegistry,
+            CreateMode.PERSISTENT,
+            new ReplicaMetadataSerializer().toModelSerializer(),
+            REPLICA_STORE_ZK_PATH),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
+        meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
@@ -2,35 +2,39 @@ package com.slack.astra.metadata.search;
 
 import com.slack.astra.metadata.core.AstraMetadataStore;
 import com.slack.astra.metadata.core.InternalMetadataStoreException;
+import com.slack.astra.metadata.core.ZookeeperMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.curator.x.async.AsyncCuratorFramework;
-import org.apache.curator.x.async.AsyncStage;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
 
 public class SearchMetadataStore extends AstraMetadataStore<SearchMetadata> {
   public static final String SEARCH_METADATA_STORE_ZK_PATH = "/search";
-  private final AstraConfigs.ZookeeperConfig zkConfig;
+  private final AstraConfigs.MetadataStoreConfig metadataStoreConfig;
 
   public SearchMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry,
-      boolean shouldCache)
-      throws Exception {
+      boolean shouldCache) {
     super(
-        curatorFramework,
-        zkConfig,
-        CreateMode.EPHEMERAL,
-        shouldCache,
-        new SearchMetadataSerializer().toModelSerializer(),
-        SEARCH_METADATA_STORE_ZK_PATH,
+        new ZookeeperMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            CreateMode.EPHEMERAL,
+            shouldCache,
+            new SearchMetadataSerializer().toModelSerializer(),
+            SEARCH_METADATA_STORE_ZK_PATH,
+            meterRegistry),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
         meterRegistry);
-    this.zkConfig = zkConfig;
+    this.metadataStoreConfig = metadataStoreConfig;
   }
 
   // ONLY updating the `searchable` field is allowed on SearchMetadata.
@@ -40,14 +44,23 @@ public class SearchMetadataStore extends AstraMetadataStore<SearchMetadata> {
     try {
       super.updateAsync(oldSearchMetadata)
           .toCompletableFuture()
-          .get(zkConfig.getZkConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+          .get(
+              metadataStoreConfig.hasZookeeperConfig()
+                  ? metadataStoreConfig.getZookeeperConfig().getZkConnectionTimeoutMs()
+                  : 1000,
+              TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error updating node: " + oldSearchMetadata, e);
     }
   }
 
   @Override
-  public AsyncStage<Stat> updateAsync(SearchMetadata metadataNode) {
+  public CompletionStage<Stat> updateAsync(SearchMetadata metadataNode) {
+    throw new UnsupportedOperationException("Updates are not permitted for search metadata");
+  }
+
+  @Override
+  public void updateSync(SearchMetadata metadataNode) {
     throw new UnsupportedOperationException("Updates are not permitted for search metadata");
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.data.Stat;
 
 public class SearchMetadataStore extends AstraMetadataStore<SearchMetadata> {
   public static final String SEARCH_METADATA_STORE_ZK_PATH = "/search";
@@ -55,7 +54,7 @@ public class SearchMetadataStore extends AstraMetadataStore<SearchMetadata> {
   }
 
   @Override
-  public CompletionStage<Stat> updateAsync(SearchMetadata metadataNode) {
+  public CompletionStage<String> updateAsync(SearchMetadata metadataNode) {
     throw new UnsupportedOperationException("Updates are not permitted for search metadata");
   }
 

--- a/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/snapshot/SnapshotMetadataStore.java
@@ -1,6 +1,7 @@
 package com.slack.astra.metadata.snapshot;
 
 import com.slack.astra.metadata.core.AstraPartitioningMetadataStore;
+import com.slack.astra.metadata.core.ZookeeperPartitioningMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.curator.x.async.AsyncCuratorFramework;
@@ -13,15 +14,19 @@ public class SnapshotMetadataStore extends AstraPartitioningMetadataStore<Snapsh
 
   public SnapshotMetadataStore(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       MeterRegistry meterRegistry)
       throws Exception {
     super(
-        curatorFramework,
-        zkConfig,
-        meterRegistry,
-        CreateMode.PERSISTENT,
-        new SnapshotMetadataSerializer().toModelSerializer(),
-        SNAPSHOT_METADATA_STORE_ZK_PATH);
+        new ZookeeperPartitioningMetadataStore<>(
+            curatorFramework,
+            metadataStoreConfig.getZookeeperConfig(),
+            meterRegistry,
+            CreateMode.PERSISTENT,
+            new SnapshotMetadataSerializer().toModelSerializer(),
+            SNAPSHOT_METADATA_STORE_ZK_PATH),
+        null, // Not using etcdStore for now
+        metadataStoreConfig.getMode(),
+        meterRegistry);
   }
 }

--- a/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
+++ b/astra/src/main/java/com/slack/astra/recovery/RecoveryService.java
@@ -137,27 +137,16 @@ public class RecoveryService extends AbstractIdleService {
 
     recoveryNodeMetadataStore =
         new RecoveryNodeMetadataStore(
-            curatorFramework,
-            AstraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, AstraConfig.getMetadataStoreConfig(), meterRegistry, false);
     recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(
-            curatorFramework,
-            AstraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, AstraConfig.getMetadataStoreConfig(), meterRegistry, false);
     snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            AstraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, AstraConfig.getMetadataStoreConfig(), meterRegistry);
     searchMetadataStore =
         new SearchMetadataStore(
-            curatorFramework,
-            AstraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, AstraConfig.getMetadataStoreConfig(), meterRegistry, false);
 
     recoveryNodeMetadataStore.createSync(
         new RecoveryNodeMetadata(
@@ -170,7 +159,7 @@ public class RecoveryService extends AbstractIdleService {
     recoveryNodeListenerMetadataStore =
         new RecoveryNodeMetadataStore(
             curatorFramework,
-            AstraConfig.getMetadataStoreConfig().getZookeeperConfig(),
+            AstraConfig.getMetadataStoreConfig(),
             meterRegistry,
             searchContext.hostname,
             true);

--- a/astra/src/main/java/com/slack/astra/server/Astra.java
+++ b/astra/src/main/java/com/slack/astra/server/Astra.java
@@ -169,7 +169,7 @@ public class Astra {
               meterRegistry,
               curatorFramework,
               astraConfig.getIndexerConfig(),
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
+              astraConfig.getMetadataStoreConfig(),
               blobStore,
               astraConfig.getS3Config());
       services.add(chunkManager);
@@ -178,7 +178,7 @@ public class Astra {
           new AstraIndexer(
               chunkManager,
               curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
+              astraConfig.getMetadataStoreConfig(),
               astraConfig.getIndexerConfig(),
               astraConfig.getIndexerConfig().getKafkaConfig(),
               meterRegistry);
@@ -194,10 +194,7 @@ public class Astra {
 
       FieldRedactionMetadataStore fieldRedactionMetadataStore =
           new FieldRedactionMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       RedactionUpdateService redactionUpdateService =
           new RedactionUpdateService(
               fieldRedactionMetadataStore, astraConfig.getRedactionUpdateServiceConfig());
@@ -215,21 +212,13 @@ public class Astra {
     if (roles.contains(AstraConfigs.NodeRole.QUERY)) {
       SearchMetadataStore searchMetadataStore =
           new SearchMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       SnapshotMetadataStore snapshotMetadataStore =
           new SnapshotMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry);
       DatasetMetadataStore datasetMetadataStore =
           new DatasetMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
 
       services.add(
           new CloseableLifecycleManager(
@@ -266,7 +255,7 @@ public class Astra {
           CachingChunkManager.fromConfig(
               meterRegistry,
               curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
+              astraConfig.getMetadataStoreConfig(),
               astraConfig.getS3Config(),
               astraConfig.getCacheConfig(),
               blobStore);
@@ -274,16 +263,10 @@ public class Astra {
 
       HpaMetricMetadataStore hpaMetricMetadataStore =
           new HpaMetricMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       FieldRedactionMetadataStore fieldRedactionMetadataStore =
           new FieldRedactionMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
 
       services.add(
           new CloseableLifecycleManager(
@@ -319,49 +302,28 @@ public class Astra {
 
       ReplicaMetadataStore replicaMetadataStore =
           new ReplicaMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry);
       SnapshotMetadataStore snapshotMetadataStore =
           new SnapshotMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry);
       RecoveryTaskMetadataStore recoveryTaskMetadataStore =
           new RecoveryTaskMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       RecoveryNodeMetadataStore recoveryNodeMetadataStore =
           new RecoveryNodeMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       CacheSlotMetadataStore cacheSlotMetadataStore =
           new CacheSlotMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry);
       DatasetMetadataStore datasetMetadataStore =
           new DatasetMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       HpaMetricMetadataStore hpaMetricMetadataStore =
           new HpaMetricMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       FieldRedactionMetadataStore fieldRedactionMetadataStore =
           new FieldRedactionMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
 
       Duration requestTimeout =
           Duration.ofMillis(astraConfig.getManagerConfig().getServerConfig().getRequestTimeoutMs());
@@ -421,14 +383,10 @@ public class Astra {
 
       CacheNodeMetadataStore cacheNodeMetadataStore =
           new CacheNodeMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry);
       CacheNodeAssignmentStore cacheNodeAssignmentStore =
           new CacheNodeAssignmentStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry);
 
       ClusterHpaMetricService clusterHpaMetricService =
           new ClusterHpaMetricService(
@@ -479,10 +437,7 @@ public class Astra {
 
       SearchMetadataStore searchMetadataStore =
           new SearchMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
       CacheNodeSearchabilityService cacheNodeSearchabilityService =
           new CacheNodeSearchabilityService(
               meterRegistry,
@@ -516,17 +471,11 @@ public class Astra {
     if (roles.contains(AstraConfigs.NodeRole.PREPROCESSOR)) {
       DatasetMetadataStore datasetMetadataStore =
           new DatasetMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
 
       PreprocessorMetadataStore preprocessorMetadataStore =
           new PreprocessorMetadataStore(
-              curatorFramework,
-              astraConfig.getMetadataStoreConfig().getZookeeperConfig(),
-              meterRegistry,
-              true);
+              curatorFramework, astraConfig.getMetadataStoreConfig(), meterRegistry, true);
 
       final AstraConfigs.PreprocessorConfig preprocessorConfig =
           astraConfig.getPreprocessorConfig();

--- a/astra/src/main/java/com/slack/astra/server/AstraIndexer.java
+++ b/astra/src/main/java/com/slack/astra/server/AstraIndexer.java
@@ -28,7 +28,7 @@ public class AstraIndexer extends AbstractExecutionThreadService {
 
   private final AsyncCuratorFramework curatorFramework;
   private final MeterRegistry meterRegistry;
-  private final AstraConfigs.ZookeeperConfig zkConfig;
+  private final AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private final AstraConfigs.IndexerConfig indexerConfig;
   private final AstraConfigs.KafkaConfig kafkaConfig;
   private final AstraKafkaConsumer kafkaConsumer;
@@ -54,13 +54,13 @@ public class AstraIndexer extends AbstractExecutionThreadService {
   public AstraIndexer(
       IndexingChunkManager<LogMessage> chunkManager,
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       AstraConfigs.IndexerConfig indexerConfig,
       AstraConfigs.KafkaConfig kafkaConfig,
       MeterRegistry meterRegistry) {
     checkNotNull(chunkManager, "Chunk manager can't be null");
     this.curatorFramework = curatorFramework;
-    this.zkConfig = zkConfig;
+    this.metadataStoreConfig = metadataStoreConfig;
     this.indexerConfig = indexerConfig;
     this.kafkaConfig = kafkaConfig;
     this.meterRegistry = meterRegistry;
@@ -92,9 +92,9 @@ public class AstraIndexer extends AbstractExecutionThreadService {
   private long indexerPreStart() throws Exception {
     LOG.info("Starting Astra indexer pre start.");
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
-        new RecoveryTaskMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new RecoveryTaskMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
 
     String partitionId = kafkaConfig.getKafkaTopicPartition();
     long maxOffsetDelay = indexerConfig.getMaxOffsetDelayMessages();

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -52,8 +52,16 @@ message KafkaConfig {
   map<string, string> additional_props = 8;
 }
 
+enum MetadataStoreMode {
+  ZookeeperExclusive = 0;
+  EtcdExclusive = 1;
+  BothReadZookeeperWrite = 2;
+  BothReadEtcdWrite = 3;
+}
+
 message MetadataStoreConfig {
   ZookeeperConfig zookeeper_config = 1;
+  MetadataStoreMode mode = 3;
 }
 
 // Configuration for Zookeeper metadata store.

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -53,10 +53,10 @@ message KafkaConfig {
 }
 
 enum MetadataStoreMode {
-  ZookeeperExclusive = 0;
-  EtcdExclusive = 1;
-  BothReadZookeeperWrite = 2;
-  BothReadEtcdWrite = 3;
+  ZOOKEEPER_EXCLUSIVE = 0;
+  ETCD_EXCLUSIVE = 1;
+  BOTH_READ_ZOOKEEPER_WRITE = 2;
+  BOTH_READ_ETCD_WRITE = 3;
 }
 
 message MetadataStoreConfig {

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -70,6 +70,13 @@ class BulkIngestKafkaProducerTest {
             .setSleepBetweenRetriesMs(1000)
             .setZkCacheInitTimeoutMs(1000)
             .build();
+
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
     kafkaServer = new TestKafkaServer();
@@ -94,7 +101,7 @@ class BulkIngestKafkaProducerTest {
             .build();
 
     datasetMetadataStore =
-        new DatasetMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new DatasetMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
             INDEX_NAME,

--- a/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
+++ b/astra/src/test/java/com/slack/astra/bulkIngestApi/BulkIngestKafkaProducerTest.java
@@ -73,7 +73,7 @@ class BulkIngestKafkaProducerTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -102,7 +102,7 @@ public class IndexingChunkImplTest {
       testingServer = new TestingServer();
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(
                   AstraConfigs.ZookeeperConfig.newBuilder()
                       .setZkConnectString(testingServer.getConnectString())
@@ -459,7 +459,7 @@ public class IndexingChunkImplTest {
       testingServer = new TestingServer();
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(
                   AstraConfigs.ZookeeperConfig.newBuilder()
                       .setZkConnectString(testingServer.getConnectString())
@@ -550,7 +550,7 @@ public class IndexingChunkImplTest {
       testingServer = new TestingServer();
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(
                   AstraConfigs.ZookeeperConfig.newBuilder()
                       .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/IndexingChunkImplTest.java
@@ -100,24 +100,28 @@ public class IndexingChunkImplTest {
       Tracing.newBuilder().build();
 
       testingServer = new TestingServer();
-      AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
-              .setZkConnectString(testingServer.getConnectString())
-              .setZkPathPrefix("shouldHandleChunkLivecycle")
-              .setZkSessionTimeoutMs(1000)
-              .setZkConnectionTimeoutMs(1000)
-              .setSleepBetweenRetriesMs(1000)
-              .setZkCacheInitTimeoutMs(1000)
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(
+                  AstraConfigs.ZookeeperConfig.newBuilder()
+                      .setZkConnectString(testingServer.getConnectString())
+                      .setZkPathPrefix("shouldHandleChunkLivecycle")
+                      .setZkSessionTimeoutMs(1000)
+                      .setZkConnectionTimeoutMs(1000)
+                      .setSleepBetweenRetriesMs(1000)
+                      .setZkCacheInitTimeoutMs(1000)
+                      .build())
               .build();
 
       registry = new SimpleMeterRegistry();
 
-      curatorFramework = CuratorBuilder.build(registry, zkConfig);
+      curatorFramework = CuratorBuilder.build(registry, metadataStoreConfig.getZookeeperConfig());
 
       SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, zkConfig, registry);
+          new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, registry);
       SearchMetadataStore searchMetadataStore =
-          new SearchMetadataStore(curatorFramework, zkConfig, registry, true);
+          new SearchMetadataStore(curatorFramework, metadataStoreConfig, registry, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -453,24 +457,28 @@ public class IndexingChunkImplTest {
       Tracing.newBuilder().build();
 
       testingServer = new TestingServer();
-      AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
-              .setZkConnectString(testingServer.getConnectString())
-              .setZkPathPrefix("shouldHandleChunkLivecycle")
-              .setZkSessionTimeoutMs(1000)
-              .setZkConnectionTimeoutMs(1000)
-              .setSleepBetweenRetriesMs(1000)
-              .setZkCacheInitTimeoutMs(1000)
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(
+                  AstraConfigs.ZookeeperConfig.newBuilder()
+                      .setZkConnectString(testingServer.getConnectString())
+                      .setZkPathPrefix("shouldHandleChunkLivecycle")
+                      .setZkSessionTimeoutMs(1000)
+                      .setZkConnectionTimeoutMs(1000)
+                      .setSleepBetweenRetriesMs(1000)
+                      .setZkCacheInitTimeoutMs(1000)
+                      .build())
               .build();
 
       registry = new SimpleMeterRegistry();
 
-      curatorFramework = CuratorBuilder.build(registry, zkConfig);
+      curatorFramework = CuratorBuilder.build(registry, metadataStoreConfig.getZookeeperConfig());
 
       SnapshotMetadataStore snapshotMetadataStore =
-          new SnapshotMetadataStore(curatorFramework, zkConfig, registry);
+          new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, registry);
       SearchMetadataStore searchMetadataStore =
-          new SearchMetadataStore(curatorFramework, zkConfig, registry, true);
+          new SearchMetadataStore(curatorFramework, metadataStoreConfig, registry, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -540,22 +548,28 @@ public class IndexingChunkImplTest {
     public void setUp() throws Exception {
       Tracing.newBuilder().build();
       testingServer = new TestingServer();
-      AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
-              .setZkConnectString(testingServer.getConnectString())
-              .setZkPathPrefix("shouldHandleChunkLivecycle")
-              .setZkSessionTimeoutMs(1000)
-              .setZkConnectionTimeoutMs(1000)
-              .setSleepBetweenRetriesMs(1000)
-              .setZkCacheInitTimeoutMs(1000)
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(
+                  AstraConfigs.ZookeeperConfig.newBuilder()
+                      .setZkConnectString(testingServer.getConnectString())
+                      .setZkPathPrefix("shouldHandleChunkLivecycle")
+                      .setZkSessionTimeoutMs(1000)
+                      .setZkConnectionTimeoutMs(1000)
+                      .setSleepBetweenRetriesMs(1000)
+                      .setZkCacheInitTimeoutMs(1000)
+                      .build())
               .build();
 
       registry = new SimpleMeterRegistry();
 
-      curatorFramework = CuratorBuilder.build(registry, zkConfig);
+      curatorFramework = CuratorBuilder.build(registry, metadataStoreConfig.getZookeeperConfig());
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, registry);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, registry, true);
+      snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, registry);
+      searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, metadataStoreConfig, registry, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -102,29 +102,34 @@ public class ReadOnlyChunkImplTest {
   @Test
   public void shouldHandleChunkLivecycle() throws Exception {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("shouldHandleChunkLivecycle")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("shouldHandleChunkLivecycle")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    AsyncCuratorFramework curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeAssignmentStore cacheNodeAssignmentStore =
-        new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeMetadataStore cacheNodeMetadataStore =
-        new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "boo";
@@ -133,8 +138,8 @@ public class ReadOnlyChunkImplTest {
     String replicaSet = "cat";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 0);
+    initializeZkReplica(curatorFramework, metadataStoreConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, metadataStoreConfig, snapshotId, 0);
     initializeBlobStorageWithIndex(snapshotId);
     initializeCacheNodeAssignment(
         cacheNodeAssignmentStore, assignmentId, snapshotId, cacheNodeId, replicaSet, replicaId);
@@ -260,35 +265,40 @@ public class ReadOnlyChunkImplTest {
   @Test
   public void shouldHandleMissingS3Assets() throws Exception {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("shouldHandleMissingS3Assets")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("shouldHandleMissingS3Assets")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    AsyncCuratorFramework curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeMetadataStore cacheNodeMetadataStore =
-        new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
     String cacheNodeId = "baz";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 0);
+    initializeZkReplica(curatorFramework, metadataStoreConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, metadataStoreConfig, snapshotId, 0);
     initializeCacheNode(cacheNodeMetadataStore, cacheNodeId, "some-host.name", 1, "rep1", true);
 
     ReadOnlyChunkImpl<LogMessage> readOnlyChunk =
@@ -336,34 +346,39 @@ public class ReadOnlyChunkImplTest {
   @Test
   public void shouldHandleMissingZkData() throws Exception {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("shouldHandleMissingZkData")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("shouldHandleMissingZkData")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    AsyncCuratorFramework curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeMetadataStore cacheNodeMetadataStore =
-        new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
     String cacheNodeId = "baz";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
+    initializeZkReplica(curatorFramework, metadataStoreConfig, replicaId, snapshotId);
     initializeCacheNode(cacheNodeMetadataStore, cacheNodeId, "some-host.name", 1, "rep1", true);
     // we intentionally do not initialize a Snapshot, so the lookup is expected to fail
 
@@ -412,29 +427,34 @@ public class ReadOnlyChunkImplTest {
   @Test
   public void closeShouldCleanupLiveChunkCorrectly() throws Exception {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("shouldHandleChunkLivecycle")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("shouldHandleChunkLivecycle")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    AsyncCuratorFramework curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeMetadataStore cacheNodeMetadataStore =
-        new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeAssignmentStore cacheNodeAssignmentStore =
-        new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "bar";
@@ -443,8 +463,8 @@ public class ReadOnlyChunkImplTest {
     String assignmentId = "dog";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 0);
+    initializeZkReplica(curatorFramework, metadataStoreConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, metadataStoreConfig, snapshotId, 0);
     initializeBlobStorageWithIndex(snapshotId);
     initializeCacheNodeAssignment(
         cacheNodeAssignmentStore, assignmentId, snapshotId, cacheNodeId, replicaSet, replicaId);
@@ -534,29 +554,34 @@ public class ReadOnlyChunkImplTest {
   @Test
   public void shouldHandleDynamicChunkSizeLifecycle() throws Exception {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("shouldHandleChunkLivecycle")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("shouldHandleChunkLivecycle")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    AsyncCuratorFramework curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     CacheSlotMetadataStore cacheSlotMetadataStore =
-        new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeAssignmentStore cacheNodeAssignmentStore =
-        new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry);
     CacheNodeMetadataStore cacheNodeMetadataStore =
-        new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     String replicaId = "foo";
     String snapshotId = "boo";
@@ -565,8 +590,8 @@ public class ReadOnlyChunkImplTest {
     String replicaSet = "cat";
 
     // setup Zk, BlobFs so data can be loaded
-    initializeZkReplica(curatorFramework, zkConfig, replicaId, snapshotId);
-    initializeZkSnapshot(curatorFramework, zkConfig, snapshotId, 29);
+    initializeZkReplica(curatorFramework, metadataStoreConfig, replicaId, snapshotId);
+    initializeZkSnapshot(curatorFramework, metadataStoreConfig, snapshotId, 29);
     initializeBlobStorageWithIndex(snapshotId);
     initializeCacheNodeAssignment(
         cacheNodeAssignmentStore, assignmentId, snapshotId, cacheNodeId, replicaSet, replicaId);
@@ -669,12 +694,12 @@ public class ReadOnlyChunkImplTest {
 
   private void initializeZkSnapshot(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       String snapshotId,
       long sizeInBytesOnDisk)
       throws Exception {
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     snapshotMetadataStore.createSync(
         new SnapshotMetadata(
             snapshotId,
@@ -687,12 +712,12 @@ public class ReadOnlyChunkImplTest {
 
   private void initializeZkReplica(
       AsyncCuratorFramework curatorFramework,
-      AstraConfigs.ZookeeperConfig zkConfig,
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig,
       String replicaId,
       String snapshotId)
       throws Exception {
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     replicaMetadataStore.createSync(
         new ReplicaMetadata(
             replicaId,

--- a/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/ReadOnlyChunkImplTest.java
@@ -104,7 +104,7 @@ public class ReadOnlyChunkImplTest {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())
@@ -267,7 +267,7 @@ public class ReadOnlyChunkImplTest {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())
@@ -348,7 +348,7 @@ public class ReadOnlyChunkImplTest {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())
@@ -429,7 +429,7 @@ public class ReadOnlyChunkImplTest {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())
@@ -556,7 +556,7 @@ public class ReadOnlyChunkImplTest {
     AstraConfigs.AstraConfig AstraConfig = makeCacheConfig();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -90,10 +90,19 @@ public class RecoveryChunkImplTest {
               .setSleepBetweenRetriesMs(1000)
               .setZkCacheInitTimeoutMs(1000)
               .build();
+
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(zkConfig)
+              .build();
+
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, registry);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, registry, false);
+      snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, registry);
+      searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, metadataStoreConfig, registry, false);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -452,10 +461,19 @@ public class RecoveryChunkImplTest {
               .setSleepBetweenRetriesMs(1000)
               .setZkCacheInitTimeoutMs(1000)
               .build();
+
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(zkConfig)
+              .build();
+
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, registry);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, registry, false);
+      snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, registry);
+      searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, metadataStoreConfig, registry, false);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(
@@ -536,12 +554,20 @@ public class RecoveryChunkImplTest {
               .setZkCacheInitTimeoutMs(1000)
               .build();
 
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(zkConfig)
+              .build();
+
       registry = new SimpleMeterRegistry();
 
       curatorFramework = CuratorBuilder.build(registry, zkConfig);
 
-      snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, registry);
-      searchMetadataStore = new SearchMetadataStore(curatorFramework, zkConfig, registry, true);
+      snapshotMetadataStore =
+          new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, registry);
+      searchMetadataStore =
+          new SearchMetadataStore(curatorFramework, metadataStoreConfig, registry, true);
 
       final LuceneIndexStoreImpl logStore =
           LuceneIndexStoreImpl.makeLogStore(

--- a/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
+++ b/astra/src/test/java/com/slack/astra/chunk/RecoveryChunkImplTest.java
@@ -93,7 +93,7 @@ public class RecoveryChunkImplTest {
 
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(zkConfig)
               .build();
 
@@ -464,7 +464,7 @@ public class RecoveryChunkImplTest {
 
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(zkConfig)
               .build();
 
@@ -556,7 +556,7 @@ public class RecoveryChunkImplTest {
 
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(zkConfig)
               .build();
 

--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -73,6 +73,7 @@ public class CachingChunkManagerTest {
 
   private AsyncCuratorFramework curatorFramework;
   private AstraConfigs.ZookeeperConfig zkConfig;
+  private AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private CachingChunkManager<LogMessage> cachingChunkManager;
   private CacheNodeAssignmentStore cacheNodeAssignmentStore;
   private SnapshotMetadataStore snapshotMetadataStore;
@@ -141,11 +142,17 @@ public class CachingChunkManagerTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
+    metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     CachingChunkManager<LogMessage> cachingChunkManager =
         new CachingChunkManager<>(
             meterRegistry,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             blobStore,
             SearchContext.fromConfig(AstraConfig.getCacheConfig().getServerConfig()),
             AstraConfig.getS3Config().getS3Bucket(),
@@ -161,8 +168,9 @@ public class CachingChunkManagerTest {
 
   private CacheNodeAssignment initAssignment(String snapshotId) throws Exception {
     cacheNodeAssignmentStore =
-        new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry);
+    snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     snapshotMetadataStore.createSync(new SnapshotMetadata(snapshotId, 1, 1, 0, "abcd", 29));
     CacheNodeAssignment newAssignment =
         new CacheNodeAssignment(
@@ -276,7 +284,7 @@ public class CachingChunkManagerTest {
 
     cachingChunkManager = initChunkManager();
     CacheNodeMetadataStore cacheNodeMetadataStore =
-        new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     List<CacheNodeMetadata> cacheNodeMetadatas = cacheNodeMetadataStore.listSync();
     assertThat(cachingChunkManager.getChunkList().size()).isEqualTo(0);

--- a/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/CachingChunkManagerTest.java
@@ -144,7 +144,7 @@ public class CachingChunkManagerTest {
 
     metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
@@ -135,7 +135,7 @@ public class IndexingChunkManagerTest {
 
     metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(localZkServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/IndexingChunkManagerTest.java
@@ -118,7 +118,7 @@ public class IndexingChunkManagerTest {
   private BlobStore blobStore;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
-  private AstraConfigs.ZookeeperConfig zkConfig;
+  private AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private SnapshotMetadataStore snapshotMetadataStore;
   private SearchMetadataStore searchMetadataStore;
 
@@ -133,20 +133,26 @@ public class IndexingChunkManagerTest {
     localZkServer = new TestingServer();
     localZkServer.start();
 
-    zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(localZkServer.getConnectString())
-            .setZkPathPrefix(ZK_PATH_PREFIX)
-            .setZkSessionTimeoutMs(15000)
-            .setZkConnectionTimeoutMs(1500)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(localZkServer.getConnectString())
+                    .setZkPathPrefix(ZK_PATH_PREFIX)
+                    .setZkSessionTimeoutMs(15000)
+                    .setZkConnectionTimeoutMs(1500)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, metricsRegistry);
+    curatorFramework =
+        CuratorBuilder.build(metricsRegistry, metadataStoreConfig.getZookeeperConfig());
+    snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry);
     searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, metricsRegistry, false);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, false);
   }
 
   @AfterEach
@@ -178,7 +184,7 @@ public class IndexingChunkManagerTest {
             curatorFramework,
             searchContext,
             AstraConfigUtil.makeIndexerConfig(TEST_PORT, 1000, 100),
-            zkConfig);
+            metadataStoreConfig);
     chunkManager.startAsync();
     chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
   }
@@ -201,7 +207,7 @@ public class IndexingChunkManagerTest {
             curatorFramework,
             searchContext,
             indexerConfig,
-            zkConfig);
+            metadataStoreConfig);
     chunkManager.startAsync();
     chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
   }
@@ -1271,9 +1277,9 @@ public class IndexingChunkManagerTest {
 
     // The stores are closed so temporarily re-create them so we can query the data in ZK.
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, metricsRegistry, false);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, metricsRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
     List<SnapshotMetadata> snapshots =
         AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore);
@@ -1325,9 +1331,9 @@ public class IndexingChunkManagerTest {
     // The stores are closed so temporarily re-create them so we can query the data in ZK.
     // All ephemeral data is ZK is deleted and no data or metadata is persisted.
     SearchMetadataStore searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, metricsRegistry, false);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, false);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, metricsRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
     searchMetadataStore.close();

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -115,7 +115,7 @@ public class RecoveryChunkManagerTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -113,10 +113,17 @@ public class RecoveryChunkManagerTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
     searchMetadataStore =
-        new SearchMetadataStore(curatorFramework, zkConfig, metricsRegistry, false);
-    snapshotMetadataStore = new SnapshotMetadataStore(curatorFramework, zkConfig, metricsRegistry);
+        new SearchMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, false);
+    snapshotMetadataStore =
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -72,7 +72,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
   private BlobStore blobStore;
   private TestingServer localZkServer;
   private AsyncCuratorFramework curatorFramework;
-  private AstraConfigs.ZookeeperConfig zkConfig;
+  private AstraConfigs.MetadataStoreConfig metadataStoreConfig;
 
   private static long MAX_BYTES_PER_CHUNK = 12000;
 
@@ -96,17 +96,22 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
     localZkServer = new TestingServer();
     localZkServer.start();
 
-    zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(localZkServer.getConnectString())
-            .setZkPathPrefix(ZK_PATH_PREFIX)
-            .setZkSessionTimeoutMs(15000)
-            .setZkConnectionTimeoutMs(1500)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(localZkServer.getConnectString())
+                    .setZkPathPrefix(ZK_PATH_PREFIX)
+                    .setZkSessionTimeoutMs(15000)
+                    .setZkConnectionTimeoutMs(1500)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(metricsRegistry, metadataStoreConfig.getZookeeperConfig());
   }
 
   @AfterEach
@@ -143,7 +148,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
             curatorFramework,
             searchContext,
             AstraConfigUtil.makeIndexerConfig(TEST_PORT, 1000, 100),
-            zkConfig);
+            metadataStoreConfig);
     chunkManager.startAsync();
     chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 

--- a/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkrollover/DiskOrMessageCountBasedRolloverStrategyTest.java
@@ -98,7 +98,7 @@ public class DiskOrMessageCountBasedRolloverStrategyTest {
 
     metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(localZkServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
@@ -69,7 +69,7 @@ public class CacheNodeAssignmentServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeAssignmentServiceTest.java
@@ -67,6 +67,12 @@ public class CacheNodeAssignmentServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     AstraConfigs.ManagerConfig.CacheNodeAssignmentServiceConfig cacheNodeAssignmentServiceConfig =
         AstraConfigs.ManagerConfig.CacheNodeAssignmentServiceConfig.newBuilder()
             .addAllReplicaSets(List.of("rep1"))
@@ -82,12 +88,13 @@ public class CacheNodeAssignmentServiceTest {
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     cacheNodeAssignmentStore =
-        spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry));
     cacheNodeMetadataStore =
-        spy(new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeSearchabilityServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeSearchabilityServiceTest.java
@@ -41,7 +41,7 @@ public class CacheNodeSearchabilityServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeSearchabilityServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/CacheNodeSearchabilityServiceTest.java
@@ -39,14 +39,18 @@ public class CacheNodeSearchabilityServiceTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig zkConfig =
-        com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("CacheNodeAssignmentServiceTest")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("CacheNodeAssignmentServiceTest")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
     AstraConfigs.ManagerConfig.CacheNodeSearchabilityServiceConfig
@@ -61,15 +65,16 @@ public class CacheNodeSearchabilityServiceTest {
             .setCacheNodeSearchabilityServiceConfig(cacheNodeSearchabilityServiceConfig)
             .build();
 
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     searchMetadataStore =
-        spy(new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true));
     cacheNodeMetadataStore =
-        spy(new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     cacheNodeAssignmentStore =
-        spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry));
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
@@ -57,7 +57,7 @@ class ClusterHpaMetricServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ClusterHpaMetricServiceTest.java
@@ -55,29 +55,35 @@ class ClusterHpaMetricServiceTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("ClusterHpaMetricServiceTest")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("ClusterHpaMetricServiceTest")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
 
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     cacheSlotMetadataStore =
-        spy(new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     cacheNodeAssignmentStore =
-        spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry));
     cacheNodeMetadataStore =
-        spy(new CacheNodeMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     hpaMetricMetadataStore =
-        spy(new HpaMetricMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(new HpaMetricMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -63,11 +63,21 @@ public class RecoveryTaskAssignmentServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     recoveryTaskMetadataStore =
-        spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(
+            new RecoveryTaskMetadataStore(
+                curatorFramework, metadataStoreConfig, meterRegistry, true));
     recoveryNodeMetadataStore =
-        spy(new RecoveryNodeMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(
+            new RecoveryNodeMetadataStore(
+                curatorFramework, metadataStoreConfig, meterRegistry, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/RecoveryTaskAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/RecoveryTaskAssignmentServiceTest.java
@@ -65,7 +65,7 @@ public class RecoveryTaskAssignmentServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
@@ -70,7 +70,7 @@ public class ReplicaAssignmentServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaAssignmentServiceTest.java
@@ -68,10 +68,17 @@ public class ReplicaAssignmentServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     cacheSlotMetadataStore =
-        spy(new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
@@ -73,7 +73,7 @@ public class ReplicaCreationServiceTest {
 
     metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
     snapshotMetadataStore =

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaCreationServiceTest.java
@@ -49,6 +49,7 @@ public class ReplicaCreationServiceTest {
 
   private AsyncCuratorFramework curatorFramework;
   private AstraConfigs.ZookeeperConfig zkConfig;
+  private AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private SnapshotMetadataStore snapshotMetadataStore;
   private ReplicaMetadataStore replicaMetadataStore;
 
@@ -69,9 +70,16 @@ public class ReplicaCreationServiceTest {
             .build();
 
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+
+    metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach
@@ -87,9 +95,9 @@ public class ReplicaCreationServiceTest {
   @Test
   public void shouldDoNothingIfReplicasAlreadyExist() throws Exception {
     ReplicaMetadataStore replicaMetadataStore =
-        new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
     SnapshotMetadataStore snapshotMetadataStore =
-        new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+        new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
 
     SnapshotMetadata snapshotA =
         new SnapshotMetadata(

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
@@ -58,7 +58,7 @@ public class ReplicaDeletionServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaDeletionServiceTest.java
@@ -56,22 +56,28 @@ public class ReplicaDeletionServiceTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("ReplicaDeletionServiceTest")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("ReplicaDeletionServiceTest")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     cacheSlotMetadataStore =
-        spy(new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     cacheNodeMetadataStore =
-        spy(new CacheNodeAssignmentStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheNodeAssignmentStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
@@ -65,10 +65,17 @@ public class ReplicaEvictionServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     cacheSlotMetadataStore =
-        spy(new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaEvictionServiceTest.java
@@ -67,7 +67,7 @@ public class ReplicaEvictionServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
@@ -45,14 +45,18 @@ public class ReplicaRestoreServiceTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig zkConfig =
-        com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("ReplicaRestoreServiceTest")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("ReplicaRestoreServiceTest")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
     AstraConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
@@ -69,8 +73,10 @@ public class ReplicaRestoreServiceTest {
             .setReplicaRestoreServiceConfig(replicaRecreationServiceConfig)
             .build();
 
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/ReplicaRestoreServiceTest.java
@@ -47,7 +47,7 @@ public class ReplicaRestoreServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
@@ -6,14 +6,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import brave.Tracing;
 import com.adobe.testing.s3mock.junit5.S3MockExtension;
@@ -35,12 +33,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
-import org.apache.curator.x.async.AsyncStage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,10 +80,17 @@ public class SnapshotDeletionServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
 
     s3AsyncClient = S3TestUtils.createS3CrtClient(S3_MOCK_EXTENSION.getServiceEndpoint());
     blobStore = spy(new BlobStore(s3AsyncClient, S3_TEST_BUCKET));
@@ -531,10 +534,13 @@ public class SnapshotDeletionServiceTest {
         new SnapshotDeletionService(
             replicaMetadataStore, snapshotMetadataStore, blobStore, managerConfig, meterRegistry);
 
-    AsyncStage asyncStage = mock(AsyncStage.class);
-    when(asyncStage.toCompletableFuture())
-        .thenReturn(CompletableFuture.failedFuture(new Exception()));
-    doReturn(asyncStage).when(snapshotMetadataStore).deleteAsync(any(SnapshotMetadata.class));
+    // Mock the deleteSync method to throw an exception
+    doAnswer(
+            invocation -> {
+              throw new RuntimeException("Test exception from ZK delete");
+            })
+        .when(snapshotMetadataStore)
+        .deleteSync(any());
     assertThat(blobStore.listFiles(chunkId)).isNotEmpty();
 
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
@@ -655,19 +661,14 @@ public class SnapshotDeletionServiceTest {
 
     ExecutorService timeoutServiceExecutor = Executors.newSingleThreadExecutor();
 
-    AsyncStage asyncStage = mock(AsyncStage.class);
-    when(asyncStage.toCompletableFuture())
-        .thenReturn(
-            CompletableFuture.runAsync(
-                () -> {
-                  try {
-                    Thread.sleep(30 * 1000);
-                  } catch (InterruptedException ignored) {
-                  }
-                },
-                timeoutServiceExecutor));
-
-    doReturn(asyncStage).when(snapshotMetadataStore).deleteAsync(any(SnapshotMetadata.class));
+    // Create a mock that simulates a timeout by sleeping longer than the timeout setting
+    doAnswer(
+            invocation -> {
+              Thread.sleep(3000); // Sleep 3 seconds (longer than the futuresListTimeoutSecs = 2)
+              return null; // This won't be reached due to the timeout
+            })
+        .when(snapshotMetadataStore)
+        .deleteSync(any());
 
     int deletes = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletes).isEqualTo(0);
@@ -684,7 +685,8 @@ public class SnapshotDeletionServiceTest {
             MetricsUtil.getTimerCount(SnapshotDeletionService.SNAPSHOT_DELETE_TIMER, meterRegistry))
         .isEqualTo(1);
 
-    doCallRealMethod().when(snapshotMetadataStore).deleteAsync(any(SnapshotMetadata.class));
+    // Reset the mock to succeed on the retry attempt
+    doCallRealMethod().when(snapshotMetadataStore).deleteSync(any());
 
     int deletesRetry = snapshotDeletionService.deleteExpiredSnapshotsWithoutReplicas();
     assertThat(deletesRetry).isEqualTo(1);

--- a/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/clusterManager/SnapshotDeletionServiceTest.java
@@ -82,7 +82,7 @@ public class SnapshotDeletionServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
@@ -462,7 +462,7 @@ public class LuceneIndexStoreImplTest {
       TestingServer testingServer = new TestingServer();
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(
                   AstraConfigs.ZookeeperConfig.newBuilder()
                       .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/LuceneIndexStoreImplTest.java
@@ -460,17 +460,22 @@ public class LuceneIndexStoreImplTest {
 
       // setup ZK and redaction metadata store for field redaction testing
       TestingServer testingServer = new TestingServer();
-      AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
-              .setZkConnectString(testingServer.getConnectString())
-              .setZkPathPrefix("test")
-              .setZkSessionTimeoutMs(1000)
-              .setZkConnectionTimeoutMs(1000)
-              .setSleepBetweenRetriesMs(1000)
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(
+                  AstraConfigs.ZookeeperConfig.newBuilder()
+                      .setZkConnectString(testingServer.getConnectString())
+                      .setZkPathPrefix("test")
+                      .setZkSessionTimeoutMs(1000)
+                      .setZkConnectionTimeoutMs(1000)
+                      .setSleepBetweenRetriesMs(1000)
+                      .build())
               .build();
 
       MeterRegistry meterRegistry = new SimpleMeterRegistry();
-      AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+      AsyncCuratorFramework curatorFramework =
+          CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
 
       String redactionName = "testRedaction";
       String fieldName = "stringproperty";
@@ -478,7 +483,8 @@ public class LuceneIndexStoreImplTest {
       long end = Instant.now().plus(2, ChronoUnit.DAYS).toEpochMilli();
 
       FieldRedactionMetadataStore fieldRedactionMetadataStore =
-          new FieldRedactionMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+          new FieldRedactionMetadataStore(
+              curatorFramework, metadataStoreConfig, meterRegistry, true);
       fieldRedactionMetadataStore.createSync(
           new FieldRedactionMetadata(redactionName, fieldName, start, end));
       await()

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -85,14 +85,20 @@ public class AstraDistributedQueryServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
 
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, metricsRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry));
     searchMetadataStore =
-        spy(new SearchMetadataStore(curatorFramework, zkConfig, metricsRegistry, true));
+        spy(new SearchMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, true));
     datasetMetadataStore =
-        new DatasetMetadataStore(curatorFramework, zkConfig, metricsRegistry, true);
+        new DatasetMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, true);
 
     indexer1SearchContext = new SearchContext("indexer_host1", 10000);
     indexer2SearchContext = new SearchContext("indexer_host2", 10001);

--- a/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/AstraDistributedQueryServiceTest.java
@@ -87,7 +87,7 @@ public class AstraDistributedQueryServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
@@ -84,18 +84,24 @@ public class LogIndexSearcherImplTest {
 
       testingServer = new TestingServer();
       meterRegistry = new SimpleMeterRegistry();
-      AstraConfigs.ZookeeperConfig zkConfig =
-          AstraConfigs.ZookeeperConfig.newBuilder()
-              .setZkConnectString(testingServer.getConnectString())
-              .setZkPathPrefix("test")
-              .setZkSessionTimeoutMs(Integer.MAX_VALUE)
-              .setZkConnectionTimeoutMs(Integer.MAX_VALUE)
-              .setSleepBetweenRetriesMs(1000)
-              .setZkCacheInitTimeoutMs(1000)
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+          AstraConfigs.MetadataStoreConfig.newBuilder()
+              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setZookeeperConfig(
+                  AstraConfigs.ZookeeperConfig.newBuilder()
+                      .setZkConnectString(testingServer.getConnectString())
+                      .setZkPathPrefix("test")
+                      .setZkSessionTimeoutMs(Integer.MAX_VALUE)
+                      .setZkConnectionTimeoutMs(Integer.MAX_VALUE)
+                      .setSleepBetweenRetriesMs(1000)
+                      .setZkCacheInitTimeoutMs(1000)
+                      .build())
               .build();
-      curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+      curatorFramework =
+          CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
       fieldRedactionMetadataStore =
-          new FieldRedactionMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+          new FieldRedactionMetadataStore(
+              curatorFramework, metadataStoreConfig, meterRegistry, true);
 
       redactionUpdateServiceConfig =
           AstraConfigs.RedactionUpdateServiceConfig.newBuilder()

--- a/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/search/LogIndexSearcherImplTest.java
@@ -86,7 +86,7 @@ public class LogIndexSearcherImplTest {
       meterRegistry = new SimpleMeterRegistry();
       AstraConfigs.MetadataStoreConfig metadataStoreConfig =
           AstraConfigs.MetadataStoreConfig.newBuilder()
-              .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+              .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
               .setZookeeperConfig(
                   AstraConfigs.ZookeeperConfig.newBuilder()
                       .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -36,7 +36,7 @@ public class CacheSlotMetadataStoreTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/cache/CacheSlotMetadataStoreTest.java
@@ -34,17 +34,22 @@ public class CacheSlotMetadataStoreTest {
     // flaky.
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("Test")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(500)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("Test")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(500)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    this.store = new CacheSlotMetadataStore(curatorFramework, zkConfig, meterRegistry);
+    this.curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
+    this.store = new CacheSlotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataTestUtils.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/AstraMetadataTestUtils.java
@@ -4,6 +4,8 @@ import static com.slack.astra.server.AstraConfig.DEFAULT_ZK_TIMEOUT_SECS;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -27,6 +29,52 @@ public class AstraMetadataTestUtils {
    * for testing, so this method still has visibility for all test suites.
    */
   public static <T extends AstraMetadata> List<T> listSyncUncached(AstraMetadataStore<T> store) {
+    try {
+      List<T> zookeeperUncached =
+          store
+              .zkStore
+              .modeledClient
+              .withPath(ZPath.parse(store.zkStore.storeFolder))
+              .childrenAsZNodes()
+              .thenApply(
+                  (zNodes) ->
+                      zNodes.stream().map(znode -> znode.model()).collect(Collectors.toList()))
+              .toCompletableFuture()
+              .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+
+      // Combine both lists, using name as identifier
+      Map<String, T> combinedMap = new ConcurrentHashMap<>();
+
+      // Add items from primary store first
+      for (T item : zookeeperUncached) {
+        combinedMap.put(item.name, item);
+      }
+
+      try {
+        // Add items from secondary store if not already present
+        for (T item : store.listSync()) {
+          combinedMap.putIfAbsent(item.name, item);
+        }
+      } catch (UnsupportedOperationException ignored) {
+      }
+
+      return new ArrayList<>(combinedMap.values());
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing node", e);
+    }
+  }
+
+  /**
+   * Listing an uncached directory is very expensive, and NOT recommended for production code. For a
+   * directory containing 100 znodes this would result in 100 additional zookeeper queries after the
+   * initial listing.
+   *
+   * <p>To prevent production access, all existing use of this method has been deprecated and
+   * removed. However, the ability to perform asserts without dealing with cache timing is useful
+   * for testing, so this method still has visibility for all test suites.
+   */
+  public static <T extends AstraMetadata> List<T> listSyncUncached(
+      ZookeeperMetadataStore<T> store) {
     try {
       return store
           .modeledClient
@@ -57,6 +105,85 @@ public class AstraMetadataTestUtils {
       try {
         children =
             store
+                .zkStore
+                .curator
+                .getChildren()
+                .forPath(store.zkStore.storeFolder)
+                .toCompletableFuture()
+                .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+      } catch (ExecutionException executionException) {
+        if (executionException.getCause() instanceof KeeperException.NoNodeException) {
+          return new ArrayList<>();
+        } else {
+          throw executionException;
+        }
+      }
+
+      List<T> zookeeperUncached = new ArrayList<>();
+      for (String child : children) {
+        String path = String.format("%s/%s", store.zkStore.storeFolder, child);
+        List<String> grandchildren =
+            store
+                .zkStore
+                .curator
+                .getChildren()
+                .forPath(path)
+                .toCompletableFuture()
+                .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS);
+
+        for (String grandchild : grandchildren) {
+          String grandchildPath =
+              String.format("%s/%s/%s", store.zkStore.storeFolder, child, grandchild);
+          zookeeperUncached.add(
+              store.zkStore.modelSerializer.deserialize(
+                  store
+                      .zkStore
+                      .curator
+                      .getData()
+                      .forPath(grandchildPath)
+                      .toCompletableFuture()
+                      .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS)));
+        }
+      }
+
+      // Combine both lists, using name as identifier
+      Map<String, T> combinedMap = new ConcurrentHashMap<>();
+
+      // Add items from primary store first
+      for (T item : zookeeperUncached) {
+        combinedMap.put(item.name, item);
+      }
+
+      try {
+        // Add items from secondary store if not already present
+        for (T item : store.listSync()) {
+          combinedMap.putIfAbsent(item.name, item);
+        }
+      } catch (UnsupportedOperationException ignored) {
+      }
+
+      return new ArrayList<>(combinedMap.values());
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      throw new InternalMetadataStoreException("Error listing nodes", e);
+    }
+  }
+
+  /**
+   * Variation of the listSyncUncached method allowing for a partitioning metadata store to be used.
+   * This is known to be very slow, as each call is done synchronously to build the resulting data.
+   * As this is a test-only method and operates with an in-memory ZK instance, performance here is
+   * not a significant concern. This implementation may be revisited in the future if this method
+   * becomes a bottleneck to test performance.
+   *
+   * @see AstraMetadataTestUtils#listSyncUncached(AstraMetadataStore store)
+   */
+  public static <T extends AstraPartitionedMetadata> List<T> listSyncUncached(
+      ZookeeperPartitioningMetadataStore<T> store) {
+    try {
+      List<String> children;
+      try {
+        children =
+            store
                 .curator
                 .getChildren()
                 .forPath(store.storeFolder)
@@ -70,7 +197,7 @@ public class AstraMetadataTestUtils {
         }
       }
 
-      List<T> results = new ArrayList<>();
+      List<T> zookeeperUncached = new ArrayList<>();
       for (String child : children) {
         String path = String.format("%s/%s", store.storeFolder, child);
         List<String> grandchildren =
@@ -83,7 +210,7 @@ public class AstraMetadataTestUtils {
 
         for (String grandchild : grandchildren) {
           String grandchildPath = String.format("%s/%s/%s", store.storeFolder, child, grandchild);
-          results.add(
+          zookeeperUncached.add(
               store.modelSerializer.deserialize(
                   store
                       .curator
@@ -93,7 +220,8 @@ public class AstraMetadataTestUtils {
                       .get(DEFAULT_ZK_TIMEOUT_SECS, TimeUnit.SECONDS)));
         }
       }
-      return results;
+
+      return zookeeperUncached;
     } catch (ExecutionException | InterruptedException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error listing nodes", e);
     }

--- a/astra/src/test/java/com/slack/astra/metadata/core/ZookeeperMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/ZookeeperMetadataStoreTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class AstraMetadataStoreTest {
+public class ZookeeperMetadataStoreTest {
 
   private TestingServer testingServer;
   private MeterRegistry meterRegistry;
@@ -97,8 +97,8 @@ public class AstraMetadataStoreTest {
 
   @Test
   public void testCrudOperations() {
-    class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public TestMetadataStore() {
+    class TestMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public TestMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -110,7 +110,7 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> store = new TestMetadataStoreZookeeper()) {
 
       // 9 metrics get created with every metadatastore
       assertThat(meterRegistry.getMeters().size()).isEqualTo(10);
@@ -160,8 +160,8 @@ public class AstraMetadataStoreTest {
 
   @Test
   public void testDuplicateCreate() {
-    class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public TestMetadataStore() {
+    class TestMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public TestMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -173,7 +173,7 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> store = new TestMetadataStoreZookeeper()) {
       TestMetadata metadata1 = new TestMetadata("foo", "val1");
       store.createSync(metadata1);
       assertThatExceptionOfType(InternalMetadataStoreException.class)
@@ -183,8 +183,8 @@ public class AstraMetadataStoreTest {
 
   @Test
   public void testUncachedStoreAttemptingCacheOperations() {
-    class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public TestMetadataStore() {
+    class TestMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public TestMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -196,7 +196,7 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> store = new TestMetadataStoreZookeeper()) {
       // create metadata
       TestMetadata metadata1 = new TestMetadata("foo", "val1");
       store.createSync(metadata1);
@@ -219,8 +219,8 @@ public class AstraMetadataStoreTest {
 
   @Test
   public void testEphemeralNodeBehavior() {
-    class PersistentMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public PersistentMetadataStore() {
+    class PersistentMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public PersistentMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -232,8 +232,8 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    class EphemeralMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public EphemeralMetadataStore() {
+    class EphemeralMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public EphemeralMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -246,7 +246,8 @@ public class AstraMetadataStoreTest {
     }
 
     TestMetadata metadata1 = new TestMetadata("foo", "val1");
-    try (AstraMetadataStore<TestMetadata> persistentStore = new PersistentMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> persistentStore =
+        new PersistentMetadataStoreZookeeper()) {
       // create metadata
       persistentStore.createSync(metadata1);
 
@@ -256,7 +257,8 @@ public class AstraMetadataStoreTest {
     }
 
     TestMetadata metadata2 = new TestMetadata("foo", "val1");
-    try (AstraMetadataStore<TestMetadata> ephemeralStore = new EphemeralMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> ephemeralStore =
+        new EphemeralMetadataStoreZookeeper()) {
       // create metadata
       ephemeralStore.createSync(metadata2);
 
@@ -270,11 +272,13 @@ public class AstraMetadataStoreTest {
     curatorFramework.unwrap().close();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
-    try (AstraMetadataStore<TestMetadata> persistentStore = new PersistentMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> persistentStore =
+        new PersistentMetadataStoreZookeeper()) {
       assertThat(persistentStore.getSync("foo")).isEqualTo(metadata1);
     }
 
-    try (AstraMetadataStore<TestMetadata> ephemeralStore = new EphemeralMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> ephemeralStore =
+        new EphemeralMetadataStoreZookeeper()) {
       assertThatExceptionOfType(InternalMetadataStoreException.class)
           .isThrownBy(() -> ephemeralStore.getSync("foo"));
     }
@@ -283,8 +287,8 @@ public class AstraMetadataStoreTest {
   @Test
   @Disabled("ZK reconnect support currently disabled")
   public void testListenersWithZkReconnect() throws Exception {
-    class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public TestMetadataStore() {
+    class TestMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public TestMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -296,7 +300,7 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> store = new TestMetadataStoreZookeeper()) {
       AtomicInteger counter = new AtomicInteger(0);
       AstraMetadataStoreChangeListener<TestMetadata> listener =
           (testMetadata) -> counter.incrementAndGet();
@@ -324,8 +328,8 @@ public class AstraMetadataStoreTest {
 
   @Test
   public void testAddRemoveListener() throws Exception {
-    class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public TestMetadataStore() {
+    class TestMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public TestMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -337,7 +341,7 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> store = new TestMetadataStoreZookeeper()) {
       AtomicInteger counter = new AtomicInteger(0);
       AstraMetadataStoreChangeListener<TestMetadata> listener =
           (testMetadata) -> counter.incrementAndGet();
@@ -390,8 +394,8 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    class TestMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public TestMetadataStore() {
+    class TestMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public TestMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -403,7 +407,7 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> store = new TestMetadataStoreZookeeper()) {
       TestMetadata metadata = new TestMetadata("name", "value");
       store.createSync(metadata);
 
@@ -422,8 +426,8 @@ public class AstraMetadataStoreTest {
 
   @Test
   public void testSlowCacheInitialization() {
-    class FastMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public FastMetadataStore() {
+    class FastMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public FastMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -455,8 +459,8 @@ public class AstraMetadataStoreTest {
       }
     }
 
-    class SlowMetadataStore extends AstraMetadataStore<TestMetadata> {
-      public SlowMetadataStore() {
+    class SlowMetadataStoreZookeeper extends ZookeeperMetadataStore<TestMetadata> {
+      public SlowMetadataStoreZookeeper() {
         super(
             curatorFramework,
             zkConfig,
@@ -469,13 +473,13 @@ public class AstraMetadataStoreTest {
     }
 
     int testMetadataInitCount = 10;
-    try (AstraMetadataStore<TestMetadata> init = new FastMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> init = new FastMetadataStoreZookeeper()) {
       for (int i = 0; i < testMetadataInitCount; i++) {
         init.createSync(new TestMetadata("name" + i, "value" + i));
       }
     }
 
-    try (AstraMetadataStore<TestMetadata> init = new SlowMetadataStore()) {
+    try (ZookeeperMetadataStore<TestMetadata> init = new SlowMetadataStoreZookeeper()) {
       List<TestMetadata> metadata = init.listSync();
       assertThat(metadata.size()).isEqualTo(testMetadataInitCount);
     }

--- a/astra/src/test/java/com/slack/astra/metadata/core/ZookeeperPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/ZookeeperPartitioningMetadataStoreTest.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class AstraPartitioningMetadataStoreTest {
+class ZookeeperPartitioningMetadataStoreTest {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(AstraPartitioningMetadataStoreTest.class);
+      LoggerFactory.getLogger(ZookeeperPartitioningMetadataStoreTest.class);
 
   private SimpleMeterRegistry meterRegistry;
   private TestingServer testingServer;
@@ -212,8 +212,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testLargeNumberOfZNodes() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -247,8 +247,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testCreate() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -272,8 +272,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testUpdate() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -306,8 +306,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testDelete() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -334,8 +334,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testFind() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -358,8 +358,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testFindMissingNode() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -374,8 +374,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testDuplicateCreate() throws IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -393,7 +393,7 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testEphemeralNodeBehavior() throws IOException {
-    class PersistentMetadataStore extends AstraPartitioningMetadataStore<ExampleMetadata> {
+    class PersistentMetadataStore extends ZookeeperPartitioningMetadataStore<ExampleMetadata> {
       public PersistentMetadataStore() {
         super(
             curatorFramework,
@@ -405,7 +405,7 @@ class AstraPartitioningMetadataStoreTest {
       }
     }
 
-    class EphemeralMetadataStore extends AstraPartitioningMetadataStore<ExampleMetadata> {
+    class EphemeralMetadataStore extends ZookeeperPartitioningMetadataStore<ExampleMetadata> {
       public EphemeralMetadataStore() {
         super(
             curatorFramework,
@@ -418,7 +418,7 @@ class AstraPartitioningMetadataStoreTest {
     }
 
     ExampleMetadata metadata1 = new ExampleMetadata("foo", "va1");
-    try (AstraPartitioningMetadataStore<ExampleMetadata> persistentStore =
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> persistentStore =
         new PersistentMetadataStore()) {
       // create metadata
       persistentStore.createSync(metadata1);
@@ -429,7 +429,7 @@ class AstraPartitioningMetadataStoreTest {
     }
 
     ExampleMetadata metadata2 = new ExampleMetadata("foo", "val1");
-    try (AstraPartitioningMetadataStore<ExampleMetadata> ephemeralStore =
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> ephemeralStore =
         new EphemeralMetadataStore()) {
       // create metadata
       ephemeralStore.createSync(metadata2);
@@ -444,12 +444,12 @@ class AstraPartitioningMetadataStoreTest {
     curatorFramework.unwrap().close();
     curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
 
-    try (AstraPartitioningMetadataStore<ExampleMetadata> persistentStore =
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> persistentStore =
         new PersistentMetadataStore()) {
       assertThat(persistentStore.getSync(metadata1.getPartition(), "foo")).isEqualTo(metadata1);
     }
 
-    try (AstraPartitioningMetadataStore<ExampleMetadata> ephemeralStore =
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> ephemeralStore =
         new EphemeralMetadataStore()) {
       assertThatExceptionOfType(InternalMetadataStoreException.class)
           .isThrownBy(() -> ephemeralStore.getSync(metadata2.getPartition(), "foo"));
@@ -459,7 +459,7 @@ class AstraPartitioningMetadataStoreTest {
   @Test
   @Disabled("ZK reconnect support currently disabled")
   void testListenersWithZkReconnect() throws Exception {
-    class TestMetadataStore extends AstraPartitioningMetadataStore<ExampleMetadata> {
+    class TestMetadataStore extends ZookeeperPartitioningMetadataStore<ExampleMetadata> {
       public TestMetadataStore() {
         super(
             curatorFramework,
@@ -471,7 +471,7 @@ class AstraPartitioningMetadataStoreTest {
       }
     }
 
-    try (AstraPartitioningMetadataStore<ExampleMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> store = new TestMetadataStore()) {
       AtomicInteger counter = new AtomicInteger(0);
       AstraMetadataStoreChangeListener<ExampleMetadata> listener =
           (testMetadata) -> counter.incrementAndGet();
@@ -500,8 +500,8 @@ class AstraPartitioningMetadataStoreTest {
   @Test
   void testListenersOnAddRemoveNodes()
       throws ExecutionException, InterruptedException, IOException {
-    try (AstraPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
-        new AstraPartitioningMetadataStore<>(
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> partitionedMetadataStore =
+        new ZookeeperPartitioningMetadataStore<>(
             curatorFramework,
             zkConfig,
             meterRegistry,
@@ -604,7 +604,7 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testAddRemoveListener() throws Exception {
-    class TestMetadataStore extends AstraPartitioningMetadataStore<ExampleMetadata> {
+    class TestMetadataStore extends ZookeeperPartitioningMetadataStore<ExampleMetadata> {
       public TestMetadataStore() {
         super(
             curatorFramework,
@@ -616,7 +616,7 @@ class AstraPartitioningMetadataStoreTest {
       }
     }
 
-    try (AstraPartitioningMetadataStore<ExampleMetadata> store = new TestMetadataStore()) {
+    try (ZookeeperPartitioningMetadataStore<ExampleMetadata> store = new TestMetadataStore()) {
       AtomicInteger counter = new AtomicInteger(0);
       AstraMetadataStoreChangeListener<ExampleMetadata> listener =
           (testMetadata) -> counter.incrementAndGet();
@@ -650,7 +650,8 @@ class AstraPartitioningMetadataStoreTest {
 
   @Test
   void testListenerNotDuplicatedAddingBeforeDuring() throws Exception {
-    class TestMetadataStore extends AstraPartitioningMetadataStore<FixedPartitionExampleMetadata> {
+    class TestMetadataStore
+        extends ZookeeperPartitioningMetadataStore<FixedPartitionExampleMetadata> {
       public TestMetadataStore() {
         super(
             curatorFramework,
@@ -662,7 +663,7 @@ class AstraPartitioningMetadataStoreTest {
       }
     }
 
-    try (AstraPartitioningMetadataStore<FixedPartitionExampleMetadata> store =
+    try (ZookeeperPartitioningMetadataStore<FixedPartitionExampleMetadata> store =
         new TestMetadataStore()) {
       AtomicInteger beforeCounter = new AtomicInteger(0);
       AstraMetadataStoreChangeListener<FixedPartitionExampleMetadata> beforeListener =
@@ -718,7 +719,8 @@ class AstraPartitioningMetadataStoreTest {
   void testPartitionFilters() throws Exception {
     final String partitionStoreFolder = "/test_partition_filters";
 
-    class TestMetadataStore extends AstraPartitioningMetadataStore<FixedPartitionExampleMetadata> {
+    class TestMetadataStore
+        extends ZookeeperPartitioningMetadataStore<FixedPartitionExampleMetadata> {
       public TestMetadataStore() {
         super(
             curatorFramework,
@@ -731,7 +733,7 @@ class AstraPartitioningMetadataStoreTest {
     }
 
     class FilteredTestMetadataStore
-        extends AstraPartitioningMetadataStore<FixedPartitionExampleMetadata> {
+        extends ZookeeperPartitioningMetadataStore<FixedPartitionExampleMetadata> {
       public FilteredTestMetadataStore() {
         super(
             curatorFramework,
@@ -744,7 +746,7 @@ class AstraPartitioningMetadataStoreTest {
       }
     }
 
-    try (AstraPartitioningMetadataStore<FixedPartitionExampleMetadata> store =
+    try (ZookeeperPartitioningMetadataStore<FixedPartitionExampleMetadata> store =
         new TestMetadataStore()) {
       store.createSync(new FixedPartitionExampleMetadata("example1", "1"));
       store.createSync(new FixedPartitionExampleMetadata("example2", "2"));
@@ -753,7 +755,7 @@ class AstraPartitioningMetadataStoreTest {
     }
 
     AtomicInteger counter = new AtomicInteger(0);
-    try (AstraPartitioningMetadataStore<FixedPartitionExampleMetadata> store =
+    try (ZookeeperPartitioningMetadataStore<FixedPartitionExampleMetadata> store =
         new FilteredTestMetadataStore()) {
       store.addListener(_ -> counter.incrementAndGet());
 

--- a/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -7,6 +7,7 @@ import static org.awaitility.Awaitility.await;
 
 import brave.Tracing;
 import com.slack.astra.metadata.core.CuratorBuilder;
+import com.slack.astra.proto.config.AstraConfigs;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -35,19 +36,24 @@ public class DatasetPartitionMetadataTest {
     testZKServer = new TestingServer();
 
     // Metadata store
-    com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig zkConfig =
-        com.slack.astra.proto.config.AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testZKServer.getConnectString())
-            .setZkPathPrefix("datasetPartitionMetadataTest")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testZKServer.getConnectString())
+                    .setZkPathPrefix("datasetPartitionMetadataTest")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    this.curatorFramework = CuratorBuilder.build(metricsRegistry, zkConfig);
+    this.curatorFramework =
+        CuratorBuilder.build(metricsRegistry, metadataStoreConfig.getZookeeperConfig());
     this.datasetMetadataStore =
-        new DatasetMetadataStore(curatorFramework, zkConfig, metricsRegistry, true);
+        new DatasetMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, true);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/dataset/DatasetPartitionMetadataTest.java
@@ -38,7 +38,7 @@ public class DatasetPartitionMetadataTest {
     // Metadata store
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testZKServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/metadata/redaction/FieldRedactionMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/redaction/FieldRedactionMetadataStoreTest.java
@@ -38,6 +38,7 @@ public class FieldRedactionMetadataStoreTest {
                     .setZkSessionTimeoutMs(1000)
                     .setZkConnectionTimeoutMs(1000)
                     .setSleepBetweenRetriesMs(500)
+                    .setZkCacheInitTimeoutMs(1000)
                     .build())
             .build();
     this.curatorFramework =

--- a/astra/src/test/java/com/slack/astra/metadata/redaction/FieldRedactionMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/redaction/FieldRedactionMetadataStoreTest.java
@@ -30,7 +30,7 @@ public class FieldRedactionMetadataStoreTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/metadata/redaction/FieldRedactionMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/redaction/FieldRedactionMetadataStoreTest.java
@@ -28,16 +28,22 @@ public class FieldRedactionMetadataStoreTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("Test")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(500)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("Test")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(500)
+                    .build())
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
-    store = new FieldRedactionMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+    this.curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
+    store =
+        new FieldRedactionMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
@@ -19,7 +19,7 @@ public class SearchMetadataStoreTest {
   private SimpleMeterRegistry meterRegistry;
   private TestingServer testingServer;
   private AsyncCuratorFramework curatorFramework;
-  private AstraConfigs.ZookeeperConfig zkConfig;
+  private AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private SearchMetadataStore store;
 
   @BeforeEach
@@ -27,16 +27,21 @@ public class SearchMetadataStoreTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("Test")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(500)
-            .setZkCacheInitTimeoutMs(1000)
+    metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("Test")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(500)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
-    this.curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    this.curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
   }
 
   @AfterEach
@@ -49,7 +54,7 @@ public class SearchMetadataStoreTest {
 
   @Test
   public void testSearchMetadataStoreUpdateSearchability() throws Exception {
-    store = new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+    store = new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     SearchMetadata searchMetadata = new SearchMetadata("test", "snapshot", "http", false);
     assertThat(searchMetadata.isSearchable()).isFalse();
     store.createSync(searchMetadata);
@@ -62,7 +67,7 @@ public class SearchMetadataStoreTest {
 
   @Test
   public void testSearchMetadataStoreIsNotUpdatable() throws Exception {
-    store = new SearchMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+    store = new SearchMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     SearchMetadata searchMetadata = new SearchMetadata("test", "snapshot", "http");
     Throwable exAsync = catchThrowable(() -> store.updateAsync(searchMetadata));
     assertThat(exAsync).isInstanceOf(UnsupportedOperationException.class);

--- a/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/search/SearchMetadataStoreTest.java
@@ -29,7 +29,7 @@ public class SearchMetadataStoreTest {
 
     metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/recovery/RecoveryServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/recovery/RecoveryServiceTest.java
@@ -159,9 +159,7 @@ public class RecoveryServiceTest {
 
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Start recovery
     RecoveryTaskMetadata recoveryTask =
@@ -233,9 +231,7 @@ public class RecoveryServiceTest {
 
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery service
@@ -319,9 +315,7 @@ public class RecoveryServiceTest {
 
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery service
@@ -377,9 +371,7 @@ public class RecoveryServiceTest {
         .isNotEqualTo(fakeS3Bucket);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     // Start recovery
@@ -418,19 +410,14 @@ public class RecoveryServiceTest {
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry, false);
     assertThat(AstraMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -443,10 +430,7 @@ public class RecoveryServiceTest {
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
         new RecoveryNodeMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry, false);
     List<RecoveryNodeMetadata> recoveryNodes =
         AstraMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);
@@ -514,19 +498,14 @@ public class RecoveryServiceTest {
     assertThat(s3AsyncClient.listBuckets().get().buckets().get(0).name()).isEqualTo(TEST_S3_BUCKET);
     SnapshotMetadataStore snapshotMetadataStore =
         new SnapshotMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry);
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
 
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore).size()).isZero();
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry, false);
     assertThat(AstraMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 30, 60, Instant.now().toEpochMilli());
@@ -539,10 +518,7 @@ public class RecoveryServiceTest {
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
         new RecoveryNodeMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry, false);
     List<RecoveryNodeMetadata> recoveryNodes =
         AstraMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);
@@ -695,10 +671,7 @@ public class RecoveryServiceTest {
     // Create a recovery task
     RecoveryTaskMetadataStore recoveryTaskMetadataStore =
         new RecoveryTaskMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry, false);
     assertThat(AstraMetadataTestUtils.listSyncUncached(recoveryTaskMetadataStore).size()).isZero();
     RecoveryTaskMetadata recoveryTask =
         new RecoveryTaskMetadata("testRecoveryTask", "0", 0, 0, Instant.now().toEpochMilli());
@@ -711,10 +684,7 @@ public class RecoveryServiceTest {
     // Assign the recovery task to node.
     RecoveryNodeMetadataStore recoveryNodeMetadataStore =
         new RecoveryNodeMetadataStore(
-            curatorFramework,
-            astraCfg.getMetadataStoreConfig().getZookeeperConfig(),
-            meterRegistry,
-            false);
+            curatorFramework, astraCfg.getMetadataStoreConfig(), meterRegistry, false);
     List<RecoveryNodeMetadata> recoveryNodes =
         AstraMetadataTestUtils.listSyncUncached(recoveryNodeMetadataStore);
     assertThat(recoveryNodes.size()).isEqualTo(1);

--- a/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraConfigTest.java
@@ -209,7 +209,7 @@ public class AstraConfigTest {
     assertThat(zookeeperConfig.getZkConnectionTimeoutMs()).isEqualTo(1500);
     assertThat(zookeeperConfig.getSleepBetweenRetriesMs()).isEqualTo(500);
     assertThat(metadataStoreConfig.getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.BothReadZookeeperWrite);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.BOTH_READ_ZOOKEEPER_WRITE);
 
     final AstraConfigs.CacheConfig cacheConfig = config.getCacheConfig();
     final AstraConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
@@ -377,7 +377,7 @@ public class AstraConfigTest {
     assertThat(zookeeperConfig.getZkConnectionTimeoutMs()).isEqualTo(1500);
     assertThat(zookeeperConfig.getSleepBetweenRetriesMs()).isEqualTo(500);
     assertThat(metadataStoreConfig.getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.ZookeeperExclusive);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE);
 
     final AstraConfigs.CacheConfig cacheConfig = config.getCacheConfig();
     final AstraConfigs.ServerConfig cacheServerConfig = cacheConfig.getServerConfig();
@@ -786,7 +786,7 @@ public class AstraConfigTest {
             + "    serverPort: 8080\n"
             + "    serverAddress: localhost\n";
 
-    // Test YAML config with ZookeeperExclusive mode (default value)
+    // Test YAML config with ZOOKEEPER_EXCLUSIVE mode (default value)
     String yamlConfig =
         "nodeRoles: [INDEX]\n"
             + baseConfig
@@ -795,63 +795,63 @@ public class AstraConfigTest {
             + "    zkConnectString: localhost:2181\n";
     AstraConfigs.AstraConfig config = AstraConfig.fromYamlConfig(yamlConfig);
     assertThat(config.getMetadataStoreConfig().getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.ZookeeperExclusive);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE);
 
-    // Test YAML config with explicitly set ZookeeperExclusive mode
+    // Test YAML config with explicitly set ZOOKEEPER_EXCLUSIVE mode
     yamlConfig =
         "nodeRoles: [INDEX]\n"
             + baseConfig
             + "metadataStoreConfig:\n"
-            + "  mode: ZookeeperExclusive\n"
+            + "  mode: ZOOKEEPER_EXCLUSIVE\n"
             + "  zookeeperConfig:\n"
             + "    zkConnectString: localhost:2181\n";
     config = AstraConfig.fromYamlConfig(yamlConfig);
     assertThat(config.getMetadataStoreConfig().getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.ZookeeperExclusive);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE);
 
-    // Test YAML config with EtcdExclusive mode
+    // Test YAML config with ETCD_EXCLUSIVE mode
     yamlConfig =
         "nodeRoles: [INDEX]\n"
             + baseConfig
             + "metadataStoreConfig:\n"
-            + "  mode: EtcdExclusive\n"
+            + "  mode: ETCD_EXCLUSIVE\n"
             + "  zookeeperConfig:\n"
             + "    zkConnectString: localhost:2181\n";
     config = AstraConfig.fromYamlConfig(yamlConfig);
     assertThat(config.getMetadataStoreConfig().getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.EtcdExclusive);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.ETCD_EXCLUSIVE);
 
-    // Test YAML config with BothReadZookeeperWrite mode
+    // Test YAML config with BOTH_READ_ZOOKEEPER_WRITE mode
     yamlConfig =
         "nodeRoles: [INDEX]\n"
             + baseConfig
             + "metadataStoreConfig:\n"
-            + "  mode: BothReadZookeeperWrite\n"
+            + "  mode: BOTH_READ_ZOOKEEPER_WRITE\n"
             + "  zookeeperConfig:\n"
             + "    zkConnectString: localhost:2181\n";
     config = AstraConfig.fromYamlConfig(yamlConfig);
     assertThat(config.getMetadataStoreConfig().getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.BothReadZookeeperWrite);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.BOTH_READ_ZOOKEEPER_WRITE);
 
-    // Test YAML config with BothReadEtcdWrite mode
+    // Test YAML config with BOTH_READ_ETCD_WRITE mode
     yamlConfig =
         "nodeRoles: [INDEX]\n"
             + baseConfig
             + "metadataStoreConfig:\n"
-            + "  mode: BothReadEtcdWrite\n"
+            + "  mode: BOTH_READ_ETCD_WRITE\n"
             + "  zookeeperConfig:\n"
             + "    zkConnectString: localhost:2181\n";
     config = AstraConfig.fromYamlConfig(yamlConfig);
     assertThat(config.getMetadataStoreConfig().getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.BothReadEtcdWrite);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.BOTH_READ_ETCD_WRITE);
 
     // Test JSON config with different modes
     String jsonConfig =
         "{\"nodeRoles\": [\"INDEX\"], "
             + "\"indexerConfig\": {\"defaultQueryTimeoutMs\": 2000, \"serverConfig\": {\"requestTimeoutMs\": 3000, \"serverPort\": 8080, \"serverAddress\": \"localhost\"}}, "
-            + "\"metadataStoreConfig\": {\"mode\": \"BothReadEtcdWrite\"}}";
+            + "\"metadataStoreConfig\": {\"mode\": \"BOTH_READ_ETCD_WRITE\"}}";
     config = AstraConfig.fromJsonConfig(jsonConfig);
     assertThat(config.getMetadataStoreConfig().getMode())
-        .isEqualTo(AstraConfigs.MetadataStoreMode.BothReadEtcdWrite);
+        .isEqualTo(AstraConfigs.MetadataStoreMode.BOTH_READ_ETCD_WRITE);
   }
 }

--- a/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
@@ -81,7 +81,7 @@ public class AstraIndexerTest {
   private TestKafkaServer kafkaServer;
   private TestingServer testZKServer;
   private AsyncCuratorFramework curatorFramework;
-  private AstraConfigs.ZookeeperConfig zkConfig;
+  private AstraConfigs.MetadataStoreConfig metadataStoreConfig;
   private SnapshotMetadataStore snapshotMetadataStore;
   private RecoveryTaskMetadataStore recoveryTaskStore;
   private SearchMetadataStore searchMetadataStore;
@@ -94,17 +94,22 @@ public class AstraIndexerTest {
 
     testZKServer = new TestingServer();
     // Metadata store
-    zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testZKServer.getConnectString())
-            .setZkPathPrefix("indexerTest")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testZKServer.getConnectString())
+                    .setZkPathPrefix("indexerTest")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    curatorFramework = spy(CuratorBuilder.build(metricsRegistry, zkConfig));
+    curatorFramework =
+        spy(CuratorBuilder.build(metricsRegistry, metadataStoreConfig.getZookeeperConfig()));
 
     chunkManagerUtil =
         new ChunkManagerUtil<>(
@@ -117,17 +122,19 @@ public class AstraIndexerTest {
             new SearchContext(TEST_HOST, TEST_PORT),
             curatorFramework,
             indexerConfig,
-            zkConfig);
+            metadataStoreConfig);
 
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, metricsRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry));
     recoveryTaskStore =
-        spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, metricsRegistry, false));
+        spy(
+            new RecoveryTaskMetadataStore(
+                curatorFramework, metadataStoreConfig, metricsRegistry, false));
     searchMetadataStore =
-        spy(new SearchMetadataStore(curatorFramework, zkConfig, metricsRegistry, false));
+        spy(new SearchMetadataStore(curatorFramework, metadataStoreConfig, metricsRegistry, false));
 
     kafkaServer = new TestKafkaServer();
   }
@@ -178,7 +185,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -216,7 +223,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -263,7 +270,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -299,7 +306,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -348,7 +355,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -399,7 +406,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(50),
             getKafkaConfig(),
             metricsRegistry);
@@ -458,7 +465,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(50),
             getKafkaConfig(),
             metricsRegistry);
@@ -521,7 +528,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);
@@ -569,7 +576,7 @@ public class AstraIndexerTest {
             new SearchContext(TEST_HOST, TEST_PORT),
             curatorFramework,
             makeIndexerConfig(),
-            zkConfig);
+            metadataStoreConfig);
     chunkManagerUtil.chunkManager.startAsync();
     chunkManagerUtil.chunkManager.awaitRunning(DEFAULT_START_STOP_DURATION);
 
@@ -577,7 +584,7 @@ public class AstraIndexerTest {
         new AstraIndexer(
             chunkManagerUtil.chunkManager,
             curatorFramework,
-            zkConfig,
+            metadataStoreConfig,
             makeIndexerConfig(1000),
             getKafkaConfig(),
             metricsRegistry);

--- a/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraIndexerTest.java
@@ -96,7 +96,7 @@ public class AstraIndexerTest {
     // Metadata store
     metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testZKServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/server/AstraTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraTest.java
@@ -118,20 +118,25 @@ public class AstraTest {
     // We side load a service metadata entry telling it to create an entry with the partitions that
     // we use in test
     meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(zkServer.getConnectString())
-            .setZkPathPrefix(ZK_PATH_PREFIX)
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(zkServer.getConnectString())
+                    .setZkPathPrefix(ZK_PATH_PREFIX)
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     datasetMetadataStore =
-        new DatasetMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new DatasetMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     fieldRedactionMetadataStore =
-        new FieldRedactionMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new FieldRedactionMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     final DatasetPartitionMetadata partition =
         new DatasetPartitionMetadata(1, Long.MAX_VALUE, List.of("0", "1"));
     final List<DatasetPartitionMetadata> partitionConfigs = Collections.singletonList(partition);

--- a/astra/src/test/java/com/slack/astra/server/AstraTest.java
+++ b/astra/src/test/java/com/slack/astra/server/AstraTest.java
@@ -120,7 +120,7 @@ public class AstraTest {
     meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(zkServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/server/BulkIngestApiTest.java
+++ b/astra/src/test/java/com/slack/astra/server/BulkIngestApiTest.java
@@ -108,8 +108,14 @@ public class BulkIngestApiTest {
             .setDatasetRateLimitPeriodSecs(15)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     datasetMetadataStore =
-        new DatasetMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new DatasetMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
     DatasetMetadata datasetMetadata =
         new DatasetMetadata(
             INDEX_NAME,
@@ -122,7 +128,7 @@ public class BulkIngestApiTest {
     datasetMetadataStore.createSync(datasetMetadata);
 
     preprocessorMetadataStore =
-        new PreprocessorMetadataStore(curatorFramework, zkConfig, meterRegistry, true);
+        new PreprocessorMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true);
 
     datasetRateLimitingService =
         new DatasetRateLimitingService(
@@ -213,9 +219,9 @@ public class BulkIngestApiTest {
 
     String request1 =
         """
-                { "index": {"_index": "testindex", "_id": "1"} }
-                { "field1" : "value1" }
-                """;
+            { "index": {"_index": "testindex", "_id": "1"} }
+            { "field1" : "value1" }
+            """;
     // use the way we calculate the throughput in the rate limiter to get the exact bytes
     Map<String, List<Trace.Span>> docs =
         BulkApiRequestParser.parseRequest(
@@ -263,11 +269,11 @@ public class BulkIngestApiTest {
     // test with multiple indexes
     String request2 =
         """
-                { "index": {"_index": "testindex1", "_id": "1"} }
-                { "field1" : "value1" }
-                { "index": {"_index": "testindex2", "_id": "1"} }
-                { "field1" : "value1" }
-                """;
+            { "index": {"_index": "testindex1", "_id": "1"} }
+            { "field1" : "value1" }
+            { "index": {"_index": "testindex2", "_id": "1"} }
+            { "field1" : "value1" }
+            """;
     response = bulkApi.addDocument(request2).aggregate().join();
     assertThat(response.status().isSuccess()).isEqualTo(false);
     assertThat(response.status().code()).isEqualTo(INTERNAL_SERVER_ERROR.code());
@@ -314,11 +320,11 @@ public class BulkIngestApiTest {
 
     String request1 =
         """
-                    { "index": {"_index": "testindex", "_id": "1"} }
-                    { "field1" : "value1" },
-                    { "index": {"_index": "testindex", "_id": "2"} }
-                    { "field1" : "value2" }
-                    """;
+            { "index": {"_index": "testindex", "_id": "1"} }
+            { "field1" : "value1" },
+            { "index": {"_index": "testindex", "_id": "2"} }
+            { "field1" : "value2" }
+            """;
     updateDatasetThroughput(request1.getBytes(StandardCharsets.UTF_8).length);
 
     KafkaConsumer kafkaConsumer = getTestKafkaConsumer();
@@ -369,11 +375,11 @@ public class BulkIngestApiTest {
 
     String request1 =
         """
-                        { "index": {"_index": "testindex", "_id": "1"} }
-                        { "field1" : "value1" },
-                        { "index": {"_index": "testindex", "_id": "2"} }
-                        { "field1" : "value2" }
-                        """;
+            { "index": {"_index": "testindex", "_id": "1"} }
+            { "field1" : "value1" },
+            { "index": {"_index": "testindex", "_id": "2"} }
+            { "field1" : "value2" }
+            """;
     updateDatasetThroughput(request1.getBytes(StandardCharsets.UTF_8).length);
 
     KafkaConsumer kafkaConsumer = getTestKafkaConsumer();

--- a/astra/src/test/java/com/slack/astra/server/BulkIngestApiTest.java
+++ b/astra/src/test/java/com/slack/astra/server/BulkIngestApiTest.java
@@ -110,7 +110,7 @@ public class BulkIngestApiTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/server/HpaMetricPublisherServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/server/HpaMetricPublisherServiceTest.java
@@ -45,7 +45,7 @@ class HpaMetricPublisherServiceTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(zkConfig)
             .build();
 

--- a/astra/src/test/java/com/slack/astra/server/HpaMetricPublisherServiceTest.java
+++ b/astra/src/test/java/com/slack/astra/server/HpaMetricPublisherServiceTest.java
@@ -13,6 +13,7 @@ import com.slack.astra.proto.metadata.Metadata;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.util.List;
 import org.apache.curator.test.TestingServer;
 import org.apache.curator.x.async.AsyncCuratorFramework;
 import org.junit.jupiter.api.AfterEach;
@@ -42,9 +43,15 @@ class HpaMetricPublisherServiceTest {
             .setZkCacheInitTimeoutMs(1000)
             .build();
 
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(zkConfig)
+            .build();
+
     curatorFramework = CuratorBuilder.build(new SimpleMeterRegistry(), zkConfig);
     hpaMetricMetadataStore =
-        spy(new HpaMetricMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(new HpaMetricMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true));
   }
 
   @AfterEach
@@ -63,25 +70,63 @@ class HpaMetricPublisherServiceTest {
             hpaMetricMetadataStore, meterRegistry, Metadata.HpaMetricMetadata.NodeRole.CACHE);
     hpaMetricPublisherService.startUp();
 
-    // AstraMetadataStore inits 9 of its own metrics
-    assertThat(meterRegistry.getMeters().size()).isEqualTo(9);
+    // ZookeeperMetadataStore inits 9 of its own metrics
+    assertThat(
+            meterRegistry.getMeters().stream()
+                .filter(meter -> meter.getId().getName().contains("astra_zk"))
+                .toList()
+                .size())
+        .isEqualTo(9);
 
     hpaMetricMetadataStore.createSync(
         new HpaMetricMetadata("foo", Metadata.HpaMetricMetadata.NodeRole.CACHE, 1.0));
 
     await().until(() -> hpaMetricMetadataStore.listSync().size() == 1);
-    await().until(() -> meterRegistry.getMeters().size() == 10);
+    await()
+        .until(
+            () ->
+                meterRegistry.getMeters().stream()
+                        .filter(
+                            meter ->
+                                meter.getId().getName().contains("astra_zk")
+                                    || List.of("foo", "bar", "baz")
+                                        .contains(meter.getId().getName()))
+                        .toList()
+                        .size()
+                    == 10);
 
     hpaMetricMetadataStore.createSync(
         new HpaMetricMetadata("bar", Metadata.HpaMetricMetadata.NodeRole.INDEX, 1.0));
 
     await().until(() -> hpaMetricMetadataStore.listSync().size() == 2);
-    await().until(() -> meterRegistry.getMeters().size() == 10);
+    await()
+        .until(
+            () ->
+                meterRegistry.getMeters().stream()
+                        .filter(
+                            meter ->
+                                meter.getId().getName().contains("astra_zk")
+                                    || List.of("foo", "bar", "baz")
+                                        .contains(meter.getId().getName()))
+                        .toList()
+                        .size()
+                    == 10);
 
     hpaMetricMetadataStore.createSync(
         new HpaMetricMetadata("baz", Metadata.HpaMetricMetadata.NodeRole.CACHE, 0.0));
 
     await().until(() -> hpaMetricMetadataStore.listSync().size() == 3);
-    await().until(() -> meterRegistry.getMeters().size() == 11);
+    await()
+        .until(
+            () ->
+                meterRegistry.getMeters().stream()
+                        .filter(
+                            meter ->
+                                meter.getId().getName().contains("astra_zk")
+                                    || List.of("foo", "bar", "baz")
+                                        .contains(meter.getId().getName()))
+                        .toList()
+                        .size()
+                    == 11);
   }
 }

--- a/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
+++ b/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
@@ -72,7 +72,7 @@ public class ManagerApiGrpcTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
+++ b/astra/src/test/java/com/slack/astra/server/ManagerApiGrpcTest.java
@@ -70,24 +70,32 @@ public class ManagerApiGrpcTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("ManagerApiGrpcTest")
-            .setZkSessionTimeoutMs(30000)
-            .setZkConnectionTimeoutMs(30000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("ManagerApiGrpcTest")
+                    .setZkSessionTimeoutMs(30000)
+                    .setZkConnectionTimeoutMs(30000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     datasetMetadataStore =
-        spy(new DatasetMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(new DatasetMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry, true));
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
-    replicaMetadataStore = spy(new ReplicaMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
+    replicaMetadataStore =
+        spy(new ReplicaMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     fieldRedactionMetadataStore =
-        spy(new FieldRedactionMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(
+            new FieldRedactionMetadataStore(
+                curatorFramework, metadataStoreConfig, meterRegistry, true));
 
     AstraConfigs.ManagerConfig.ReplicaRestoreServiceConfig replicaRecreationServiceConfig =
         AstraConfigs.ManagerConfig.ReplicaRestoreServiceConfig.newBuilder()

--- a/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
+++ b/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
@@ -65,7 +65,7 @@ public class RecoveryTaskCreatorTest {
 
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(testingServer.getConnectString())

--- a/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
+++ b/astra/src/test/java/com/slack/astra/server/RecoveryTaskCreatorTest.java
@@ -63,14 +63,18 @@ public class RecoveryTaskCreatorTest {
     meterRegistry = new SimpleMeterRegistry();
     testingServer = new TestingServer();
 
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(testingServer.getConnectString())
-            .setZkPathPrefix("test")
-            .setZkSessionTimeoutMs(1000)
-            .setZkConnectionTimeoutMs(1000)
-            .setSleepBetweenRetriesMs(500)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(testingServer.getConnectString())
+                    .setZkPathPrefix("test")
+                    .setZkSessionTimeoutMs(1000)
+                    .setZkConnectionTimeoutMs(1000)
+                    .setSleepBetweenRetriesMs(500)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
 
     // Default behavior
@@ -82,11 +86,14 @@ public class RecoveryTaskCreatorTest {
             .setCreateRecoveryTasksOnStart(false)
             .build();
 
-    curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
     snapshotMetadataStore =
-        spy(new SnapshotMetadataStore(curatorFramework, zkConfig, meterRegistry));
+        spy(new SnapshotMetadataStore(curatorFramework, metadataStoreConfig, meterRegistry));
     recoveryTaskStore =
-        spy(new RecoveryTaskMetadataStore(curatorFramework, zkConfig, meterRegistry, true));
+        spy(
+            new RecoveryTaskMetadataStore(
+                curatorFramework, metadataStoreConfig, meterRegistry, true));
   }
 
   @AfterEach

--- a/astra/src/test/java/com/slack/astra/testlib/ChunkManagerUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/ChunkManagerUtil.java
@@ -53,16 +53,21 @@ public class ChunkManagerUtil<T> {
       AstraConfigs.IndexerConfig indexerConfig)
       throws Exception {
     TestingServer zkServer = new TestingServer();
-    AstraConfigs.ZookeeperConfig zkConfig =
-        AstraConfigs.ZookeeperConfig.newBuilder()
-            .setZkConnectString(zkServer.getConnectString())
-            .setZkPathPrefix(ZK_PATH_PREFIX)
-            .setZkSessionTimeoutMs(30000)
-            .setZkConnectionTimeoutMs(30000)
-            .setSleepBetweenRetriesMs(1000)
-            .setZkCacheInitTimeoutMs(1000)
+    AstraConfigs.MetadataStoreConfig metadataStoreConfig =
+        AstraConfigs.MetadataStoreConfig.newBuilder()
+            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setZookeeperConfig(
+                AstraConfigs.ZookeeperConfig.newBuilder()
+                    .setZkConnectString(zkServer.getConnectString())
+                    .setZkPathPrefix(ZK_PATH_PREFIX)
+                    .setZkSessionTimeoutMs(30000)
+                    .setZkConnectionTimeoutMs(30000)
+                    .setSleepBetweenRetriesMs(1000)
+                    .setZkCacheInitTimeoutMs(1000)
+                    .build())
             .build();
-    AsyncCuratorFramework curatorFramework = CuratorBuilder.build(meterRegistry, zkConfig);
+    AsyncCuratorFramework curatorFramework =
+        CuratorBuilder.build(meterRegistry, metadataStoreConfig.getZookeeperConfig());
 
     return new ChunkManagerUtil<>(
         s3MockExtension,
@@ -74,7 +79,7 @@ public class ChunkManagerUtil<T> {
         new SearchContext(TEST_HOST, TEST_PORT),
         curatorFramework,
         indexerConfig,
-        zkConfig);
+        metadataStoreConfig);
   }
 
   public ChunkManagerUtil(
@@ -87,7 +92,7 @@ public class ChunkManagerUtil<T> {
       SearchContext searchContext,
       AsyncCuratorFramework curatorFramework,
       AstraConfigs.IndexerConfig indexerConfig,
-      AstraConfigs.ZookeeperConfig zkConfig)
+      AstraConfigs.MetadataStoreConfig metadataStoreConfig)
       throws Exception {
 
     tempFolder = Files.createTempDir(); // TODO: don't use beta func.
@@ -115,7 +120,7 @@ public class ChunkManagerUtil<T> {
             curatorFramework,
             searchContext,
             indexerConfig,
-            zkConfig);
+            metadataStoreConfig);
   }
 
   public void close() throws IOException, TimeoutException {

--- a/astra/src/test/java/com/slack/astra/testlib/ChunkManagerUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/ChunkManagerUtil.java
@@ -55,7 +55,7 @@ public class ChunkManagerUtil<T> {
     TestingServer zkServer = new TestingServer();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()
-            .setMode(AstraConfigs.MetadataStoreMode.ZookeeperExclusive)
+            .setMode(AstraConfigs.MetadataStoreMode.ZOOKEEPER_EXCLUSIVE)
             .setZookeeperConfig(
                 AstraConfigs.ZookeeperConfig.newBuilder()
                     .setZkConnectString(zkServer.getConnectString())

--- a/astra/src/test/resources/test_config.json
+++ b/astra/src/test/resources/test_config.json
@@ -60,7 +60,7 @@
     "managerConnectString": "localhost:8083"
   },
   "metadataStoreConfig": {
-    "mode": "BothReadZookeeperWrite",
+    "mode": "BOTH_READ_ZOOKEEPER_WRITE",
     "zookeeperConfig": {
       "zkConnectString": "1.2.3.4:9092",
       "zkPathPrefix": "zkPrefix",

--- a/astra/src/test/resources/test_config.json
+++ b/astra/src/test/resources/test_config.json
@@ -60,6 +60,7 @@
     "managerConnectString": "localhost:8083"
   },
   "metadataStoreConfig": {
+    "mode": "BothReadZookeeperWrite",
     "zookeeperConfig": {
       "zkConnectString": "1.2.3.4:9092",
       "zkPathPrefix": "zkPrefix",

--- a/astra/src/test/resources/test_config.yaml
+++ b/astra/src/test/resources/test_config.yaml
@@ -48,6 +48,7 @@ tracingConfig:
     clusterName: "astra_local"
 
 metadataStoreConfig:
+  mode: ZookeeperExclusive
   zookeeperConfig:
     zkConnectString: "1.2.3.4:9092"
     zkPathPrefix: "zkPrefix"

--- a/astra/src/test/resources/test_config.yaml
+++ b/astra/src/test/resources/test_config.yaml
@@ -48,7 +48,7 @@ tracingConfig:
     clusterName: "astra_local"
 
 metadataStoreConfig:
-  mode: ZookeeperExclusive
+  mode: ZOOKEEPER_EXCLUSIVE
   zookeeperConfig:
     zkConnectString: "1.2.3.4:9092"
     zkPathPrefix: "zkPrefix"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,6 +53,7 @@ queryConfig:
   managerConnectString: ${ASTRA_MANAGER_CONNECTION_STRING:-localhost:8083}
 
 metadataStoreConfig:
+  mode: ${ASTRA_METADATA_MODE:-ZookeeperExclusive}
   zookeeperConfig:
     zkConnectString: ${ASTRA_ZK_CONNECTION_STRING:-localhost:2181}
     zkPathPrefix: ${ASTRA_ZK_PATH_PREFIX:-ASTRA}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,7 +53,7 @@ queryConfig:
   managerConnectString: ${ASTRA_MANAGER_CONNECTION_STRING:-localhost:8083}
 
 metadataStoreConfig:
-  mode: ${ASTRA_METADATA_MODE:-ZookeeperExclusive}
+  mode: ${ASTRA_METADATA_MODE:-ZOOKEEPER_EXCLUSIVE}
   zookeeperConfig:
     zkConnectString: ${ASTRA_ZK_CONNECTION_STRING:-localhost:2181}
     zkPathPrefix: ${ASTRA_ZK_PATH_PREFIX:-ASTRA}


### PR DESCRIPTION
###  Summary

Introduces an abstraction to explore migrating from Zookeeper to Etcd. 

Structure now follows:
* AstraMetadataStore
  * ZookeeperMetdataStore
  * EtcdMetdataStore
* AstraPartitionedMetadataStore
  * ZookeeperPartitionedMetdataStore
  * EtcdPartitionedMetdataStore

To support this structure we now pass around the previously existing MetdataStoreConfig instead of the ZkStoreConfig.
The Astra metadata stores now have a config value that indicates which store / combination of stores to resolve to at runtime.

If only one store is provided to AstraMetdataStore, it will use that store regardless of the config selected. This is to facilitate testing and validation.