### PR TITLE
Thread shouldCache through etcd, fetch only keys

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -67,6 +67,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private final EtcdCreateMode createMode;
   protected final MetadataSerializer<T> serializer;
   private final List<String> partitionFilters;
+  private final boolean shouldCache;
   private final AstraConfigs.EtcdConfig etcdConfig;
   private final MeterRegistry meterRegistry;
   private final Client etcdClient;
@@ -122,6 +123,41 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
       MetadataSerializer<T> serializer,
       String storeFolder,
       List<String> partitionFilters) {
+    this(
+        etcdClient,
+        etcdConfig,
+        meterRegistry,
+        createMode,
+        serializer,
+        storeFolder,
+        partitionFilters,
+        true);
+  }
+
+  /**
+   * Constructor for EtcdPartitioningMetadataStore.
+   *
+   * @param etcdClient the etcd client
+   * @param etcdConfig the etcd configuration
+   * @param meterRegistry metrics registry
+   * @param createMode whether to create persistent or ephemeral nodes
+   * @param serializer serializer for the metadata type
+   * @param storeFolder the folder to store data in
+   * @param partitionFilters optional list of partition IDs to filter on
+   * @param shouldCache when false, skip cluster-wide partition discovery and watching and do not
+   *     cache per-partition data. Nodes that only register and remove their own entries (e.g.
+   *     cache, index, recovery) never read the global set, so they can avoid mirroring every
+   *     partition.
+   */
+  public EtcdPartitioningMetadataStore(
+      Client etcdClient,
+      AstraConfigs.EtcdConfig etcdConfig,
+      MeterRegistry meterRegistry,
+      EtcdCreateMode createMode,
+      MetadataSerializer<T> serializer,
+      String storeFolder,
+      List<String> partitionFilters,
+      boolean shouldCache) {
     this.etcdClient = etcdClient;
     this.watchClient = etcdClient.getWatchClient();
     this.storeFolder = storeFolder;
@@ -129,6 +165,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     this.createMode = createMode;
     this.serializer = serializer;
     this.partitionFilters = partitionFilters;
+    this.shouldCache = shouldCache;
     this.etcdConfig = etcdConfig;
     this.meterRegistry = meterRegistry;
     this.retryTotalDurationMs =
@@ -157,57 +194,9 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
               return t;
             });
 
-    startPartitionWatch(
-        REVISION_LATEST,
-        new EtcdMetadataStore.WatchRetryState(
-            initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
-
-    ByteSequence storeFolderKey = ByteSequence.from(storeFolder, StandardCharsets.UTF_8);
-    etcdClient
-        .getKVClient()
-        .get(storeFolderKey, GetOption.builder().isPrefix(true).build())
-        .thenComposeAsync(
-            getResponse -> {
-              if (getResponse.getKvs().isEmpty()) {
-                // This is similar to KeeperException.NoNodeException in ZK
-                // The storeFolder does not yet exist in etcd
-                return CompletableFuture.completedFuture(List.<String>of());
-              } else {
-                ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
-                return etcdClient
-                    .getKVClient()
-                    .get(prefix, GetOption.builder().isPrefix(true).build())
-                    .orTimeout(etcdConfig.getOperationsTimeoutMs(), TimeUnit.MILLISECONDS)
-                    .thenApplyAsync(
-                        childResponse -> {
-                          List<String> children = new ArrayList<>();
-                          childResponse
-                              .getKvs()
-                              .forEach(
-                                  kv -> {
-                                    String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
-                                    String partition = extractPartition(keyStr);
-                                    if (partition != null && !children.contains(partition)) {
-                                      children.add(partition);
-                                    }
-                                  });
-                          return children;
-                        });
-              }
-            })
-        .thenAcceptAsync(
-            (children) -> {
-              if (partitionFilters.isEmpty()) {
-                children.forEach(this::getOrCreateMetadataStore);
-              } else {
-                children.stream()
-                    .filter(partitionFilters::contains)
-                    .forEach(this::getOrCreateMetadataStore);
-              }
-            })
-        .toCompletableFuture()
-        // wait for all the stores to be initialized prior to exiting the constructor
-        .join();
+    if (shouldCache) {
+      initPartitionCache();
+    }
 
     if (partitionFilters.isEmpty()) {
       LOG.info(
@@ -221,6 +210,22 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
           metadataStoreMap.size(),
           String.join(",", partitionFilters));
     }
+  }
+
+  /**
+   * Establishes the cluster-wide partition watch and scans etcd for existing partitions, creating a
+   * sub-store for each before the constructor returns. Only invoked when {@code shouldCache} is
+   * true; nodes that only register their own entry skip this entirely.
+   */
+  private void initPartitionCache() {
+    startPartitionWatch(
+        REVISION_LATEST,
+        new EtcdMetadataStore.WatchRetryState(
+            initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
+
+    // Watch is established first, so any partition created during the scan is picked up via an
+    // event rather than missed. Wait for all sub-stores to initialize prior to returning.
+    getPartitionsFromEtcd().forEach(this::getOrCreateMetadataStore);
   }
 
   /**
@@ -819,7 +824,13 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
 
               EtcdMetadataStore<T> newStore =
                   new EtcdMetadataStore<>(
-                      path, etcdConfig, true, meterRegistry, serializer, createMode, etcdClient);
+                      path,
+                      etcdConfig,
+                      shouldCache,
+                      meterRegistry,
+                      serializer,
+                      createMode,
+                      etcdClient);
               listenerMap.forEach((_, listener) -> newStore.addListener(listener));
 
               created.set(true);

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -195,7 +195,58 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
             });
 
     if (shouldCache) {
-      initPartitionCache();
+      startPartitionWatch(
+          REVISION_LATEST,
+          new EtcdMetadataStore.WatchRetryState(
+              initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
+
+      ByteSequence storeFolderKey = ByteSequence.from(storeFolder, StandardCharsets.UTF_8);
+      etcdClient
+          .getKVClient()
+          .get(storeFolderKey, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
+          .thenComposeAsync(
+              getResponse -> {
+                if (getResponse.getKvs().isEmpty()) {
+                  // This is similar to KeeperException.NoNodeException in ZK
+                  // The storeFolder does not yet exist in etcd
+                  return CompletableFuture.completedFuture(List.<String>of());
+                } else {
+                  ByteSequence prefix =
+                      ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
+                  return etcdClient
+                      .getKVClient()
+                      .get(prefix, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
+                      .orTimeout(etcdConfig.getOperationsTimeoutMs(), TimeUnit.MILLISECONDS)
+                      .thenApplyAsync(
+                          childResponse -> {
+                            List<String> children = new ArrayList<>();
+                            childResponse
+                                .getKvs()
+                                .forEach(
+                                    kv -> {
+                                      String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
+                                      String partition = extractPartition(keyStr);
+                                      if (partition != null && !children.contains(partition)) {
+                                        children.add(partition);
+                                      }
+                                    });
+                            return children;
+                          });
+                }
+              })
+          .thenAcceptAsync(
+              (children) -> {
+                if (partitionFilters.isEmpty()) {
+                  children.forEach(this::getOrCreateMetadataStore);
+                } else {
+                  children.stream()
+                      .filter(partitionFilters::contains)
+                      .forEach(this::getOrCreateMetadataStore);
+                }
+              })
+          .toCompletableFuture()
+          // wait for all the stores to be initialized prior to exiting the constructor
+          .join();
     }
 
     if (partitionFilters.isEmpty()) {
@@ -210,22 +261,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
           metadataStoreMap.size(),
           String.join(",", partitionFilters));
     }
-  }
-
-  /**
-   * Establishes the cluster-wide partition watch and scans etcd for existing partitions, creating a
-   * sub-store for each before the constructor returns. Only invoked when {@code shouldCache} is
-   * true; nodes that only register their own entry skip this entirely.
-   */
-  private void initPartitionCache() {
-    startPartitionWatch(
-        REVISION_LATEST,
-        new EtcdMetadataStore.WatchRetryState(
-            initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
-
-    // Watch is established first, so any partition created during the scan is picked up via an
-    // event rather than missed. Wait for all sub-stores to initialize prior to returning.
-    getPartitionsFromEtcd().forEach(this::getOrCreateMetadataStore);
   }
 
   /**

--- a/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
@@ -30,6 +30,8 @@ public class SearchMetadataStore extends AstraPartitioningMetadataStore<SearchMe
       boolean shouldCache) {
     super(
         curatorFramework != null
+            // The ZK store intentionally ignores shouldCache and always builds the cluster-wide
+            // mirror; only the etcd path honors it, since ZK is legacy and being retired.
             ? new ZookeeperPartitioningMetadataStore<>(
                 curatorFramework,
                 metadataStoreConfig.getZookeeperConfig(),
@@ -45,7 +47,9 @@ public class SearchMetadataStore extends AstraPartitioningMetadataStore<SearchMe
                 meterRegistry,
                 EtcdCreateMode.EPHEMERAL,
                 new SearchMetadataSerializer(),
-                SEARCH_PARTITIONED_METADATA_STORE_PATH)
+                SEARCH_PARTITIONED_METADATA_STORE_PATH,
+                List.of(),
+                shouldCache)
             : null,
         metadataStoreConfig.getStoreModesOrDefault(
             "SearchMetadataStore", AstraConfigs.MetadataStoreMode.ETCD_CREATES),

--- a/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/search/SearchMetadataStore.java
@@ -30,8 +30,6 @@ public class SearchMetadataStore extends AstraPartitioningMetadataStore<SearchMe
       boolean shouldCache) {
     super(
         curatorFramework != null
-            // The ZK store intentionally ignores shouldCache and always builds the cluster-wide
-            // mirror; only the etcd path honors it, since ZK is legacy and being retired.
             ? new ZookeeperPartitioningMetadataStore<>(
                 curatorFramework,
                 metadataStoreConfig.getZookeeperConfig(),


### PR DESCRIPTION
###  Summary
On booting of a new Astra node, we try to fetch the entire ETCD database and on larger clusters, due to the amount of metadata we store, we run into the GRPC 4MB limit. This PR does two things:
* changes the fetch to only fetch the keys, since that is all we need
* threads the `shouldCache` value through the `EtcdPartitioningMetadataStore` as it wasn't doing that before, causing all cache and indexer nodes to try to fetch the whole DB when they didn't need it (they only need to know what's on their own node)

Caveat: The query nodes are the only ones trying to not cache the `SearchMetadataStore` as they need to know where all chunks of data are across the cluster to fan-out queries. The `keysOnly` change will help this a bit but we could still run into this limit on larger clusters.


### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
