### PR TITLE
ZK Dataset Metadata Migration to Etcd Feature

### DIFF
--- a/astra/src/main/java/com/slack/astra/server/ManagerApiGrpc.java
+++ b/astra/src/main/java/com/slack/astra/server/ManagerApiGrpc.java
@@ -486,4 +486,9 @@ public class ManagerApiGrpc extends ManagerApiServiceGrpc.ManagerApiServiceImplB
       responseObserver.onError(Status.UNKNOWN.withDescription(e.getMessage()).asException());
     }
   }
+
+  @Override
+  public void migrateZKDatasetMetadataStoreToEtcd(ManagerApi.MigrateZKDatasetMetadataStoreToEtcdRequest request) {
+
+  }
 }

--- a/astra/src/main/proto/manager_api.proto
+++ b/astra/src/main/proto/manager_api.proto
@@ -38,6 +38,10 @@ service ManagerApiService {
 
   // ListFieldRedactions lists all existing field redactions
   rpc ListFieldRedactions(ListFieldRedactionsRequest) returns (ListFieldRedactionsResponse) {}
+
+  // MigrateZKDatasetMetadataStoreToEtcd migrates the datasetmetadata store to Etcd
+  // We need this since that is the only store that never ages out
+  rpc MigrateZKDatasetMetadataStoreToEtcd(MigrateZKDatasetMetadataStoreToEtcdRequest) returns (MigrateZKDatasetMetadataStoreToEtcdResponse) {}
 }
 
 // CreateDatasetMetadataRequest represents a new dataset with uninitialized thoughput and partition assignments
@@ -148,4 +152,11 @@ message ListFieldRedactionsRequest {}
 // ListFieldRedactionsResponse represents the response when listing all existing field redactions
 message ListFieldRedactionsResponse {
   repeated RedactedFieldMetadata redacted_fields = 1;
+}
+
+message MigrateZKDatasetMetadataStoreToEtcdRequest {}
+
+message MigrateZKDatasetMetadataStoreToEtcdResponse {
+  // was the migration successful
+  string status = 1;
 }

--- a/astra/src/main/proto/manager_api.proto
+++ b/astra/src/main/proto/manager_api.proto
@@ -154,9 +154,12 @@ message ListFieldRedactionsResponse {
   repeated RedactedFieldMetadata redacted_fields = 1;
 }
 
-message MigrateZKDatasetMetadataStoreToEtcdRequest {}
+message MigrateZKDatasetMetadataStoreToEtcdRequest {
+  bool dry_run = 1;
+}
 
 message MigrateZKDatasetMetadataStoreToEtcdResponse {
-  // was the migration successful
-  string status = 1;
+  // dataset that was migrated to etcd
+  repeated DatasetMetadata dataset_metadata = 1;
+  string status = 2;
 }


### PR DESCRIPTION
###  Summary

Add the ability to migrate ZK Dataset Metadata from ZK to Etcd, since it is the one store that never gets re-written (besides redaction metadata).

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
