### PR TITLE
diag: log interrupts on Lucene-I/O threads to trace write.lock crash

### DIFF
--- a/astra/src/main/java/com/slack/astra/blobfs/BlobStore.java
+++ b/astra/src/main/java/com/slack/astra/blobfs/BlobStore.java
@@ -128,6 +128,16 @@ public class BlobStore {
         LOG.error("Error attempting to upload file '{}' to S3", keys.get(i), e.getCause());
         failures.add(e);
       } catch (InterruptedException e) {
+        // Lucene shares one write.lock FileChannel per chunk; an interrupt flag left set on a
+        // write-path thread will later invalidate that lock (see
+        // docs/indexer-filelock-interrupt-crash.md).
+        // This is a known site where an interrupt surfaces on the rollover thread, so log which
+        // upload was in flight before restoring the flag to help identify the source in prod.
+        LOG.warn(
+            "Thread '{}' interrupted while awaiting S3 upload of '{}'; restoring interrupt flag and aborting batch",
+            Thread.currentThread().getName(),
+            keys.get(i),
+            e);
         Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }

--- a/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
+++ b/astra/src/main/java/com/slack/astra/chunkManager/IndexingChunkManager.java
@@ -25,6 +25,7 @@ import com.slack.astra.logstore.LuceneIndexStoreImpl;
 import com.slack.astra.metadata.search.SearchMetadataStore;
 import com.slack.astra.metadata.snapshot.SnapshotMetadataStore;
 import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.util.InterruptLoggingThreadFactory;
 import com.slack.service.murron.trace.Trace;
 import io.etcd.jetcd.Client;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -107,10 +108,15 @@ public class IndexingChunkManager<T> extends ChunkManagerBase<T> {
    */
   @SuppressWarnings("UnstableApiUsage")
   public static ListeningExecutorService makeDefaultRollOverExecutor() {
-    // TODO: Create a named thread pool and pass it in.
     ThreadPoolExecutor rollOverExecutor =
         new ThreadPoolExecutor(
-            1, 1, 0, MILLISECONDS, new SynchronousQueue<>(), new ThreadPoolExecutor.AbortPolicy());
+            1,
+            1,
+            0,
+            MILLISECONDS,
+            new SynchronousQueue<>(),
+            new InterruptLoggingThreadFactory("lucene-rollover-%d"),
+            new ThreadPoolExecutor.AbortPolicy());
     return MoreExecutors.listeningDecorator(
         MoreExecutors.getExitingExecutorService(rollOverExecutor));
   }

--- a/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
+++ b/astra/src/main/java/com/slack/astra/logstore/LuceneIndexStoreImpl.java
@@ -5,6 +5,7 @@ import com.slack.astra.logstore.search.AstraSearcherManager;
 import com.slack.astra.logstore.search.fieldRedaction.RedactionFilterDirectoryReader;
 import com.slack.astra.metadata.schema.LuceneFieldDef;
 import com.slack.astra.proto.config.AstraConfigs;
+import com.slack.astra.util.InterruptLoggingThreadFactory;
 import com.slack.astra.util.RuntimeHalterImpl;
 import com.slack.service.murron.trace.Trace;
 import io.micrometer.core.instrument.Counter;
@@ -63,9 +64,11 @@ public class LuceneIndexStoreImpl implements LogStore {
   private final AstraConfigs.LuceneConfig luceneConfig;
 
   private final ScheduledExecutorService scheduledCommit =
-      Executors.newSingleThreadScheduledExecutor();
+      Executors.newSingleThreadScheduledExecutor(
+          new InterruptLoggingThreadFactory("lucene-commit-%d"));
   private final ScheduledExecutorService scheduledRefresh =
-      Executors.newSingleThreadScheduledExecutor();
+      Executors.newSingleThreadScheduledExecutor(
+          new InterruptLoggingThreadFactory("lucene-refresh-%d"));
   private final SnapshotDeletionPolicy snapshotDeletionPolicy;
   private Optional<IndexWriter> indexWriter;
 

--- a/astra/src/main/java/com/slack/astra/util/InterruptLoggingThreadFactory.java
+++ b/astra/src/main/java/com/slack/astra/util/InterruptLoggingThreadFactory.java
@@ -1,0 +1,65 @@
+package com.slack.astra.util;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// In short: makes threads that log "who interrupted me, and from where" so we can find the code
+// that is breaking the indexer's write lock. It only watches; it does not change any behavior.
+
+/**
+ * A {@link ThreadFactory} whose threads log the caller's stack trace whenever {@link
+ * Thread#interrupt()} is invoked on them, before delegating to {@link Thread#interrupt()}.
+ *
+ * <p>This exists purely to diagnose the production "FileLock invalidated by an external force"
+ * crashes. A leaked interrupt flag on a reused Lucene-I/O pool thread (scheduled commit/refresh,
+ * rollover) is eaten by the next channel op and permanently invalidates the shared write.lock for
+ * the whole chunk. Lucene will not defend against this (see LUCENE-8262 and apache/lucene#9309,
+ * both resolved "Won't Fix"); their guidance is that callers must not interrupt threads performing
+ * Lucene I/O. We do not yet know what interrupts these threads in steady state.
+ *
+ * <p>Because nothing outside those classes holds a reference to these threads, the interrupt must
+ * originate either from an executor shutdown escalation ({@code shutdownNow()}) or from Lucene
+ * internals restoring the flag ({@code Thread.currentThread().interrupt()}) after catching an
+ * {@link InterruptedException}. Overriding {@code interrupt()} captures the caller stack in either
+ * case, which is the piece the JVM otherwise gives us no way to observe.
+ *
+ * <p>This factory only logs; it does not clear or suppress the interrupt. It is a diagnostic, not a
+ * fix.
+ */
+public class InterruptLoggingThreadFactory implements ThreadFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InterruptLoggingThreadFactory.class);
+
+  private final ThreadFactory delegate;
+
+  public InterruptLoggingThreadFactory(String nameFormat) {
+    // Guava's ThreadFactoryBuilder owns the "%d" naming/counter convention used across the
+    // codebase; we only add the interrupt() override on top of the threads it produces.
+    this.delegate =
+        new ThreadFactoryBuilder()
+            .setNameFormat(nameFormat)
+            .setThreadFactory(
+                r ->
+                    new Thread(r) {
+                      @Override
+                      public void interrupt() {
+                        // Capture who is interrupting a Lucene-I/O thread. The Throwable is never
+                        // thrown -- it only records the calling stack synchronously at interrupt.
+                        LOG.warn(
+                            "Thread '{}' performing Lucene I/O was interrupted; capturing caller "
+                                + "stack to identify the write.lock-invalidation trigger",
+                            getName(),
+                            new Throwable("interrupt() caller stack"));
+                        super.interrupt();
+                      }
+                    })
+            .build();
+  }
+
+  @Override
+  public Thread newThread(Runnable r) {
+    return delegate.newThread(r);
+  }
+}

--- a/astra/src/test/java/com/slack/astra/util/InterruptLoggingThreadFactoryTest.java
+++ b/astra/src/test/java/com/slack/astra/util/InterruptLoggingThreadFactoryTest.java
@@ -1,0 +1,55 @@
+package com.slack.astra.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public class InterruptLoggingThreadFactoryTest {
+
+  /**
+   * The factory's threads must still behave as normal interruptible threads: calling interrupt()
+   * sets the flag (after logging the caller stack) so the diagnostic never changes runtime
+   * behavior. We assert the running thread observes its own interrupt.
+   */
+  @Test
+  public void interruptStillSetsTheFlagAfterLogging() throws InterruptedException {
+    InterruptLoggingThreadFactory factory =
+        new InterruptLoggingThreadFactory("test-interrupt-logging-%d");
+
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicBoolean sawInterrupt = new AtomicBoolean(false);
+
+    Thread thread =
+        factory.newThread(
+            () -> {
+              started.countDown();
+              try {
+                // Block until interrupted.
+                Thread.sleep(TimeUnit.SECONDS.toMillis(30));
+              } catch (InterruptedException e) {
+                sawInterrupt.set(true);
+              } finally {
+                done.countDown();
+              }
+            });
+
+    thread.start();
+    assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+
+    thread.interrupt();
+
+    assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(sawInterrupt.get()).isTrue();
+  }
+
+  @Test
+  public void appliesTheConfiguredNameFormat() {
+    InterruptLoggingThreadFactory factory = new InterruptLoggingThreadFactory("named-worker-%d");
+    Thread thread = factory.newThread(() -> {});
+    assertThat(thread.getName()).isEqualTo("named-worker-0");
+  }
+}

--- a/docs/indexer-filelock-interrupt-crash.md
+++ b/docs/indexer-filelock-interrupt-crash.md
@@ -1,0 +1,134 @@
+# Indexer `FileLock invalidated` crash
+
+## Symptom
+
+Indexer pods die via `System.exit(1)` (hundreds of VM halts per week) with:
+
+```
+org.apache.lucene.store.AlreadyClosedException: FileLock invalidated by an external force:
+  NativeFSLock(path=/astra_data/indices/<chunk-id>/write.lock, impl=...[... invalid], ...)
+```
+
+The error surfaces during a Lucene write (`commit`, `forceMerge`, or chunk `close()`), then
+propagates up to `AstraIndexer.run()`, which treats any exception as fatal and halts the VM.
+
+## Root cause (mechanism)
+
+A **leaked Java thread interrupt flag** destroys the Lucene `write.lock`.
+
+The chain:
+
+1. Lucene validates the `write.lock` on many operations via
+   `NativeFSLock.ensureValid()`, which calls `channel.size()` on the lock's
+   `FileChannel`.
+2. `FileChannel` is an `InterruptibleChannel`. If the calling thread's **interrupt flag is
+   already set** when it enters a blocking channel op, the JDK's NIO machinery **closes the
+   channel** (`ClosedByInterruptException`).
+3. Once that channel is closed, the underlying `FileLock` is invalid **forever**.
+   `FileLock.isValid()` returns false, so every later `ensureValid()` throws
+   `FileLock invalidated by an external force`.
+4. The write.lock is shared by the whole index (chunk), so the entire chunk is now broken.
+   The next write fails fatally → VM halt.
+
+### The flag is *dormant*
+
+The interrupt does not have to happen during the failing operation. A flag set earlier just
+**sits set on a reused pool thread** until the next op that touches a channel:
+
+- Ops that block/wait (`forceMerge` → internal wait, `awaitTermination`, the writer's event
+  queue) observe the flag, throw `InterruptedException`, **consume** the flag, and the lock
+  *survives*.
+- A no-op `commit()` with nothing to flush never touches the lock's channel — flag stays
+  dormant, lock alive.
+- The **first op that actually writes to a channel** with the flag still set (a flush, a file
+  delete, or `ensureValid` → `channel.size()`) is the one that closes the channel and kills
+  the lock.
+
+This is why the production stack traces throw at the `!lock.isValid()` check rather than at
+`channel.size()`: the kill happened on an *earlier* operation, and the observed failure merely
+inherited an already-dead channel.
+
+### This is a known, unfixed Lucene behavior
+
+This is not an Astra bug in Lucene's sense — it is documented upstream and Lucene declined to
+defend against it:
+
+- **LUCENE-8262** — `NativeFSLockFactory`'s `FileChannel` closes on interrupt, permanently
+  invalidating the lock. Resolved **Won't Fix**.
+- **apache/lucene#9309** — same mechanism, same symptom. Resolved **Won't Fix**.
+
+Both issues proposed switching to `AsynchronousFileChannel` (which is not an
+`InterruptibleChannel`); both were rejected. Lucene's guidance is explicit: **do not interrupt
+threads that perform Lucene I/O.** The responsibility to avoid the interrupt sits with the
+caller — us.
+
+## The problem we still have to solve: *what sets the flag?*
+
+Knowing the mechanism is not enough to fix it, because we do not yet know **what interrupts the
+Lucene-I/O threads in steady state.** A production crash was captured on the **scheduled commit
+thread** (a private, per-store single-thread executor) during a normal commit — not during
+shutdown. Nothing outside `LuceneIndexStoreImpl` holds a reference to that thread, which
+narrows the origin to:
+
+1. **Self-restoration inside Lucene** — a prior op on the same thread caught an
+   `InterruptedException` and restored the flag (`Thread.currentThread().interrupt()`), which
+   our `catch` then logged and swallowed *without clearing it*, leaving it on the pooled thread
+   for the next commit. (Consistent with the captured steady-state crash.)
+2. **Executor shutdown escalation** — `ExecutorService.close()` / `shutdownNow()` interrupting
+   the worker during shutdown. (Does not match a steady-state commit crash.)
+3. External `.interrupt()` on the thread — effectively impossible; no code holds the reference.
+
+The JVM gives us no callback for "a thread was interrupted," so in the general case we cannot
+see *who* set the flag.
+
+## Current change: diagnostics to identify the trigger
+
+This branch does **not** add a barrier or otherwise alter behavior. It adds an
+`InterruptLoggingThreadFactory` that produces threads whose `interrupt()` override logs the
+**caller's stack** (via a never-thrown `Throwable`) synchronously, then delegates to
+`super.interrupt()`. This captures the one piece we cannot otherwise observe — the code that
+interrupts a Lucene-I/O thread — for both the self-restoration and shutdown-escalation cases.
+
+Applied to the three reused Lucene-I/O executors:
+
+- `LuceneIndexStoreImpl` scheduled **commit** (`lucene-commit-%d`) — the thread of the captured
+  prod crash.
+- `LuceneIndexStoreImpl` scheduled **refresh** (`lucene-refresh-%d`).
+- `IndexingChunkManager` **rollover** pool (`lucene-rollover-%d`), which also runs the
+  stale-chunk `close()` via a `directExecutor` callback.
+
+The factory is diagnostic-only: it logs and delegates, it does not clear or suppress the
+interrupt. Volume is low (these threads are rarely interrupted), so it is safe to run in prod.
+
+### What to look for in prod
+
+A WARN of the form:
+
+```
+Thread 'lucene-commit-0' performing Lucene I/O was interrupted; capturing caller stack ...
+```
+
+The attached stack identifies the trigger:
+
+- If it points into Lucene internals restoring the flag → theory (1), self-restoration.
+- If it points into an executor `close()` / `shutdownNow()` path → theory (2), shutdown
+  escalation.
+
+Cross-reference the WARN timestamp with rollover / shutdown events on the same pod.
+
+## Deferred follow-up: the fix
+
+Once the trigger is identified, the fix should remove it **at the source** (e.g. stop the
+offending code from interrupting a Lucene-I/O thread, or sever the `directExecutor` chain that
+lets an S3-upload interrupt reach a `close()`). A blanket `Thread.interrupted()` barrier at each
+worker entry was considered as a catch-all backstop but is deliberately **not** included here:
+we want the trigger data first, so the eventual fix is targeted rather than defensive.
+
+### A separate, confirmed trigger in the S3 upload path
+
+`BlobStore.awaitUploads` catches `InterruptedException`, **restores** the flag
+(`Thread.currentThread().interrupt()`), and throws a `RuntimeException`. That exception is
+caught and swallowed by `ReadWriteChunk.snapshotToS3` (`catch (Exception) { return false; }`),
+orphaning the restored flag on the **rollover thread** — which then runs the stale-chunk
+`close()` inline via `directExecutor`. This is a clear leak on the rollover path, independent of
+the still-unknown commit-thread trigger, and is a candidate for the source-level fix above.


### PR DESCRIPTION
Adds diagnostics to identify what interrupts Lucene-I/O threads and invalidates the shared `write.lock`, causing the indexer `FileLock invalidated by an external force` crashes.

- `InterruptLoggingThreadFactory`: logs the caller's stack when one of its threads is interrupted, applied to the commit, refresh, and rollover executors.
- `BlobStore.awaitUploads`: logs the in-flight S3 key when the upload wait is interrupted.

Diagnostic only. Full writeup in `docs/indexer-filelock-interrupt-crash.md`.

-- Not intending to merge, just branch deploy.
