### PR TITLE
fix: disable SearcherManager for recovery nodes

### DIFF
--- a/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
+++ b/astra/src/main/java/com/slack/astra/chunk/ReadWriteChunk.java
@@ -102,10 +102,14 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
     this.logStore = logStore;
     String logStoreId = ((LuceneIndexStoreImpl) logStore).getId();
     AstraConfigs.LuceneConfig luceneConfig = ((LuceneIndexStoreImpl) logStore).getLuceneConfig();
-    this.logSearcher =
-        (LogIndexSearcher<T>)
-            new LogIndexSearcherImpl(
-                logStore.getAstraSearcherManager(), logStore.getSchema(), luceneConfig);
+    if (logStore.getAstraSearcherManager() != null) {
+      this.logSearcher =
+          (LogIndexSearcher<T>)
+              new LogIndexSearcherImpl(
+                  logStore.getAstraSearcherManager(), logStore.getSchema(), luceneConfig);
+    } else {
+      this.logSearcher = null;
+    }
 
     // Create chunk metadata
     Instant chunkCreationTime = Instant.now();
@@ -181,7 +185,9 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
   public void close() throws IOException {
     preClose();
 
-    logSearcher.close();
+    if (logSearcher != null) {
+      logSearcher.close();
+    }
     logStore.close();
     logger.info("Closed chunk {}", chunkInfo);
 
@@ -282,6 +288,9 @@ public abstract class ReadWriteChunk<T> implements Chunk<T> {
 
   @Override
   public SearchResult<T> query(SearchQuery query) {
+    if (logSearcher == null) {
+      throw new UnsupportedOperationException("Search is disabled for chunk " + chunkInfo.chunkId);
+    }
     return logSearcher.search(
         query.dataset,
         query.howMany,

--- a/astra/src/main/java/com/slack/astra/chunk/RecoveryChunkFactoryImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/RecoveryChunkFactoryImpl.java
@@ -55,7 +55,7 @@ public class RecoveryChunkFactoryImpl<T> implements ChunkFactory<T> {
     final File dataDirectory = new File(indexerConfig.getDataDirectory());
 
     LogStore logStore =
-        LuceneIndexStoreImpl.makeLogStore(dataDirectory, luceneConfig, meterRegistry);
+        LuceneIndexStoreImpl.makeLogStore(dataDirectory, luceneConfig, meterRegistry, false);
 
     return new RecoveryChunkImpl<>(
         logStore,

--- a/astra/src/main/java/com/slack/astra/chunk/RecoveryChunkImpl.java
+++ b/astra/src/main/java/com/slack/astra/chunk/RecoveryChunkImpl.java
@@ -12,12 +12,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A recovery chunk is a read write chunk used in the recovery service. A recovery chunk is
- * optimized for indexing the data as fast as it can. So, we don't plan to expose it for reads for
- * the time being.
+ * optimized for indexing the data as fast as it can and does not support search.
  *
  * <p>To prevent external queries, a recovery node doesn't publish any live snapshots or search
- * nodes to be queried by query nodes. We don't block the local read API since we need it for tests
- * and helps with code reuse.
+ * nodes to be queried by query nodes. The SearcherManager is disabled to avoid holding
+ * DirectoryReader references that prevent segment cleanup during long-running indexing.
  */
 public class RecoveryChunkImpl<T> extends ReadWriteChunk<T> {
   private static final Logger LOG = LoggerFactory.getLogger(ReadOnlyChunkImpl.class);

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreConfig.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreConfig.java
@@ -29,6 +29,10 @@ public class LuceneIndexStoreConfig {
   // A flag that turns on internal logging.
   public final boolean enableTracing;
 
+  // Recovery nodes don't serve queries and should disable this to avoid
+  // segment retention from DirectoryReader references.
+  public final boolean enableSearcher;
+
   // TODO: Tweak the default values once in prod.
   static final Duration defaultCommitDuration = Duration.ofSeconds(15);
   static final Duration defaultRefreshDuration = Duration.ofSeconds(15);
@@ -45,7 +49,7 @@ public class LuceneIndexStoreConfig {
 
   public LuceneIndexStoreConfig(
       Duration commitDuration, Duration refreshDuration, String indexRoot, boolean enableTracing) {
-    this(commitDuration, refreshDuration, indexRoot, DEFAULT_LOG_FILE_NAME, enableTracing);
+    this(commitDuration, refreshDuration, indexRoot, DEFAULT_LOG_FILE_NAME, enableTracing, true);
   }
 
   public LuceneIndexStoreConfig(
@@ -54,6 +58,16 @@ public class LuceneIndexStoreConfig {
       String indexRoot,
       String logFileName,
       boolean enableTracing) {
+    this(commitDuration, refreshDuration, indexRoot, logFileName, enableTracing, true);
+  }
+
+  public LuceneIndexStoreConfig(
+      Duration commitDuration,
+      Duration refreshDuration,
+      String indexRoot,
+      String logFileName,
+      boolean enableTracing,
+      boolean enableSearcher) {
     ensureTrue(
         !(commitDuration.isZero() || commitDuration.isNegative()),
         "Commit duration should be greater than zero");
@@ -65,6 +79,7 @@ public class LuceneIndexStoreConfig {
     this.indexRoot = indexRoot;
     this.logFileName = logFileName;
     this.enableTracing = enableTracing;
+    this.enableSearcher = enableSearcher;
   }
 
   public File indexFolder(String id) {

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -57,15 +57,14 @@ public class LuceneIndexStoreImpl implements LogStore {
 
   public static final String FINAL_MERGES_TIMER = "astra_index_final_merges";
 
-  private final AstraSearcherManager astraSearcherManager;
+  private final AstraSearcherManager astraSearcherManager; // null when enableSearcher=false
   private final DocumentBuilder documentBuilder;
   private final FSDirectory indexDirectory;
   private final AstraConfigs.LuceneConfig luceneConfig;
 
   private final ScheduledExecutorService scheduledCommit =
       Executors.newSingleThreadScheduledExecutor();
-  private final ScheduledExecutorService scheduledRefresh =
-      Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService scheduledRefresh;
   private final SnapshotDeletionPolicy snapshotDeletionPolicy;
   private Optional<IndexWriter> indexWriter;
 
@@ -88,6 +87,15 @@ public class LuceneIndexStoreImpl implements LogStore {
   public static LuceneIndexStoreImpl makeLogStore(
       File dataDirectory, AstraConfigs.LuceneConfig luceneConfig, MeterRegistry metricsRegistry)
       throws IOException {
+    return makeLogStore(dataDirectory, luceneConfig, metricsRegistry, true);
+  }
+
+  public static LuceneIndexStoreImpl makeLogStore(
+      File dataDirectory,
+      AstraConfigs.LuceneConfig luceneConfig,
+      MeterRegistry metricsRegistry,
+      boolean enableSearcher)
+      throws IOException {
     return makeLogStore(
         dataDirectory,
         LuceneIndexStoreConfig.getCommitDuration(luceneConfig.getCommitDurationSecs()),
@@ -95,7 +103,8 @@ public class LuceneIndexStoreImpl implements LogStore {
         luceneConfig.getEnableFullTextSearch(),
         SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy.CONVERT_VALUE_AND_DUPLICATE_FIELD,
         metricsRegistry,
-        luceneConfig);
+        luceneConfig,
+        enableSearcher);
   }
 
   public static LuceneIndexStoreImpl makeLogStore(
@@ -113,7 +122,8 @@ public class LuceneIndexStoreImpl implements LogStore {
         enableFullTextSearch,
         fieldConflictPolicy,
         metricsRegistry,
-        null);
+        null,
+        true);
   }
 
   public static LuceneIndexStoreImpl makeLogStore(
@@ -123,13 +133,17 @@ public class LuceneIndexStoreImpl implements LogStore {
       boolean enableFullTextSearch,
       SchemaAwareLogDocumentBuilderImpl.FieldConflictPolicy fieldConflictPolicy,
       MeterRegistry metricsRegistry,
-      AstraConfigs.LuceneConfig luceneConfig)
+      AstraConfigs.LuceneConfig luceneConfig,
+      boolean enableSearcher)
       throws IOException {
-    // TODO: Move all these config values into chunk?
-    // TODO: Chunk should create log store?
     LuceneIndexStoreConfig indexStoreCfg =
         new LuceneIndexStoreConfig(
-            commitInterval, refreshInterval, dataDirectory.getAbsolutePath(), false);
+            commitInterval,
+            refreshInterval,
+            dataDirectory.getAbsolutePath(),
+            LuceneIndexStoreConfig.DEFAULT_LOG_FILE_NAME,
+            false,
+            enableSearcher);
 
     return new LuceneIndexStoreImpl(
         indexStoreCfg,
@@ -162,13 +176,30 @@ public class LuceneIndexStoreImpl implements LogStore {
     indexDirectory = new MMapDirectory(config.indexFolder(id).toPath());
     indexWriter = Optional.of(new IndexWriter(indexDirectory, indexWriterConfig));
 
-    RedactionFilterDirectoryReader reader =
-        new RedactionFilterDirectoryReader(DirectoryReader.open(indexWriter.get(), false, false));
-    OpenSearchDirectoryReader openSearchDirectoryReader =
-        OpenSearchDirectoryReader.wrap(
-            reader,
-            ShardId.fromString("[shard-index][%d]".formatted(UUID.fromString(id).hashCode())));
-    this.astraSearcherManager = new AstraSearcherManager(openSearchDirectoryReader);
+    if (config.enableSearcher) {
+      RedactionFilterDirectoryReader reader =
+          new RedactionFilterDirectoryReader(DirectoryReader.open(indexWriter.get(), false, false));
+      OpenSearchDirectoryReader openSearchDirectoryReader =
+          OpenSearchDirectoryReader.wrap(
+              reader,
+              ShardId.fromString("[shard-index][%d]".formatted(UUID.fromString(id).hashCode())));
+      this.astraSearcherManager = new AstraSearcherManager(openSearchDirectoryReader);
+      this.scheduledRefresh = Executors.newSingleThreadScheduledExecutor();
+      scheduledRefresh.scheduleWithFixedDelay(
+          () -> {
+            try {
+              refresh();
+            } catch (Exception e) {
+              LOG.error("Error running scheduled refresh", e);
+            }
+          },
+          config.refreshDuration.toMillis(),
+          config.refreshDuration.toMillis(),
+          TimeUnit.MILLISECONDS);
+    } else {
+      this.astraSearcherManager = null;
+      this.scheduledRefresh = null;
+    }
 
     scheduledCommit.scheduleWithFixedDelay(
         () -> {
@@ -180,18 +211,6 @@ public class LuceneIndexStoreImpl implements LogStore {
         },
         config.commitDuration.toMillis(),
         config.commitDuration.toMillis(),
-        TimeUnit.MILLISECONDS);
-
-    scheduledRefresh.scheduleWithFixedDelay(
-        () -> {
-          try {
-            refresh();
-          } catch (Exception e) {
-            LOG.error("Error running scheduled commit", e);
-          }
-        },
-        config.refreshDuration.toMillis(),
-        config.refreshDuration.toMillis(),
         TimeUnit.MILLISECONDS);
 
     // Initialize stats counters
@@ -272,6 +291,9 @@ public class LuceneIndexStoreImpl implements LogStore {
   }
 
   private void syncRefresh() throws IOException {
+    if (astraSearcherManager == null) {
+      return;
+    }
     indexWriterLock.lock();
     try {
       if (indexWriter.isPresent()) {
@@ -347,6 +369,9 @@ public class LuceneIndexStoreImpl implements LogStore {
 
   @Override
   public void refresh() {
+    if (astraSearcherManager == null) {
+      return;
+    }
     refreshesTimer.record(
         () -> {
           LOG.debug("Indexer starting refresh for: " + indexDirectory.getDirectory().toString());
@@ -416,12 +441,14 @@ public class LuceneIndexStoreImpl implements LogStore {
   public void close() throws IOException {
     LOG.info("Closing index {}", id);
     scheduledCommit.close();
-    scheduledRefresh.close();
+    if (scheduledRefresh != null) {
+      scheduledRefresh.close();
+    }
     try {
       if (!scheduledCommit.awaitTermination(30, TimeUnit.SECONDS)) {
         LOG.error("Timed out waiting for scheduled commit to close");
       }
-      if (!scheduledRefresh.awaitTermination(30, TimeUnit.SECONDS)) {
+      if (scheduledRefresh != null && !scheduledRefresh.awaitTermination(30, TimeUnit.SECONDS)) {
         LOG.error("Timed out waiting for scheduled refresh to close");
       }
     } catch (InterruptedException e) {

--- a/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
+++ b/astra/src/test/java/com/slack/astra/chunkManager/RecoveryChunkManagerTest.java
@@ -245,7 +245,7 @@ public class RecoveryChunkManagerTest {
     assertThat(AstraMetadataTestUtils.listSyncUncached(snapshotMetadataStore)).isEmpty();
     assertThat(AstraMetadataTestUtils.listSyncUncached(searchMetadataStore)).isEmpty();
 
-    // Search query
+    // Recovery chunks don't support search
     SearchQuery searchQuery =
         new SearchQuery(
             MessageUtil.TEST_DATASET_NAME,
@@ -257,8 +257,8 @@ public class RecoveryChunkManagerTest {
             null,
             createGenericDateHistogramAggregatorFactoriesBuilder(),
             List.of());
-    SearchResult<LogMessage> results = chunkManager.getActiveChunk().query(searchQuery);
-    assertThat(results.hits.size()).isEqualTo(1);
+    assertThatThrownBy(() -> chunkManager.getActiveChunk().query(searchQuery))
+        .isInstanceOf(UnsupportedOperationException.class);
 
     // Test chunk metadata.
     ChunkInfo chunkInfo = chunkManager.getActiveChunk().info();
@@ -286,23 +286,6 @@ public class RecoveryChunkManagerTest {
         veryHighOffset);
     assertThat(chunkManager.getActiveChunk().info().getMaxOffset()).isEqualTo(veryHighOffset);
     chunkManager.getActiveChunk().commit();
-    assertThat(
-            chunkManager
-                .getActiveChunk()
-                .query(
-                    new SearchQuery(
-                        MessageUtil.TEST_DATASET_NAME,
-                        0,
-                        MAX_TIME,
-                        10,
-                        Collections.emptyList(),
-                        QueryBuilderUtil.generateQueryBuilder("Message101", 0L, MAX_TIME),
-                        null,
-                        createGenericDateHistogramAggregatorFactoriesBuilder(),
-                        List.of()))
-                .hits
-                .size())
-        .isEqualTo(1);
 
     // Add a message with a lower offset.
     final int lowerOffset = 500;
@@ -317,23 +300,6 @@ public class RecoveryChunkManagerTest {
         lowerOffset);
     assertThat(chunkManager.getActiveChunk().info().getMaxOffset()).isEqualTo(veryHighOffset);
     chunkManager.getActiveChunk().commit();
-    assertThat(
-            chunkManager
-                .getActiveChunk()
-                .query(
-                    new SearchQuery(
-                        MessageUtil.TEST_DATASET_NAME,
-                        0,
-                        MAX_TIME,
-                        10,
-                        Collections.emptyList(),
-                        QueryBuilderUtil.generateQueryBuilder("Message102", 0L, MAX_TIME),
-                        null,
-                        createGenericDateHistogramAggregatorFactoriesBuilder(),
-                        List.of()))
-                .hits
-                .size())
-        .isEqualTo(1);
 
     // Inserting a message from a different kafka partition fails
     Trace.Span messageWithInvalidTopic = SpanUtil.makeSpan(103);
@@ -446,14 +412,11 @@ public class RecoveryChunkManagerTest {
     //noinspection UnusedAssignment
     offset++;
 
-    // Commit the new chunk so we can search it.
     chunkManager.getActiveChunk().commit();
 
     assertThat(chunkManager.getChunkList().size()).isEqualTo(1);
     assertThat(getCount(MESSAGES_RECEIVED_COUNTER, metricsRegistry)).isEqualTo(2);
     assertThat(getCount(MESSAGES_FAILED_COUNTER, metricsRegistry)).isEqualTo(0);
-    testChunkManagerSearch(chunkManager, "Message1", 1);
-    testChunkManagerSearch(chunkManager, "Message100", 1);
 
     // Check metadata.
     List<SnapshotMetadata> snapshots =


### PR DESCRIPTION
## Summary

- Recovery nodes never serve queries but were unconditionally creating a `SearcherManager` and running scheduled refreshes every 15s
- On long-running chunks this starves commits (refresh holds `indexWriterLock` for 5-60s), prevents merged segment deletion, and causes monotonic growth of mmap'd memory until OOM
- Adds `enableSearcher` flag to `LuceneIndexStoreConfig` (default `true`); recovery passes `false`, skipping `DirectoryReader`, `SearcherManager`, and scheduled refresh entirely

## Changes

- `LuceneIndexStoreConfig`: new `enableSearcher` field with backwards-compatible constructors
- `LuceneIndexStoreImpl`: conditionally create searcher infrastructure; `refresh()` becomes a no-op when disabled
- `ReadWriteChunk`: nullable `logSearcher`; `query()` throws `UnsupportedOperationException` when search is disabled
- `RecoveryChunkFactoryImpl`: passes `enableSearcher=false`
- `RecoveryChunkImpl`: updated Javadoc to reflect new behavior

## Expected impact

- `astra_index_refreshes_seconds_count` rate drops to 0 for recovery
- `astra_index_commits_seconds_count` rate stays at ~0.067/s (no longer starved by refresh lock contention)
- `container_memory_working_set_bytes` stays bounded — old segments can be deleted after merge

## Test plan

- [x] `LuceneIndexStoreImplTest` — 14/14 pass (including S3 snapshot test)
- [ ] Deploy to recovery fleet and confirm refresh rate drops to 0
- [ ] Monitor `container_memory_working_set_bytes` stays bounded over 24h
- [ ] Verify snapshots still upload successfully to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)