### PR TITLE
ETCD Pagination

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -106,6 +106,17 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   static final long DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
   static final long DEFAULT_INITIAL_RETRY_INTERVAL_MS = 2_000;
 
+  /**
+   * Maximum number of entries fetched per etcd range request. Full-folder reads are paginated so
+   * that no single gRPC response can exceed the client's inbound message size limit (4 MiB by
+   * default). A single unbounded range read over a large store previously overflowed this limit and
+   * failed with {@code RESOURCE_EXHAUSTED} (e.g. the query node loading the search metadata cache).
+   */
+  private static final long LIST_PAGE_SIZE = 500;
+
+  /** Single zero byte appended to a key to form the smallest key strictly greater than it. */
+  private static final ByteSequence NEXT_KEY_SUFFIX = ByteSequence.from(new byte[] {0});
+
   private static volatile FatalErrorHandler fatalErrorHandler = new RuntimeHalterImpl();
 
   static void setFatalErrorHandler(FatalErrorHandler handler) {
@@ -870,19 +881,15 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     }
 
     // Add a trailing slash to the folder to make sure we only list entries directly under this
-    // folder
+    // folder. Paginated so a large store cannot overflow the gRPC inbound message size limit.
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-    GetOption getOption = GetOption.builder().withPrefix(prefix).build();
 
-    return etcdClient
-        .getKVClient()
-        .get(prefix, getOption)
-        .orTimeout(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS)
+    return listRangePaginatedAsync(prefix)
         .thenApplyAsync(
-            getResponse -> {
+            keyValues -> {
               List<T> nodes = new ArrayList<>();
 
-              for (KeyValue kv : getResponse.getKvs()) {
+              for (KeyValue kv : keyValues) {
                 try {
                   String json = kv.getValue().toString(StandardCharsets.UTF_8);
                   T node = serializer.fromJsonStr(json);
@@ -937,19 +944,13 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
 
     try {
       // Add a trailing slash to the folder to make sure we only list entries directly under this
-      // folder
+      // folder. Paginated so a large store cannot overflow the gRPC inbound message size limit.
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-      GetOption getOption = GetOption.builder().withPrefix(prefix).build();
-
-      GetResponse getResponse =
-          etcdClient
-              .getKVClient()
-              .get(prefix, getOption)
-              .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS);
+      List<KeyValue> keyValues = listRangePaginated(prefix).keyValues();
 
       List<T> nodes = new ArrayList<>();
 
-      for (KeyValue kv : getResponse.getKvs()) {
+      for (KeyValue kv : keyValues) {
         try {
           String json = kv.getValue().toString(StandardCharsets.UTF_8);
           T node = serializer.fromJsonStr(json);
@@ -1279,22 +1280,117 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     }
   }
 
+  /**
+   * The key/values read under a folder prefix, together with the etcd revision the read was pinned
+   * to. All pages of a paginated read share a single revision so the aggregate is a consistent
+   * point-in-time snapshot.
+   */
+  private record PaginatedRange(List<KeyValue> keyValues, long revision) {}
+
+  /**
+   * Appends a single zero byte to a key to produce the smallest key strictly greater than it. Used
+   * to advance a range read past the last key of the previous page without skipping or repeating
+   * any key.
+   */
+  private static ByteSequence nextKey(ByteSequence key) {
+    return key.concat(NEXT_KEY_SUFFIX);
+  }
+
+  /**
+   * Builds the {@link GetOption} for a single page of a paginated range read: key-ascending order,
+   * bounded to {@link #LIST_PAGE_SIZE} entries. When {@code revision} is past {@link
+   * #REVISION_LATEST} the read is pinned to that revision so every page observes one consistent
+   * snapshot.
+   */
+  private static GetOption pageOption(ByteSequence prefix, long revision) {
+    GetOption.Builder options =
+        GetOption.builder()
+            .withPrefix(prefix)
+            .withLimit(LIST_PAGE_SIZE)
+            .withSortField(GetOption.SortTarget.KEY)
+            .withSortOrder(GetOption.SortOrder.ASCEND);
+    if (revision > REVISION_LATEST) {
+      options.withRevision(revision);
+    }
+    return options.build();
+  }
+
+  /**
+   * Reads every key/value under {@code prefix} synchronously, paging the range request so no single
+   * etcd response can exceed the gRPC inbound message size limit. Each page is individually bounded
+   * by the operation timeout, and every page after the first is pinned to the revision of the first
+   * page so the returned set is a consistent snapshot.
+   *
+   * @param prefix the folder prefix (including any trailing slash) to range over
+   * @return the aggregated key/values and the revision they were read at
+   */
+  private PaginatedRange listRangePaginated(ByteSequence prefix)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    List<KeyValue> keyValues = new ArrayList<>();
+    ByteSequence fromKey = prefix;
+    long revision = REVISION_LATEST;
+    while (true) {
+      GetResponse response =
+          etcdClient
+              .getKVClient()
+              .get(fromKey, pageOption(prefix, revision))
+              .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS);
+
+      List<KeyValue> page = response.getKvs();
+      keyValues.addAll(page);
+      if (revision == REVISION_LATEST) {
+        revision = response.getHeader().getRevision();
+      }
+
+      if (!response.isMore() || page.isEmpty()) {
+        return new PaginatedRange(keyValues, revision);
+      }
+      fromKey = nextKey(page.get(page.size() - 1).getKey());
+    }
+  }
+
+  /**
+   * Asynchronous, non-blocking variant of {@link #listRangePaginated} used by {@link #listAsync()}.
+   * Pages are fetched sequentially by chaining futures; each page is bounded by the operation
+   * timeout and pinned to the revision of the first page.
+   */
+  private CompletableFuture<List<KeyValue>> listRangePaginatedAsync(ByteSequence prefix) {
+    return fetchPageAsync(prefix, prefix, REVISION_LATEST, new ArrayList<>());
+  }
+
+  private CompletableFuture<List<KeyValue>> fetchPageAsync(
+      ByteSequence prefix, ByteSequence fromKey, long pinnedRevision, List<KeyValue> keyValues) {
+    return etcdClient
+        .getKVClient()
+        .get(fromKey, pageOption(prefix, pinnedRevision))
+        .orTimeout(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS)
+        .thenCompose(
+            response -> {
+              List<KeyValue> page = response.getKvs();
+              keyValues.addAll(page);
+              long revision =
+                  pinnedRevision > REVISION_LATEST
+                      ? pinnedRevision
+                      : response.getHeader().getRevision();
+              if (!response.isMore() || page.isEmpty()) {
+                return CompletableFuture.completedFuture(keyValues);
+              }
+              return fetchPageAsync(
+                  prefix, nextKey(page.get(page.size() - 1).getKey()), revision, keyValues);
+            });
+  }
+
   /** Populates the cache with all nodes from etcd. This is called once during initialization. */
   private void populateInitialCache() {
     try {
       LOG.debug("Populating cache for store {}", storeFolder);
-      // Get only nodes from this store folder
+      // Get only nodes from this store folder. Paginated so a large store cannot overflow the
+      // gRPC inbound message size limit.
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-      GetOption getOption = GetOption.builder().withPrefix(prefix).build();
-
-      GetResponse getResponse =
-          etcdClient
-              .getKVClient()
-              .get(prefix, getOption)
-              .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS);
+      List<KeyValue> keyValues = listRangePaginated(prefix).keyValues();
 
       // Filter for only direct children of the store folder
-      for (KeyValue kv : getResponse.getKvs()) {
+      for (KeyValue kv : keyValues) {
         // Check for interruption on each iteration
         if (Thread.currentThread().isInterrupted()) {
           LOG.info(
@@ -1358,18 +1454,14 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   private long resyncCacheFromEtcd(AstraMetadataStoreChangeListener<T> listener)
       throws InterruptedException, ExecutionException, TimeoutException {
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-    GetResponse getResponse =
-        etcdClient
-            .getKVClient()
-            .get(prefix, GetOption.builder().withPrefix(prefix).build())
-            .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS);
+    PaginatedRange range = listRangePaginated(prefix);
 
-    long listRevision = getResponse.getHeader().getRevision();
+    long listRevision = range.revision();
 
     // Build the new state from etcd and collect names for delete detection
     Set<String> newKeys = new HashSet<>();
     List<T> newNodes = new ArrayList<>();
-    for (KeyValue kv : getResponse.getKvs()) {
+    for (KeyValue kv : range.keyValues()) {
       if (isDirectChild(kv.getKey())) {
         try {
           String json = kv.getValue().toString(StandardCharsets.UTF_8);

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -9,7 +9,6 @@ import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.Watch.Watcher;
-import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
 import io.etcd.jetcd.options.GetOption;
 import io.etcd.jetcd.options.PutOption;
@@ -105,17 +104,6 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   static final long DEFAULT_RETRY_TOTAL_DURATION_MS = 60_000;
   static final long DEFAULT_MAX_RETRY_DELAY_MS = 10_000;
   static final long DEFAULT_INITIAL_RETRY_INTERVAL_MS = 2_000;
-
-  /**
-   * Maximum number of entries fetched per etcd range request. Full-folder reads are paginated so
-   * that no single gRPC response can exceed the client's inbound message size limit (4 MiB by
-   * default). A single unbounded range read over a large store previously overflowed this limit and
-   * failed with {@code RESOURCE_EXHAUSTED} (e.g. the query node loading the search metadata cache).
-   */
-  private static final long LIST_PAGE_SIZE = 500;
-
-  /** Single zero byte appended to a key to form the smallest key strictly greater than it. */
-  private static final ByteSequence NEXT_KEY_SUFFIX = ByteSequence.from(new byte[] {0});
 
   private static volatile FatalErrorHandler fatalErrorHandler = new RuntimeHalterImpl();
 
@@ -884,12 +872,13 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     // folder. Paginated so a large store cannot overflow the gRPC inbound message size limit.
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
 
-    return listRangePaginatedAsync(prefix)
+    return EtcdRangePaginator.listRangeAsync(
+            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs)
         .thenApplyAsync(
-            keyValues -> {
+            range -> {
               List<T> nodes = new ArrayList<>();
 
-              for (KeyValue kv : keyValues) {
+              for (KeyValue kv : range.keyValues()) {
                 try {
                   String json = kv.getValue().toString(StandardCharsets.UTF_8);
                   T node = serializer.fromJsonStr(json);
@@ -946,7 +935,10 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       // Add a trailing slash to the folder to make sure we only list entries directly under this
       // folder. Paginated so a large store cannot overflow the gRPC inbound message size limit.
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-      List<KeyValue> keyValues = listRangePaginated(prefix).keyValues();
+      List<KeyValue> keyValues =
+          EtcdRangePaginator.listRange(
+                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs)
+              .keyValues();
 
       List<T> nodes = new ArrayList<>();
 
@@ -1047,10 +1039,11 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       if (startRevision == REVISION_RESYNC) {
         currentRevision = resyncCacheFromEtcd(listener);
       } else if (startRevision == REVISION_LATEST) {
+        // Only the header revision is needed here, so count-only avoids transferring any keys.
         currentRevision =
             etcdClient
                 .getKVClient()
-                .get(prefix, GetOption.builder().withPrefix(prefix).withKeysOnly(true).build())
+                .get(prefix, GetOption.builder().withPrefix(prefix).withCountOnly(true).build())
                 .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS)
                 .getHeader()
                 .getRevision();
@@ -1280,106 +1273,6 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     }
   }
 
-  /**
-   * The key/values read under a folder prefix, together with the etcd revision the read was pinned
-   * to. All pages of a paginated read share a single revision so the aggregate is a consistent
-   * point-in-time snapshot.
-   */
-  private record PaginatedRange(List<KeyValue> keyValues, long revision) {}
-
-  /**
-   * Appends a single zero byte to a key to produce the smallest key strictly greater than it. Used
-   * to advance a range read past the last key of the previous page without skipping or repeating
-   * any key.
-   */
-  private static ByteSequence nextKey(ByteSequence key) {
-    return key.concat(NEXT_KEY_SUFFIX);
-  }
-
-  /**
-   * Builds the {@link GetOption} for a single page of a paginated range read: key-ascending order,
-   * bounded to {@link #LIST_PAGE_SIZE} entries. When {@code revision} is past {@link
-   * #REVISION_LATEST} the read is pinned to that revision so every page observes one consistent
-   * snapshot.
-   */
-  private static GetOption pageOption(ByteSequence prefix, long revision) {
-    GetOption.Builder options =
-        GetOption.builder()
-            .withPrefix(prefix)
-            .withLimit(LIST_PAGE_SIZE)
-            .withSortField(GetOption.SortTarget.KEY)
-            .withSortOrder(GetOption.SortOrder.ASCEND);
-    if (revision > REVISION_LATEST) {
-      options.withRevision(revision);
-    }
-    return options.build();
-  }
-
-  /**
-   * Reads every key/value under {@code prefix} synchronously, paging the range request so no single
-   * etcd response can exceed the gRPC inbound message size limit. Each page is individually bounded
-   * by the operation timeout, and every page after the first is pinned to the revision of the first
-   * page so the returned set is a consistent snapshot.
-   *
-   * @param prefix the folder prefix (including any trailing slash) to range over
-   * @return the aggregated key/values and the revision they were read at
-   */
-  private PaginatedRange listRangePaginated(ByteSequence prefix)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    List<KeyValue> keyValues = new ArrayList<>();
-    ByteSequence fromKey = prefix;
-    long revision = REVISION_LATEST;
-    while (true) {
-      GetResponse response =
-          etcdClient
-              .getKVClient()
-              .get(fromKey, pageOption(prefix, revision))
-              .get(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS);
-
-      List<KeyValue> page = response.getKvs();
-      keyValues.addAll(page);
-      if (revision == REVISION_LATEST) {
-        revision = response.getHeader().getRevision();
-      }
-
-      if (!response.isMore() || page.isEmpty()) {
-        return new PaginatedRange(keyValues, revision);
-      }
-      fromKey = nextKey(page.get(page.size() - 1).getKey());
-    }
-  }
-
-  /**
-   * Asynchronous, non-blocking variant of {@link #listRangePaginated} used by {@link #listAsync()}.
-   * Pages are fetched sequentially by chaining futures; each page is bounded by the operation
-   * timeout and pinned to the revision of the first page.
-   */
-  private CompletableFuture<List<KeyValue>> listRangePaginatedAsync(ByteSequence prefix) {
-    return fetchPageAsync(prefix, prefix, REVISION_LATEST, new ArrayList<>());
-  }
-
-  private CompletableFuture<List<KeyValue>> fetchPageAsync(
-      ByteSequence prefix, ByteSequence fromKey, long pinnedRevision, List<KeyValue> keyValues) {
-    return etcdClient
-        .getKVClient()
-        .get(fromKey, pageOption(prefix, pinnedRevision))
-        .orTimeout(etcdOperationTimeoutMs, TimeUnit.MILLISECONDS)
-        .thenCompose(
-            response -> {
-              List<KeyValue> page = response.getKvs();
-              keyValues.addAll(page);
-              long revision =
-                  pinnedRevision > REVISION_LATEST
-                      ? pinnedRevision
-                      : response.getHeader().getRevision();
-              if (!response.isMore() || page.isEmpty()) {
-                return CompletableFuture.completedFuture(keyValues);
-              }
-              return fetchPageAsync(
-                  prefix, nextKey(page.get(page.size() - 1).getKey()), revision, keyValues);
-            });
-  }
-
   /** Populates the cache with all nodes from etcd. This is called once during initialization. */
   private void populateInitialCache() {
     try {
@@ -1387,7 +1280,10 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       // Get only nodes from this store folder. Paginated so a large store cannot overflow the
       // gRPC inbound message size limit.
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-      List<KeyValue> keyValues = listRangePaginated(prefix).keyValues();
+      List<KeyValue> keyValues =
+          EtcdRangePaginator.listRange(
+                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs)
+              .keyValues();
 
       // Filter for only direct children of the store folder
       for (KeyValue kv : keyValues) {
@@ -1454,7 +1350,9 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   private long resyncCacheFromEtcd(AstraMetadataStoreChangeListener<T> listener)
       throws InterruptedException, ExecutionException, TimeoutException {
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
-    PaginatedRange range = listRangePaginated(prefix);
+    EtcdRangePaginator.PaginatedRange range =
+        EtcdRangePaginator.listRange(
+            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs);
 
     long listRevision = range.revision();
 

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -868,8 +868,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       return CompletableFuture.completedFuture(cachedNodes);
     }
 
-    // Add a trailing slash to the folder to make sure we only list entries directly under this
-    // folder. Paginated so a large store cannot overflow the gRPC inbound message size limit.
+    // Add a trailing slash to the folder to make sure we only list entries directly under it.
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
 
     return EtcdRangePaginator.listRangeAsync(
@@ -1277,8 +1276,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   private void populateInitialCache() {
     try {
       LOG.debug("Populating cache for store {}", storeFolder);
-      // Get only nodes from this store folder. Paginated so a large store cannot overflow the
-      // gRPC inbound message size limit.
+      // Get only nodes from this store folder.
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
       List<KeyValue> keyValues =
           EtcdRangePaginator.listRange(

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -199,10 +199,9 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
           new EtcdMetadataStore.WatchRetryState(
               initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
 
-      // Discover existing partitions and initialize a store for each before exiting the
-      // constructor. Paginated and keys-only so a store with many partitions cannot overflow the
-      // gRPC inbound message size limit; getPartitionsFromEtcd already applies any partition
-      // filters and returns empty when the folder does not yet exist.
+      // Initialize a store for each existing partition before exiting the constructor.
+      // getPartitionsFromEtcd applies any partition filters and returns empty if the folder is
+      // absent.
       getPartitionsFromEtcd().forEach(this::getOrCreateMetadataStore);
     }
 
@@ -711,8 +710,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private Set<String> getPartitionsFromEtcd() {
     try {
       ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
-      // Paginated and keys-only so a store with many partitions cannot overflow the gRPC inbound
-      // message size limit.
       return extractPartitions(
           EtcdRangePaginator.listRange(
                   etcdClient.getKVClient(), prefix, true, etcdConfig.getConnectionTimeoutMs())
@@ -744,8 +741,6 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private long resyncPartitionsFromEtcd()
       throws InterruptedException, ExecutionException, TimeoutException {
     ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
-    // Paginated and keys-only so a store with many partitions cannot overflow the gRPC inbound
-    // message size limit.
     EtcdRangePaginator.PaginatedRange range =
         EtcdRangePaginator.listRange(
             etcdClient.getKVClient(), prefix, true, etcdConfig.getConnectionTimeoutMs());

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -8,7 +8,6 @@ import com.slack.astra.util.ExponentialBackOff;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.Watch;
-import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.GetOption;
 import io.etcd.jetcd.options.WatchOption;
 import io.etcd.jetcd.watch.WatchEvent;
@@ -200,53 +199,11 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
           new EtcdMetadataStore.WatchRetryState(
               initialRetryIntervalMs, maxRetryDelayMs, retryTotalDurationMs));
 
-      ByteSequence storeFolderKey = ByteSequence.from(storeFolder, StandardCharsets.UTF_8);
-      etcdClient
-          .getKVClient()
-          .get(storeFolderKey, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
-          .thenComposeAsync(
-              getResponse -> {
-                if (getResponse.getKvs().isEmpty()) {
-                  // This is similar to KeeperException.NoNodeException in ZK
-                  // The storeFolder does not yet exist in etcd
-                  return CompletableFuture.completedFuture(List.<String>of());
-                } else {
-                  ByteSequence prefix =
-                      ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
-                  return etcdClient
-                      .getKVClient()
-                      .get(prefix, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
-                      .orTimeout(etcdConfig.getOperationsTimeoutMs(), TimeUnit.MILLISECONDS)
-                      .thenApplyAsync(
-                          childResponse -> {
-                            List<String> children = new ArrayList<>();
-                            childResponse
-                                .getKvs()
-                                .forEach(
-                                    kv -> {
-                                      String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
-                                      String partition = extractPartition(keyStr);
-                                      if (partition != null && !children.contains(partition)) {
-                                        children.add(partition);
-                                      }
-                                    });
-                            return children;
-                          });
-                }
-              })
-          .thenAcceptAsync(
-              (children) -> {
-                if (partitionFilters.isEmpty()) {
-                  children.forEach(this::getOrCreateMetadataStore);
-                } else {
-                  children.stream()
-                      .filter(partitionFilters::contains)
-                      .forEach(this::getOrCreateMetadataStore);
-                }
-              })
-          .toCompletableFuture()
-          // wait for all the stores to be initialized prior to exiting the constructor
-          .join();
+      // Discover existing partitions and initialize a store for each before exiting the
+      // constructor. Paginated and keys-only so a store with many partitions cannot overflow the
+      // gRPC inbound message size limit; getPartitionsFromEtcd already applies any partition
+      // filters and returns empty when the folder does not yet exist.
+      getPartitionsFromEtcd().forEach(this::getOrCreateMetadataStore);
     }
 
     if (partitionFilters.isEmpty()) {
@@ -285,12 +242,13 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
       if (startRevision == REVISION_RESYNC) {
         currentRevision = resyncPartitionsFromEtcd();
       } else if (startRevision == REVISION_LATEST) {
+        // Only the header revision is needed here, so count-only avoids transferring any keys.
         currentRevision =
             etcdClient
                 .getKVClient()
                 .get(
                     storeFolderKey,
-                    GetOption.builder().withPrefix(storeFolderKey).withKeysOnly(true).build())
+                    GetOption.builder().withPrefix(storeFolderKey).withCountOnly(true).build())
                 .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS)
                 .getHeader()
                 .getRevision();
@@ -753,21 +711,20 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private Set<String> getPartitionsFromEtcd() {
     try {
       ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
-      GetResponse getResponse =
-          etcdClient
-              .getKVClient()
-              .get(prefix, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
-              .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
-
-      return extractPartitionsFromResponse(getResponse);
+      // Paginated and keys-only so a store with many partitions cannot overflow the gRPC inbound
+      // message size limit.
+      return extractPartitions(
+          EtcdRangePaginator.listRange(
+                  etcdClient.getKVClient(), prefix, true, etcdConfig.getConnectionTimeoutMs())
+              .keyValues());
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error fetching partitions from etcd", e);
     }
   }
 
-  private Set<String> extractPartitionsFromResponse(GetResponse getResponse) {
+  private Set<String> extractPartitions(List<io.etcd.jetcd.KeyValue> keyValues) {
     Set<String> partitions = new HashSet<>();
-    for (io.etcd.jetcd.KeyValue kv : getResponse.getKvs()) {
+    for (io.etcd.jetcd.KeyValue kv : keyValues) {
       String keyStr = kv.getKey().toString(StandardCharsets.UTF_8);
       String partition = extractPartition(keyStr);
       if (partition != null
@@ -787,15 +744,15 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private long resyncPartitionsFromEtcd()
       throws InterruptedException, ExecutionException, TimeoutException {
     ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
-    GetResponse getResponse =
-        etcdClient
-            .getKVClient()
-            .get(prefix, GetOption.builder().isPrefix(true).withKeysOnly(true).build())
-            .get(etcdConfig.getConnectionTimeoutMs(), TimeUnit.MILLISECONDS);
+    // Paginated and keys-only so a store with many partitions cannot overflow the gRPC inbound
+    // message size limit.
+    EtcdRangePaginator.PaginatedRange range =
+        EtcdRangePaginator.listRange(
+            etcdClient.getKVClient(), prefix, true, etcdConfig.getConnectionTimeoutMs());
 
-    long listRevision = getResponse.getHeader().getRevision();
+    long listRevision = range.revision();
 
-    Set<String> discoveredPartitions = extractPartitionsFromResponse(getResponse);
+    Set<String> discoveredPartitions = extractPartitions(range.keyValues());
     discoveredPartitions.forEach(this::getOrCreateMetadataStore);
 
     // Remove stores for partitions that no longer exist in etcd

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -12,8 +12,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Pages are read in ascending key order, each after the first pinned to the first
- * page's revision for a consistent snapshot.
+ * Pages are read in ascending key order, each after the first pinned to the first page's revision
+ * for a consistent snapshot.
  */
 final class EtcdRangePaginator {
   /** etcd treats revision 0 as latest. */

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -1,0 +1,152 @@
+package com.slack.astra.metadata.core;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.options.GetOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Reads every key under a folder prefix, paging the underlying etcd range request so that no single
+ * gRPC response can exceed the client's inbound message size limit (4 MiB by default). A single
+ * unbounded range read over a large store previously overflowed this limit and failed with {@code
+ * RESOURCE_EXHAUSTED} (e.g. a query node loading the search metadata cache, or a partitioning store
+ * enumerating partitions in a very large cluster).
+ *
+ * <p>Pages are read in ascending key order and advanced past the last key of the previous page.
+ * Every page after the first is pinned to the revision of the first page, so the aggregated result
+ * is a consistent point-in-time snapshot. Both a blocking ({@link #listRange}) and a non-blocking
+ * ({@link #listRangeAsync}) variant are provided; each page is individually bounded by {@code
+ * timeoutMs}.
+ */
+final class EtcdRangePaginator {
+  /** Sentinel meaning "read at the latest revision"; etcd treats revision 0 as latest. */
+  private static final long REVISION_LATEST = 0;
+
+  /**
+   * Maximum number of entries fetched per etcd range request. Bounds a page by entry count rather
+   * than bytes (etcd's range API has no byte budget), so it protects the default 4 MiB limit only
+   * while per-entry size stays under ~8 KiB — comfortably true for the metadata types stored here.
+   */
+  static final long DEFAULT_PAGE_SIZE = 500;
+
+  /** Single zero byte appended to a key to form the smallest key strictly greater than it. */
+  private static final ByteSequence NEXT_KEY_SUFFIX = ByteSequence.from(new byte[] {0});
+
+  private EtcdRangePaginator() {}
+
+  /**
+   * The key/values read under a folder prefix, together with the etcd revision the read was pinned
+   * to. Callers that establish a watch use {@link #revision()} to start watching from {@code
+   * revision + 1} without missing or replaying events.
+   */
+  record PaginatedRange(List<KeyValue> keyValues, long revision) {}
+
+  /**
+   * Appends a single zero byte to a key to produce the smallest key strictly greater than it, used
+   * to advance a range read past the last key of the previous page without skipping or repeating
+   * any key.
+   */
+  private static ByteSequence nextKey(ByteSequence key) {
+    return key.concat(NEXT_KEY_SUFFIX);
+  }
+
+  /**
+   * Builds the {@link GetOption} for a single page: key-ascending order, bounded to {@link
+   * #DEFAULT_PAGE_SIZE} entries. When {@code revision} is past {@link #REVISION_LATEST} the read is
+   * pinned to that revision so every page observes one consistent snapshot.
+   */
+  private static GetOption pageOption(ByteSequence prefix, boolean keysOnly, long revision) {
+    GetOption.Builder options =
+        GetOption.builder()
+            .withPrefix(prefix)
+            .withLimit(DEFAULT_PAGE_SIZE)
+            .withSortField(GetOption.SortTarget.KEY)
+            .withSortOrder(GetOption.SortOrder.ASCEND)
+            .withKeysOnly(keysOnly);
+    if (revision > REVISION_LATEST) {
+      options.withRevision(revision);
+    }
+    return options.build();
+  }
+
+  /**
+   * Reads every key/value under {@code prefix} synchronously, one page at a time.
+   *
+   * @param kvClient the etcd KV client to read through
+   * @param prefix the folder prefix (including any trailing slash) to range over
+   * @param keysOnly when true, only key metadata is fetched and values are omitted
+   * @param timeoutMs per-page operation timeout
+   * @return the aggregated key/values and the revision they were read at
+   */
+  static PaginatedRange listRange(
+      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    List<KeyValue> keyValues = new ArrayList<>();
+    ByteSequence fromKey = prefix;
+    long revision = REVISION_LATEST;
+    while (true) {
+      GetResponse response =
+          kvClient
+              .get(fromKey, pageOption(prefix, keysOnly, revision))
+              .get(timeoutMs, TimeUnit.MILLISECONDS);
+
+      List<KeyValue> page = response.getKvs();
+      keyValues.addAll(page);
+      if (revision == REVISION_LATEST) {
+        revision = response.getHeader().getRevision();
+      }
+
+      if (!response.isMore() || page.isEmpty()) {
+        return new PaginatedRange(keyValues, revision);
+      }
+      fromKey = nextKey(page.get(page.size() - 1).getKey());
+    }
+  }
+
+  /** Non-blocking variant of {@link #listRange}; pages are chained sequentially via futures. */
+  static CompletableFuture<PaginatedRange> listRangeAsync(
+      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs) {
+    return fetchPageAsync(
+        kvClient, prefix, prefix, keysOnly, timeoutMs, REVISION_LATEST, new ArrayList<>());
+  }
+
+  private static CompletableFuture<PaginatedRange> fetchPageAsync(
+      KV kvClient,
+      ByteSequence prefix,
+      ByteSequence fromKey,
+      boolean keysOnly,
+      long timeoutMs,
+      long pinnedRevision,
+      List<KeyValue> keyValues) {
+    return kvClient
+        .get(fromKey, pageOption(prefix, keysOnly, pinnedRevision))
+        .orTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+        .thenCompose(
+            response -> {
+              List<KeyValue> page = response.getKvs();
+              keyValues.addAll(page);
+              long revision =
+                  pinnedRevision > REVISION_LATEST
+                      ? pinnedRevision
+                      : response.getHeader().getRevision();
+              if (!response.isMore() || page.isEmpty()) {
+                return CompletableFuture.completedFuture(new PaginatedRange(keyValues, revision));
+              }
+              return fetchPageAsync(
+                  kvClient,
+                  prefix,
+                  nextKey(page.get(page.size() - 1).getKey()),
+                  keysOnly,
+                  timeoutMs,
+                  revision,
+                  keyValues);
+            });
+  }
+}

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -3,7 +3,6 @@ package com.slack.astra.metadata.core;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
-import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.GetOption;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,17 +21,22 @@ final class EtcdRangePaginator {
   private static final long REVISION_LATEST = 0;
 
   static final long DEFAULT_PAGE_SIZE = 500;
+
+  /**
+   * Appended to a page's last key to resume the next page. etcd keys are byte strings sorted in
+   * lexical byte order, and a range read's start key is inclusive, so resuming from {@code lastKey
+   * + \0} — the smallest key that sorts after {@code lastKey} — reads the next key without
+   * repeating the last one. See the etcd data model for key ordering
+   * (https://etcd.io/docs/v3.5/learning/data_model/); the {@code lastKey + "\x00"} resume pattern
+   * matches the Kubernetes apiserver etcd3 store
+   * (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go).
+   */
   private static final ByteSequence NEXT_KEY_SUFFIX = ByteSequence.from(new byte[] {0});
 
   private EtcdRangePaginator() {}
 
   /** The key/values read under a prefix, with the revision the read was pinned to. */
   record PaginatedRange(List<KeyValue> keyValues, long revision) {}
-
-  /** Smallest key strictly greater than {@code key}, used to advance past the previous page. */
-  private static ByteSequence nextKey(ByteSequence key) {
-    return key.concat(NEXT_KEY_SUFFIX);
-  }
 
   private static GetOption pageOption(ByteSequence prefix, boolean keysOnly, long revision) {
     GetOption.Builder options =
@@ -48,30 +52,12 @@ final class EtcdRangePaginator {
     return options.build();
   }
 
-  /** Reads every key/value under prefix synchronously, one page at a time. */
+  /** Reads every key/value under prefix synchronously by blocking on {@link #listRangeAsync}. */
   static PaginatedRange listRange(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
       throws InterruptedException, ExecutionException, TimeoutException {
-    List<KeyValue> keyValues = new ArrayList<>();
-    ByteSequence fromKey = prefix;
-    long revision = REVISION_LATEST;
-    while (true) {
-      GetResponse response =
-          kvClient
-              .get(fromKey, pageOption(prefix, keysOnly, revision))
-              .get(timeoutMs, TimeUnit.MILLISECONDS);
-
-      List<KeyValue> page = response.getKvs();
-      keyValues.addAll(page);
-      if (revision == REVISION_LATEST) {
-        revision = response.getHeader().getRevision();
-      }
-
-      if (!response.isMore() || page.isEmpty()) {
-        return new PaginatedRange(keyValues, revision);
-      }
-      fromKey = nextKey(page.get(page.size() - 1).getKey());
-    }
+    return listRangeAsync(kvClient, prefix, keysOnly, timeoutMs)
+        .get(timeoutMs, TimeUnit.MILLISECONDS);
   }
 
   /** Non-blocking variant of listRange pages are chained sequentially via futures. */
@@ -106,7 +92,7 @@ final class EtcdRangePaginator {
               return fetchPageAsync(
                   kvClient,
                   prefix,
-                  nextKey(page.get(page.size() - 1).getKey()),
+                  page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX),
                   keysOnly,
                   timeoutMs,
                   revision,

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -18,13 +18,9 @@ import java.util.concurrent.TimeoutException;
  * order, each after the first pinned to the first page's revision for a consistent snapshot.
  */
 final class EtcdRangePaginator {
-  /** Sentinel meaning "read at the latest revision"; etcd treats revision 0 as latest. */
+  /** etcd treats revision 0 as latest. */
   private static final long REVISION_LATEST = 0;
-
-  /** Max entries per page. Protects the 4 MiB limit while per-entry size stays under ~8 KiB. */
   static final long DEFAULT_PAGE_SIZE = 500;
-
-  /** Single zero byte appended to a key to form the smallest key strictly greater than it. */
   private static final ByteSequence NEXT_KEY_SUFFIX = ByteSequence.from(new byte[] {0});
 
   private EtcdRangePaginator() {}
@@ -51,7 +47,7 @@ final class EtcdRangePaginator {
     return options.build();
   }
 
-  /** Reads every key/value under {@code prefix} synchronously, one page at a time. */
+  /** Reads every key/value under prefix synchronously, one page at a time. */
   static PaginatedRange listRange(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
       throws InterruptedException, ExecutionException, TimeoutException {
@@ -77,7 +73,7 @@ final class EtcdRangePaginator {
     }
   }
 
-  /** Non-blocking variant of {@link #listRange}; pages are chained sequentially via futures. */
+  /** Non-blocking variant of listRange pages are chained sequentially via futures. */
   static CompletableFuture<PaginatedRange> listRangeAsync(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs) {
     return fetchPageAsync(

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeoutException;
 final class EtcdRangePaginator {
   /** etcd treats revision 0 as latest. */
   private static final long REVISION_LATEST = 0;
+
   static final long DEFAULT_PAGE_SIZE = 500;
   private static final ByteSequence NEXT_KEY_SUFFIX = ByteSequence.from(new byte[] {0});
 

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -13,27 +13,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Reads every key under a folder prefix, paging the underlying etcd range request so that no single
- * gRPC response can exceed the client's inbound message size limit (4 MiB by default). A single
- * unbounded range read over a large store previously overflowed this limit and failed with {@code
- * RESOURCE_EXHAUSTED} (e.g. a query node loading the search metadata cache, or a partitioning store
- * enumerating partitions in a very large cluster).
- *
- * <p>Pages are read in ascending key order and advanced past the last key of the previous page.
- * Every page after the first is pinned to the revision of the first page, so the aggregated result
- * is a consistent point-in-time snapshot. Both a blocking ({@link #listRange}) and a non-blocking
- * ({@link #listRangeAsync}) variant are provided; each page is individually bounded by {@code
- * timeoutMs}.
+ * Reads every key under a folder prefix, paging the etcd range request so no single gRPC response
+ * exceeds the client's inbound message size limit (4 MiB default). Pages are read in ascending key
+ * order, each after the first pinned to the first page's revision for a consistent snapshot.
  */
 final class EtcdRangePaginator {
   /** Sentinel meaning "read at the latest revision"; etcd treats revision 0 as latest. */
   private static final long REVISION_LATEST = 0;
 
-  /**
-   * Maximum number of entries fetched per etcd range request. Bounds a page by entry count rather
-   * than bytes (etcd's range API has no byte budget), so it protects the default 4 MiB limit only
-   * while per-entry size stays under ~8 KiB — comfortably true for the metadata types stored here.
-   */
+  /** Max entries per page. Protects the 4 MiB limit while per-entry size stays under ~8 KiB. */
   static final long DEFAULT_PAGE_SIZE = 500;
 
   /** Single zero byte appended to a key to form the smallest key strictly greater than it. */
@@ -41,27 +29,14 @@ final class EtcdRangePaginator {
 
   private EtcdRangePaginator() {}
 
-  /**
-   * The key/values read under a folder prefix, together with the etcd revision the read was pinned
-   * to. Callers that establish a watch use {@link #revision()} to start watching from {@code
-   * revision + 1} without missing or replaying events.
-   */
+  /** The key/values read under a prefix, with the revision the read was pinned to. */
   record PaginatedRange(List<KeyValue> keyValues, long revision) {}
 
-  /**
-   * Appends a single zero byte to a key to produce the smallest key strictly greater than it, used
-   * to advance a range read past the last key of the previous page without skipping or repeating
-   * any key.
-   */
+  /** Smallest key strictly greater than {@code key}, used to advance past the previous page. */
   private static ByteSequence nextKey(ByteSequence key) {
     return key.concat(NEXT_KEY_SUFFIX);
   }
 
-  /**
-   * Builds the {@link GetOption} for a single page: key-ascending order, bounded to {@link
-   * #DEFAULT_PAGE_SIZE} entries. When {@code revision} is past {@link #REVISION_LATEST} the read is
-   * pinned to that revision so every page observes one consistent snapshot.
-   */
   private static GetOption pageOption(ByteSequence prefix, boolean keysOnly, long revision) {
     GetOption.Builder options =
         GetOption.builder()
@@ -76,15 +51,7 @@ final class EtcdRangePaginator {
     return options.build();
   }
 
-  /**
-   * Reads every key/value under {@code prefix} synchronously, one page at a time.
-   *
-   * @param kvClient the etcd KV client to read through
-   * @param prefix the folder prefix (including any trailing slash) to range over
-   * @param keysOnly when true, only key metadata is fetched and values are omitted
-   * @param timeoutMs per-page operation timeout
-   * @return the aggregated key/values and the revision they were read at
-   */
+  /** Reads every key/value under {@code prefix} synchronously, one page at a time. */
   static PaginatedRange listRange(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
       throws InterruptedException, ExecutionException, TimeoutException {

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -3,20 +3,17 @@ package com.slack.astra.metadata.core;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
-import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.GetOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Reads every key under a folder prefix, paging the etcd range request so no single gRPC response
- * exceeds the client's inbound message size limit (4 MiB default). Pages are read in ascending key
- * order, each after the first pinned to the first page's revision for a consistent snapshot.
+ * Pages are read in ascending key order, each after the first pinned to the first
+ * page's revision for a consistent snapshot.
  */
 final class EtcdRangePaginator {
   /** etcd treats revision 0 as latest. */
@@ -54,47 +51,47 @@ final class EtcdRangePaginator {
     return options.build();
   }
 
-  /** Reads every key/value under prefix, paging until etcd reports no more keys. */
+  static CompletableFuture<PaginatedRange> listRangeAsync(
+      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs) {
+    return fetchPage(
+        kvClient, prefix, prefix, keysOnly, timeoutMs, REVISION_LATEST, new ArrayList<>());
+  }
+
+  private static CompletableFuture<PaginatedRange> fetchPage(
+      KV kvClient,
+      ByteSequence prefix,
+      ByteSequence fromKey,
+      boolean keysOnly,
+      long timeoutMs,
+      long pinnedRevision,
+      List<KeyValue> keyValues) {
+    return kvClient
+        .get(fromKey, pageOption(prefix, keysOnly, pinnedRevision))
+        .orTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+        .thenCompose(
+            response -> {
+              // Pin every page after the first to the first page's revision for a consistent
+              // snapshot.
+              long revision =
+                  pinnedRevision > REVISION_LATEST
+                      ? pinnedRevision
+                      : response.getHeader().getRevision();
+
+              List<KeyValue> page = response.getKvs();
+              keyValues.addAll(page);
+              if (!response.isMore() || page.isEmpty()) {
+                return CompletableFuture.completedFuture(new PaginatedRange(keyValues, revision));
+              }
+
+              ByteSequence nextKey = page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX);
+              return fetchPage(kvClient, prefix, nextKey, keysOnly, timeoutMs, revision, keyValues);
+            });
+  }
+
   static PaginatedRange listRange(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
       throws InterruptedException, ExecutionException, TimeoutException {
-    List<KeyValue> keyValues = new ArrayList<>();
-    ByteSequence fromKey = prefix;
-    long revision = REVISION_LATEST;
-    GetResponse response;
-    do {
-      response =
-          kvClient
-              .get(fromKey, pageOption(prefix, keysOnly, revision))
-              .get(timeoutMs, TimeUnit.MILLISECONDS);
-
-      List<KeyValue> page = response.getKvs();
-      keyValues.addAll(page);
-      // Pin every page after the first to the first page's revision for a consistent snapshot.
-      if (revision == REVISION_LATEST) {
-        revision = response.getHeader().getRevision();
-      }
-      // Advance past this page; guard against an empty page before indexing into it.
-      if (!page.isEmpty()) {
-        fromKey = page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX);
-      }
-    } while (response.isMore() && !response.getKvs().isEmpty());
-    return new PaginatedRange(keyValues, revision);
-  }
-
-  /** Non-blocking variant that runs {@link #listRange} on the common pool. */
-  static CompletableFuture<PaginatedRange> listRangeAsync(
-      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs) {
-    return CompletableFuture.supplyAsync(
-        () -> {
-          try {
-            return listRange(kvClient, prefix, keysOnly, timeoutMs);
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new CompletionException(e);
-          } catch (ExecutionException | TimeoutException e) {
-            throw new CompletionException(e);
-          }
-        });
+    return listRangeAsync(kvClient, prefix, keysOnly, timeoutMs)
+        .get(timeoutMs, TimeUnit.MILLISECONDS);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -3,10 +3,12 @@ package com.slack.astra.metadata.core;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.options.GetOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -52,51 +54,47 @@ final class EtcdRangePaginator {
     return options.build();
   }
 
-  /** Reads every key/value under prefix synchronously by blocking on {@link #listRangeAsync}. */
+  /** Reads every key/value under prefix, paging until etcd reports no more keys. */
   static PaginatedRange listRange(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return listRangeAsync(kvClient, prefix, keysOnly, timeoutMs)
-        .get(timeoutMs, TimeUnit.MILLISECONDS);
+    List<KeyValue> keyValues = new ArrayList<>();
+    ByteSequence fromKey = prefix;
+    long revision = REVISION_LATEST;
+    GetResponse response;
+    do {
+      response =
+          kvClient
+              .get(fromKey, pageOption(prefix, keysOnly, revision))
+              .get(timeoutMs, TimeUnit.MILLISECONDS);
+
+      List<KeyValue> page = response.getKvs();
+      keyValues.addAll(page);
+      // Pin every page after the first to the first page's revision for a consistent snapshot.
+      if (revision == REVISION_LATEST) {
+        revision = response.getHeader().getRevision();
+      }
+      // Advance past this page; guard against an empty page before indexing into it.
+      if (!page.isEmpty()) {
+        fromKey = page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX);
+      }
+    } while (response.isMore() && !response.getKvs().isEmpty());
+    return new PaginatedRange(keyValues, revision);
   }
 
-  /** Non-blocking variant of listRange pages are chained sequentially via futures. */
+  /** Non-blocking variant that runs {@link #listRange} on the common pool. */
   static CompletableFuture<PaginatedRange> listRangeAsync(
       KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs) {
-    return fetchPageAsync(
-        kvClient, prefix, prefix, keysOnly, timeoutMs, REVISION_LATEST, new ArrayList<>());
-  }
-
-  private static CompletableFuture<PaginatedRange> fetchPageAsync(
-      KV kvClient,
-      ByteSequence prefix,
-      ByteSequence fromKey,
-      boolean keysOnly,
-      long timeoutMs,
-      long pinnedRevision,
-      List<KeyValue> keyValues) {
-    return kvClient
-        .get(fromKey, pageOption(prefix, keysOnly, pinnedRevision))
-        .orTimeout(timeoutMs, TimeUnit.MILLISECONDS)
-        .thenCompose(
-            response -> {
-              List<KeyValue> page = response.getKvs();
-              keyValues.addAll(page);
-              long revision =
-                  pinnedRevision > REVISION_LATEST
-                      ? pinnedRevision
-                      : response.getHeader().getRevision();
-              if (!response.isMore() || page.isEmpty()) {
-                return CompletableFuture.completedFuture(new PaginatedRange(keyValues, revision));
-              }
-              return fetchPageAsync(
-                  kvClient,
-                  prefix,
-                  page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX),
-                  keysOnly,
-                  timeoutMs,
-                  revision,
-                  keyValues);
-            });
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            return listRange(kvClient, prefix, keysOnly, timeoutMs);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CompletionException(e);
+          } catch (ExecutionException | TimeoutException e) {
+            throw new CompletionException(e);
+          }
+        });
   }
 }

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
@@ -6,6 +6,7 @@ import static org.awaitility.Awaitility.await;
 
 import com.slack.astra.proto.config.AstraConfigs;
 import com.slack.astra.testlib.TestEtcdClusterFactory;
+import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import io.etcd.jetcd.launcher.EtcdCluster;
@@ -14,7 +15,9 @@ import io.grpc.StatusRuntimeException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -773,5 +776,82 @@ public class EtcdMetadataStoreTest {
 
     assertThat(EtcdMetadataStore.isCompactionError(new RuntimeException("connection refused")))
         .isFalse();
+  }
+
+  /**
+   * Regression test for the RESOURCE_EXHAUSTED failure that occurred when a full-folder range read
+   * returned a single gRPC response larger than the client's inbound message size limit.
+   * Full-folder reads are now paginated, so no single response can overflow the limit even though
+   * the store holds far more data than one message can carry.
+   */
+  @Test
+  public void testListPaginationHandlesResponsesLargerThanInboundLimit() throws Exception {
+    // ~1 KiB per value so the full range response (~1.1 MiB) exceeds the reader's 1 MiB inbound
+    // limit, while any single LIST_PAGE_SIZE (500) page stays comfortably under it.
+    int entryCount = 1100;
+    String data = "x".repeat(1024);
+
+    // Write via the default (large-limit) client. Names are zero-padded so key order is
+    // deterministic across page boundaries.
+    List<CompletableFuture<String>> creates = new ArrayList<>();
+    for (int i = 0; i < entryCount; i++) {
+      creates.add(
+          store
+              .createAsync(new TestMetadata(String.format("node-%05d", i), data))
+              .toCompletableFuture());
+    }
+    CompletableFuture.allOf(creates.toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
+
+    AstraConfigs.EtcdConfig readerConfig =
+        AstraConfigs.EtcdConfig.newBuilder()
+            .addAllEndpoints(etcdCluster.clientEndpoints().stream().map(Object::toString).toList())
+            .setConnectionTimeoutMs(5000)
+            .setKeepaliveTimeoutMs(3000)
+            .setOperationsMaxRetries(3)
+            .setOperationsTimeoutMs(10000)
+            .setRetryDelayMs(100)
+            .setNamespace("test")
+            .setEphemeralNodeTtlMs(3000)
+            .setEphemeralNodeMaxRetries(3)
+            .build();
+
+    // A reader whose inbound message size is smaller than the full range response. Before
+    // pagination, any full-folder read on this client failed with RESOURCE_EXHAUSTED.
+    Client readerClient =
+        Client.builder()
+            .endpoints(
+                etcdCluster.clientEndpoints().stream().map(Object::toString).toArray(String[]::new))
+            .namespace(ByteSequence.from("test", StandardCharsets.UTF_8))
+            .maxInboundMessageSize(1024 * 1024)
+            .build();
+
+    EtcdMetadataStore<TestMetadata> uncachedReader = null;
+    EtcdMetadataStore<TestMetadata> cachedReader = null;
+    try {
+      // cache disabled -> listSyncUncached()/listSync() page directly against etcd.
+      uncachedReader =
+          new EtcdMetadataStore<>(
+              "/test", readerConfig, false, meterRegistry, serializer, readerClient);
+
+      List<TestMetadata> uncached = uncachedReader.listSyncUncached();
+      assertThat(uncached).hasSize(entryCount);
+      assertThat(uncached.stream().map(TestMetadata::getName).distinct().count())
+          .isEqualTo(entryCount);
+      assertThat(uncachedReader.listSync()).hasSize(entryCount);
+
+      // cache enabled -> exercises the paginated populateInitialCache path (the query node path).
+      cachedReader =
+          new EtcdMetadataStore<>(
+              "/test", readerConfig, true, meterRegistry, serializer, readerClient);
+      assertThat(cachedReader.listSync()).hasSize(entryCount);
+    } finally {
+      if (uncachedReader != null) {
+        uncachedReader.close();
+      }
+      if (cachedReader != null) {
+        cachedReader.close();
+      }
+      readerClient.close();
+    }
   }
 }

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
@@ -787,7 +787,8 @@ public class EtcdMetadataStoreTest {
   @Test
   public void testListPaginationHandlesResponsesLargerThanInboundLimit() throws Exception {
     // ~1 KiB per value so the full range response (~1.1 MiB) exceeds the reader's 1 MiB inbound
-    // limit, while any single LIST_PAGE_SIZE (500) page stays comfortably under it.
+    // limit, while any single page (EtcdRangePaginator.DEFAULT_PAGE_SIZE = 500) stays comfortably
+    // under it.
     int entryCount = 1100;
     String data = "x".repeat(1024);
 

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
@@ -779,16 +779,13 @@ public class EtcdMetadataStoreTest {
   }
 
   /**
-   * Regression test for the RESOURCE_EXHAUSTED failure that occurred when a full-folder range read
-   * returned a single gRPC response larger than the client's inbound message size limit.
-   * Full-folder reads are now paginated, so no single response can overflow the limit even though
-   * the store holds far more data than one message can carry.
+   * Regression test: a full-folder read used to return one gRPC response larger than the inbound
+   * limit. Reads are now paginated, so a large store no longer triggers RESOURCE_EXHAUSTED.
    */
   @Test
   public void testListPaginationHandlesResponsesLargerThanInboundLimit() throws Exception {
-    // ~1 KiB per value so the full range response (~1.1 MiB) exceeds the reader's 1 MiB inbound
-    // limit, while any single page (EtcdRangePaginator.DEFAULT_PAGE_SIZE = 500) stays comfortably
-    // under it.
+    // ~1 KiB per value so the full response (~1.1 MiB) exceeds the reader's 1 MiB inbound limit
+    // while any single page (500 entries) stays under it.
     int entryCount = 1100;
     String data = "x".repeat(1024);
 

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
@@ -14,8 +14,10 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -596,6 +598,77 @@ public class EtcdPartitioningMetadataStoreTest {
       assertThat(result.getData()).isEqualTo("new-data");
 
       assertThat(fatalHandler.getCount()).isEqualTo(0);
+    }
+  }
+
+  /**
+   * Regression test for the RESOURCE_EXHAUSTED failure that occurred when partition discovery read
+   * every key under the store folder in a single gRPC response larger than the client's inbound
+   * message size limit. Discovery is now paginated (and keys-only), so no single response can
+   * overflow the limit even though the store holds far more keys than one message can carry.
+   */
+  @Test
+  public void testPartitionDiscoveryPaginatesLargeKeyOnlyResponses() throws Exception {
+    // ~1 KiB per key (via long names) so the full keys-only range response (~1.1 MiB) exceeds the
+    // reader's 1 MiB inbound limit, while any single page (DEFAULT_PAGE_SIZE = 500) stays under it.
+    // Keys are spread across a handful of partitions so discovery reads many keys but only a few
+    // partition stores are created.
+    int entryCount = 1100;
+    int partitionCount = 4;
+    String pad = "x".repeat(1000);
+
+    List<CompletableFuture<String>> creates = new ArrayList<>();
+    for (int i = 0; i < entryCount; i++) {
+      String partition = "partition-" + (i % partitionCount);
+      String name = String.format("node-%05d-", i) + pad;
+      creates.add(
+          store
+              .createAsync(new TestPartitionedMetadata(name, partition, "d"))
+              .toCompletableFuture());
+    }
+    CompletableFuture.allOf(creates.toArray(new CompletableFuture[0])).get(60, TimeUnit.SECONDS);
+
+    AstraConfigs.EtcdConfig readerConfig =
+        AstraConfigs.EtcdConfig.newBuilder()
+            .addAllEndpoints(etcdCluster.clientEndpoints().stream().map(Object::toString).toList())
+            .setConnectionTimeoutMs(5000)
+            .setKeepaliveTimeoutMs(3000)
+            .setOperationsMaxRetries(3)
+            .setOperationsTimeoutMs(10000)
+            .setRetryDelayMs(100)
+            .setRetryTotalDurationMs(5000)
+            .setMaxRetryDelayMs(1000)
+            .setInitialRetryIntervalMs(100)
+            .setNamespace("test")
+            .build();
+
+    // A reader whose inbound message size is smaller than the full keys-only response. Before
+    // pagination, the cache-enabled constructor's partition discovery failed with
+    // RESOURCE_EXHAUSTED on this client.
+    Client readerClient =
+        Client.builder()
+            .endpoints(
+                etcdCluster.clientEndpoints().stream().map(Object::toString).toArray(String[]::new))
+            .namespace(ByteSequence.from("test", StandardCharsets.UTF_8))
+            .maxInboundMessageSize(1024 * 1024)
+            .build();
+
+    try (EtcdPartitioningMetadataStore<TestPartitionedMetadata> reader =
+        new EtcdPartitioningMetadataStore<>(
+            readerClient,
+            readerConfig,
+            meterRegistry,
+            EtcdCreateMode.PERSISTENT,
+            serializer,
+            "/test")) {
+      reader.awaitCacheInitialized();
+
+      for (int p = 0; p < partitionCount; p++) {
+        assertThat(reader.hasPartition("partition-" + p)).isTrue();
+      }
+      assertThat(reader.listSync()).hasSize(entryCount);
+    } finally {
+      readerClient.close();
     }
   }
 }

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
@@ -602,17 +602,14 @@ public class EtcdPartitioningMetadataStoreTest {
   }
 
   /**
-   * Regression test for the RESOURCE_EXHAUSTED failure that occurred when partition discovery read
-   * every key under the store folder in a single gRPC response larger than the client's inbound
-   * message size limit. Discovery is now paginated (and keys-only), so no single response can
-   * overflow the limit even though the store holds far more keys than one message can carry.
+   * Regression test: partition discovery used to read every key in one gRPC response, overflowing
+   * the inbound limit. It is now paginated, so a large store no longer triggers RESOURCE_EXHAUSTED.
    */
   @Test
   public void testPartitionDiscoveryPaginatesLargeKeyOnlyResponses() throws Exception {
-    // ~1 KiB per key (via long names) so the full keys-only range response (~1.1 MiB) exceeds the
-    // reader's 1 MiB inbound limit, while any single page (DEFAULT_PAGE_SIZE = 500) stays under it.
-    // Keys are spread across a handful of partitions so discovery reads many keys but only a few
-    // partition stores are created.
+    // ~1 KiB per key so the full response (~1.1 MiB) exceeds the reader's 1 MiB inbound limit while
+    // any single page (500 keys) stays under it. Spread over a few partitions to keep store count
+    // low.
     int entryCount = 1100;
     int partitionCount = 4;
     String pad = "x".repeat(1000);
@@ -642,9 +639,8 @@ public class EtcdPartitioningMetadataStoreTest {
             .setNamespace("test")
             .build();
 
-    // A reader whose inbound message size is smaller than the full keys-only response. Before
-    // pagination, the cache-enabled constructor's partition discovery failed with
-    // RESOURCE_EXHAUSTED on this client.
+    // Reader with an inbound limit smaller than the full response; discovery failed here before
+    // pagination.
     Client readerClient =
         Client.builder()
             .endpoints(


### PR DESCRIPTION
###  Summary
In https://github.com/slackhq/astra/pull/1714, we added `keysOnly` and threaded through the `shouldCache` value but query nodes still need to fetch the entire ETCD `SearchMetadataStore` because they need a full cluster view to fan-out searches. This is failing on larger clusters with too many chunks of data due to the 4mb GRPC limit. 

This PR paginates on ETCD calls to prevent ever hitting that limit.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
