### PR TITLE
Conditionally set default field depending on full text search setting

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
@@ -17,6 +17,7 @@ import com.slack.astra.metadata.search.SearchMetadata;
 import com.slack.astra.metadata.search.SearchMetadataStore;
 import com.slack.astra.metadata.snapshot.SnapshotMetadata;
 import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
+import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -100,9 +101,11 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
     // TODO: Add checkArgument for the fields.
     this.logStore = logStore;
     String logStoreId = ((LuceneIndexStoreImpl) logStore).getId();
+    AstraConfigs.LuceneConfig luceneConfig = ((LuceneIndexStoreImpl) logStore).getLuceneConfig();
     this.logSearcher =
         (LogIndexSearcher<T>)
-            new LogIndexSearcherImpl(logStore.getAstraSearcherManager(), logStore.getSchema());
+            new LogIndexSearcherImpl(
+                logStore.getAstraSearcherManager(), logStore.getSchema(), luceneConfig);
 
     // Create chunk metadata
     Instant chunkCreationTime = Instant.now();

--- a/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/search/LogIndexSearcherImpl.java
@@ -11,6 +11,7 @@ import com.slack.astra.logstore.LogMessage.SystemField;
 import com.slack.astra.logstore.LogWireMessage;
 import com.slack.astra.logstore.opensearch.OpenSearchAdapter;
 import com.slack.astra.metadata.schema.LuceneFieldDef;
+import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.util.JsonUtil;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,7 +57,18 @@ public class LogIndexSearcherImpl implements LogIndexSearcher<LogMessage> {
   public LogIndexSearcherImpl(
       AstraSearcherManager astraSearcherManager,
       ConcurrentHashMap<String, LuceneFieldDef> chunkSchema) {
-    this.openSearchAdapter = new OpenSearchAdapter(chunkSchema);
+    this(astraSearcherManager, chunkSchema, null);
+  }
+
+  public LogIndexSearcherImpl(
+      AstraSearcherManager astraSearcherManager,
+      ConcurrentHashMap<String, LuceneFieldDef> chunkSchema,
+      AstraConfigs.LuceneConfig luceneConfig) {
+    if (luceneConfig != null) {
+      this.openSearchAdapter = new OpenSearchAdapter(chunkSchema, luceneConfig);
+    } else {
+      this.openSearchAdapter = new OpenSearchAdapter(chunkSchema);
+    }
     this.refreshListener =
         new ReferenceManager.RefreshListener() {
           @Override

--- a/astra/src/test/java/com/slack/astra/logstore/opensearch/AstraIndexSettingsTest.java
+++ b/astra/src/test/java/com/slack/astra/logstore/opensearch/AstraIndexSettingsTest.java
@@ -1,0 +1,45 @@
+package com.slack.astra.logstore.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.slack.astra.logstore.LogMessage;
+import com.slack.astra.proto.config.AstraConfigs;
+import org.junit.jupiter.api.Test;
+import org.opensearch.index.IndexSettings;
+
+public class AstraIndexSettingsTest {
+
+  @Test
+  public void testDefaultFieldWithNullLuceneConfig() {
+    IndexSettings indexSettings = AstraIndexSettings.getInstance(null);
+    String defaultField = indexSettings.getSettings().get("index.query.default_field");
+    assertThat(defaultField).isEqualTo(LogMessage.SystemField.ALL.fieldName);
+  }
+
+  @Test
+  public void testDefaultFieldWithFullTextSearchEnabled() {
+    AstraConfigs.LuceneConfig luceneConfig =
+        AstraConfigs.LuceneConfig.newBuilder().setEnableFullTextSearch(true).build();
+
+    IndexSettings indexSettings = AstraIndexSettings.getInstance(luceneConfig);
+    String defaultField = indexSettings.getSettings().get("index.query.default_field");
+    assertThat(defaultField).isEqualTo(LogMessage.SystemField.ALL.fieldName);
+  }
+
+  @Test
+  public void testDefaultFieldWithFullTextSearchDisabled() {
+    AstraConfigs.LuceneConfig luceneConfig =
+        AstraConfigs.LuceneConfig.newBuilder().setEnableFullTextSearch(false).build();
+
+    IndexSettings indexSettings = AstraIndexSettings.getInstance(luceneConfig);
+    String defaultField = indexSettings.getSettings().get("index.query.default_field");
+    assertThat(defaultField).isEqualTo("*");
+  }
+
+  @Test
+  public void testDefaultInstanceStillWorks() {
+    IndexSettings indexSettings = AstraIndexSettings.getInstance();
+    String defaultField = indexSettings.getSettings().get("index.query.default_field");
+    assertThat(defaultField).isEqualTo(LogMessage.SystemField.ALL.fieldName);
+  }
+}

--- a/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
@@ -164,12 +164,21 @@ public class AstraConfigUtil {
     return makeIndexerConfig(TEST_INDEXER_PORT, 1000, 100);
   }
 
+  public static AstraConfigs.IndexerConfig makeIndexerConfig(boolean enableFullTextSearch) {
+    return makeIndexerConfig(TEST_INDEXER_PORT, 1000, 100, enableFullTextSearch);
+  }
+
   public static AstraConfigs.IndexerConfig makeIndexerConfig(int maxOffsetDelay) {
     return makeIndexerConfig(TEST_INDEXER_PORT, maxOffsetDelay, 100);
   }
 
   public static AstraConfigs.IndexerConfig makeIndexerConfig(
       int indexerPort, int maxOffsetDelay, int maxMessagesPerChunk) {
+    return makeIndexerConfig(indexerPort, maxOffsetDelay, maxMessagesPerChunk, true);
+  }
+
+  public static AstraConfigs.IndexerConfig makeIndexerConfig(
+      int indexerPort, int maxOffsetDelay, int maxMessagesPerChunk, boolean enableFullTextSearch) {
     return AstraConfigs.IndexerConfig.newBuilder()
         .setServerConfig(
             AstraConfigs.ServerConfig.newBuilder()
@@ -182,7 +191,7 @@ public class AstraConfigUtil {
             AstraConfigs.LuceneConfig.newBuilder()
                 .setCommitDurationSecs(10)
                 .setRefreshDurationSecs(10)
-                .setEnableFullTextSearch(true)
+                .setEnableFullTextSearch(enableFullTextSearch)
                 .build())
         .setMaxChunksOnDisk(3)
         .setStaleDurationSecs(7200)


### PR DESCRIPTION
###  Summary

Addresses an issue where queries to `*` don't work when the cluster is configured full text search disabled. This also opens the opportunity for pushing any new lucene config options into the index settings class, which will allow for per-cluster configs if needed (ie, default field limits, etc).

This is an alternative implementation to #1410, and is the preferred approach.