### PR TITLE
Fix value_count aggregation JSON serialization

### DIFF
--- a/astra/src/main/java/com/slack/astra/elasticsearchApi/ElasticsearchApiService.java
+++ b/astra/src/main/java/com/slack/astra/elasticsearchApi/ElasticsearchApiService.java
@@ -199,7 +199,9 @@ public class ElasticsearchApiService {
         OpenSearchInternalAggregation.fromByteArray(byteInput.toByteArray());
     if (internalAggregations != null) {
       XContentBuilder builder = XContentFactory.jsonBuilder();
+      builder.startObject();
       internalAggregations.toXContent(builder, ToXContent.EMPTY_PARAMS);
+      builder.endObject();
       return objectMapper.readTree(builder.toString());
     }
     return null;

--- a/astra/src/main/java/com/slack/astra/elasticsearchApi/ElasticsearchApiService.java
+++ b/astra/src/main/java/com/slack/astra/elasticsearchApi/ElasticsearchApiService.java
@@ -42,6 +42,9 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.StructuredTaskScope;
 import java.util.concurrent.TimeUnit;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.search.aggregations.InternalAggregation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,7 +198,9 @@ public class ElasticsearchApiService {
     InternalAggregation internalAggregations =
         OpenSearchInternalAggregation.fromByteArray(byteInput.toByteArray());
     if (internalAggregations != null) {
-      return objectMapper.readTree(internalAggregations.toString());
+      XContentBuilder builder = XContentFactory.jsonBuilder();
+      internalAggregations.toXContent(builder, ToXContent.EMPTY_PARAMS);
+      return objectMapper.readTree(builder.toString());
     }
     return null;
   }


### PR DESCRIPTION
###  Summary

InternalValueCount.toString() returns "count[N]" which is not valid JSON, unlike other aggregation types that inherit the base class toString() producing JSON via toXContent. Use toXContent directly for all aggregation types.

## Testing

All of the unit tests pass, and I tried deploying this locally, and querying it with count aggregations, and getting 200's:

```
yiyuwu@yiyuwu-ltmfpt6 astra-local-test % printf '{"index":"test-logs"}\n{"size":0,"query":{"match_all":{}},"aggs":{"1":{"value_count":{"field":"_timesinceepoch"}}}}\n' | curl -s -X POST  'http://localhost:8081/_msearch' -H 'Content-Type: application/x-ndjson' --data-binary @-
{"took":0,"responses":[{"took":466,"timed_out":false,"_shards":{"total":2,"failed":0},"_debug":{},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"1":{"value":46050}},"status":200}],"_debug":{"traceId":"d2f57eaa91ef05d2"}}%   
```

Confirmed it doesn't break other aggregations:

```
yiyuwu@yiyuwu-ltmfpt6 astra-local-test % printf '{"index":"test-logs"}\n{"size":0,"query":{"match_all":{}},"aggs":{"my_min":{"min":{"field":"sequence"}}}}\n' | curl -s -X POST 'http://localhost:8081/_msearch' -H 'Content-Type: application/x-ndjson' --data-binary @-
{"took":0,"responses":[{"took":369,"timed_out":false,"_shards":{"total":3,"failed":0},"_debug":{},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"my_min":{"value":1.0}},"status":200}],"_debug":{"traceId":"d6848997a30db726"}}%   
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
