### PR TITLE
Fix etcd lease TTL timeout

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
@@ -486,10 +486,8 @@ public class AstraMetadataStore<T extends AstraMetadata> implements Closeable {
 
                         // Handle case where node exists in only one store
                         if (existsInZk) {
-                          LOG.info("Node does not exist in ETCD, deleting in ZK: {}", path);
                           return zkStore.deleteAsync(path);
                         } else { // existsInEtcd
-                          LOG.info("Node does not exist in ZK, deleting in etcd: {}", path);
                           return etcdStore.deleteAsync(path);
                         }
                       });

--- a/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/AstraMetadataStore.java
@@ -486,8 +486,10 @@ public class AstraMetadataStore<T extends AstraMetadata> implements Closeable {
 
                         // Handle case where node exists in only one store
                         if (existsInZk) {
+                          LOG.info("Node does not exist in ETCD, deleting in ZK: {}", path);
                           return zkStore.deleteAsync(path);
                         } else { // existsInEtcd
+                          LOG.info("Node does not exist in ZK, deleting in etcd: {}", path);
                           return etcdStore.deleteAsync(path);
                         }
                       });

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -210,7 +210,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
         sharedLeaseId =
             etcdClient
                 .getLeaseClient()
-                .grant(ephemeralTtlMs)
+                .grant(ephemeralTtlMs / 1000) // grant ttl is in seconds
                 .get(ephemeralTtlMs, TimeUnit.MILLISECONDS)
                 .getID();
       } catch (InterruptedException | ExecutionException | TimeoutException e) {


### PR DESCRIPTION
###  Summary
This timeout is in millis, but `grant` takes seconds, so the TTL was way longer and the ephemeral data was hanging around. 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
