### PR TITLE
ETCD Pagination Size and Timeout

### DIFF
--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -87,6 +87,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   protected final boolean shouldCache;
   protected final MetadataSerializer<T> serializer;
   private final long etcdOperationTimeoutMs;
+  private final long listPageSize;
   private final long retryTotalDurationMs;
   private final long maxRetryDelayMs;
   private final long initialRetryIntervalMs;
@@ -191,6 +192,8 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     this.createMode = createMode;
     this.ephemeralTtlMs = config.getEphemeralNodeTtlMs();
     this.etcdOperationTimeoutMs = config.getOperationsTimeoutMs();
+    this.listPageSize =
+        positiveOrDefault(config.getListPageSize(), EtcdRangePaginator.DEFAULT_PAGE_SIZE);
 
     this.retryTotalDurationMs =
         positiveOrDefault(config.getRetryTotalDurationMs(), DEFAULT_RETRY_TOTAL_DURATION_MS);
@@ -872,7 +875,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
 
     return EtcdRangePaginator.listRangeAsync(
-            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs)
+            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize)
         .thenApplyAsync(
             range -> {
               List<T> nodes = new ArrayList<>();
@@ -936,7 +939,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
       List<KeyValue> keyValues =
           EtcdRangePaginator.listRange(
-                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs)
+                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize)
               .keyValues();
 
       List<T> nodes = new ArrayList<>();
@@ -1280,7 +1283,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
       List<KeyValue> keyValues =
           EtcdRangePaginator.listRange(
-                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs)
+                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize)
               .keyValues();
 
       // Filter for only direct children of the store folder
@@ -1350,7 +1353,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
     EtcdRangePaginator.PaginatedRange range =
         EtcdRangePaginator.listRange(
-            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs);
+            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize);
 
     long listRevision = range.revision();
 

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -192,8 +192,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     this.createMode = createMode;
     this.ephemeralTtlMs = config.getEphemeralNodeTtlMs();
     this.etcdOperationTimeoutMs = config.getOperationsTimeoutMs();
-    this.listPageSize =
-        positiveOrDefault(config.getListPageSize(), EtcdRangePaginator.DEFAULT_PAGE_SIZE);
+    this.listPageSize = config.getListPageSize();
 
     this.retryTotalDurationMs =
         positiveOrDefault(config.getRetryTotalDurationMs(), DEFAULT_RETRY_TOTAL_DURATION_MS);

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdMetadataStore.java
@@ -88,6 +88,7 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
   protected final MetadataSerializer<T> serializer;
   private final long etcdOperationTimeoutMs;
   private final long listPageSize;
+  private final long listPageTimeoutMs;
   private final long retryTotalDurationMs;
   private final long maxRetryDelayMs;
   private final long initialRetryIntervalMs;
@@ -193,6 +194,9 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     this.ephemeralTtlMs = config.getEphemeralNodeTtlMs();
     this.etcdOperationTimeoutMs = config.getOperationsTimeoutMs();
     this.listPageSize = config.getListPageSize();
+    // Falls back to the operation timeout when unset, preserving prior behavior.
+    this.listPageTimeoutMs =
+        positiveOrDefault(config.getListPageTimeoutMs(), etcdOperationTimeoutMs);
 
     this.retryTotalDurationMs =
         positiveOrDefault(config.getRetryTotalDurationMs(), DEFAULT_RETRY_TOTAL_DURATION_MS);
@@ -874,7 +878,12 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
 
     return EtcdRangePaginator.listRangeAsync(
-            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize)
+            etcdClient.getKVClient(),
+            prefix,
+            false,
+            etcdOperationTimeoutMs,
+            listPageTimeoutMs,
+            listPageSize)
         .thenApplyAsync(
             range -> {
               List<T> nodes = new ArrayList<>();
@@ -938,7 +947,12 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
       List<KeyValue> keyValues =
           EtcdRangePaginator.listRange(
-                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize)
+                  etcdClient.getKVClient(),
+                  prefix,
+                  false,
+                  etcdOperationTimeoutMs,
+                  listPageTimeoutMs,
+                  listPageSize)
               .keyValues();
 
       List<T> nodes = new ArrayList<>();
@@ -1282,7 +1296,12 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
       ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
       List<KeyValue> keyValues =
           EtcdRangePaginator.listRange(
-                  etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize)
+                  etcdClient.getKVClient(),
+                  prefix,
+                  false,
+                  etcdOperationTimeoutMs,
+                  listPageTimeoutMs,
+                  listPageSize)
               .keyValues();
 
       // Filter for only direct children of the store folder
@@ -1352,7 +1371,12 @@ public class EtcdMetadataStore<T extends AstraMetadata> implements Closeable {
     ByteSequence prefix = ByteSequence.from(storeFolder + "/", StandardCharsets.UTF_8);
     EtcdRangePaginator.PaginatedRange range =
         EtcdRangePaginator.listRange(
-            etcdClient.getKVClient(), prefix, false, etcdOperationTimeoutMs, listPageSize);
+            etcdClient.getKVClient(),
+            prefix,
+            false,
+            etcdOperationTimeoutMs,
+            listPageTimeoutMs,
+            listPageSize);
 
     long listRevision = range.revision();
 

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -79,6 +79,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private final long maxRetryDelayMs;
   private final long initialRetryIntervalMs;
   private final long listPageSize;
+  private final long listPageTimeoutMs;
   private final ReentrantLock watchLock = new ReentrantLock();
   private Watch.Watcher partitionWatcher;
   private volatile boolean closing = false;
@@ -180,6 +181,11 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
             etcdConfig.getInitialRetryIntervalMs(),
             EtcdMetadataStore.DEFAULT_INITIAL_RETRY_INTERVAL_MS);
     this.listPageSize = etcdConfig.getListPageSize();
+    // Falls back to the connection timeout (used as the operation timeout for list reads here) when
+    // unset, preserving prior behavior.
+    this.listPageTimeoutMs =
+        EtcdMetadataStore.positiveOrDefault(
+            etcdConfig.getListPageTimeoutMs(), etcdConfig.getConnectionTimeoutMs());
     this.executorService =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder()
@@ -718,6 +724,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
                   prefix,
                   true,
                   etcdConfig.getConnectionTimeoutMs(),
+                  listPageTimeoutMs,
                   listPageSize)
               .keyValues());
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
@@ -753,6 +760,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
             prefix,
             true,
             etcdConfig.getConnectionTimeoutMs(),
+            listPageTimeoutMs,
             listPageSize);
 
     long listRevision = range.revision();

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -179,9 +179,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
         EtcdMetadataStore.positiveOrDefault(
             etcdConfig.getInitialRetryIntervalMs(),
             EtcdMetadataStore.DEFAULT_INITIAL_RETRY_INTERVAL_MS);
-    this.listPageSize =
-        EtcdMetadataStore.positiveOrDefault(
-            etcdConfig.getListPageSize(), EtcdRangePaginator.DEFAULT_PAGE_SIZE);
+    this.listPageSize = etcdConfig.getListPageSize();
     this.executorService =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder()

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStore.java
@@ -78,6 +78,7 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
   private final long retryTotalDurationMs;
   private final long maxRetryDelayMs;
   private final long initialRetryIntervalMs;
+  private final long listPageSize;
   private final ReentrantLock watchLock = new ReentrantLock();
   private Watch.Watcher partitionWatcher;
   private volatile boolean closing = false;
@@ -178,6 +179,9 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
         EtcdMetadataStore.positiveOrDefault(
             etcdConfig.getInitialRetryIntervalMs(),
             EtcdMetadataStore.DEFAULT_INITIAL_RETRY_INTERVAL_MS);
+    this.listPageSize =
+        EtcdMetadataStore.positiveOrDefault(
+            etcdConfig.getListPageSize(), EtcdRangePaginator.DEFAULT_PAGE_SIZE);
     this.executorService =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder()
@@ -712,7 +716,11 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
       ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
       return extractPartitions(
           EtcdRangePaginator.listRange(
-                  etcdClient.getKVClient(), prefix, true, etcdConfig.getConnectionTimeoutMs())
+                  etcdClient.getKVClient(),
+                  prefix,
+                  true,
+                  etcdConfig.getConnectionTimeoutMs(),
+                  listPageSize)
               .keyValues());
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new InternalMetadataStoreException("Error fetching partitions from etcd", e);
@@ -743,7 +751,11 @@ public class EtcdPartitioningMetadataStore<T extends AstraPartitionedMetadata>
     ByteSequence prefix = ByteSequence.from(storeFolderPrefix, StandardCharsets.UTF_8);
     EtcdRangePaginator.PaginatedRange range =
         EtcdRangePaginator.listRange(
-            etcdClient.getKVClient(), prefix, true, etcdConfig.getConnectionTimeoutMs());
+            etcdClient.getKVClient(),
+            prefix,
+            true,
+            etcdConfig.getConnectionTimeoutMs(),
+            listPageSize);
 
     long listRevision = range.revision();
 

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -19,7 +19,7 @@ final class EtcdRangePaginator {
   /** etcd treats revision 0 as latest. */
   private static final long REVISION_LATEST = 0;
 
-  static final long DEFAULT_PAGE_SIZE = 500;
+  static final long DEFAULT_PAGE_SIZE = 10000;
 
   /**
    * Appended to a page's last key to resume the next page. etcd keys are byte strings sorted in

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -37,11 +37,12 @@ final class EtcdRangePaginator {
   /** The key/values read under a prefix, with the revision the read was pinned to. */
   record PaginatedRange(List<KeyValue> keyValues, long revision) {}
 
-  private static GetOption pageOption(ByteSequence prefix, boolean keysOnly, long revision) {
+  private static GetOption pageOption(
+      ByteSequence prefix, boolean keysOnly, long revision, long pageSize) {
     GetOption.Builder options =
         GetOption.builder()
             .withPrefix(prefix)
-            .withLimit(DEFAULT_PAGE_SIZE)
+            .withLimit(pageSize)
             .withSortField(GetOption.SortTarget.KEY)
             .withSortOrder(GetOption.SortOrder.ASCEND)
             .withKeysOnly(keysOnly);
@@ -52,9 +53,16 @@ final class EtcdRangePaginator {
   }
 
   static CompletableFuture<PaginatedRange> listRangeAsync(
-      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs) {
+      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs, long pageSize) {
     return fetchPage(
-        kvClient, prefix, prefix, keysOnly, timeoutMs, REVISION_LATEST, new ArrayList<>());
+        kvClient,
+        prefix,
+        prefix,
+        keysOnly,
+        timeoutMs,
+        pageSize,
+        REVISION_LATEST,
+        new ArrayList<>());
   }
 
   private static CompletableFuture<PaginatedRange> fetchPage(
@@ -63,10 +71,11 @@ final class EtcdRangePaginator {
       ByteSequence fromKey,
       boolean keysOnly,
       long timeoutMs,
+      long pageSize,
       long pinnedRevision,
       List<KeyValue> keyValues) {
     return kvClient
-        .get(fromKey, pageOption(prefix, keysOnly, pinnedRevision))
+        .get(fromKey, pageOption(prefix, keysOnly, pinnedRevision, pageSize))
         .orTimeout(timeoutMs, TimeUnit.MILLISECONDS)
         .thenCompose(
             response -> {
@@ -84,14 +93,15 @@ final class EtcdRangePaginator {
               }
 
               ByteSequence nextKey = page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX);
-              return fetchPage(kvClient, prefix, nextKey, keysOnly, timeoutMs, revision, keyValues);
+              return fetchPage(
+                  kvClient, prefix, nextKey, keysOnly, timeoutMs, pageSize, revision, keyValues);
             });
   }
 
   static PaginatedRange listRange(
-      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs)
+      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs, long pageSize)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return listRangeAsync(kvClient, prefix, keysOnly, timeoutMs)
+    return listRangeAsync(kvClient, prefix, keysOnly, timeoutMs, pageSize)
         .get(timeoutMs, TimeUnit.MILLISECONDS);
   }
 }

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -19,8 +19,6 @@ final class EtcdRangePaginator {
   /** etcd treats revision 0 as latest. */
   private static final long REVISION_LATEST = 0;
 
-  static final long DEFAULT_PAGE_SIZE = 10000;
-
   /**
    * Appended to a page's last key to resume the next page. etcd keys are byte strings sorted in
    * lexical byte order, and a range read's start key is inclusive, so resuming from {@code lastKey

--- a/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
+++ b/astra/src/main/java/com/slack/astra/metadata/core/EtcdRangePaginator.java
@@ -50,17 +50,28 @@ final class EtcdRangePaginator {
     return options.build();
   }
 
+  /**
+   * {@code pageTimeoutMs} bounds each page read independently; {@code operationTimeoutMs} bounds
+   * the whole (possibly multi-page) list so the returned future cannot outlast it even when
+   * consumed without a blocking {@code get}.
+   */
   static CompletableFuture<PaginatedRange> listRangeAsync(
-      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs, long pageSize) {
+      KV kvClient,
+      ByteSequence prefix,
+      boolean keysOnly,
+      long operationTimeoutMs,
+      long pageTimeoutMs,
+      long pageSize) {
     return fetchPage(
-        kvClient,
-        prefix,
-        prefix,
-        keysOnly,
-        timeoutMs,
-        pageSize,
-        REVISION_LATEST,
-        new ArrayList<>());
+            kvClient,
+            prefix,
+            prefix,
+            keysOnly,
+            pageTimeoutMs,
+            pageSize,
+            REVISION_LATEST,
+            new ArrayList<>())
+        .orTimeout(operationTimeoutMs, TimeUnit.MILLISECONDS);
   }
 
   private static CompletableFuture<PaginatedRange> fetchPage(
@@ -68,13 +79,13 @@ final class EtcdRangePaginator {
       ByteSequence prefix,
       ByteSequence fromKey,
       boolean keysOnly,
-      long timeoutMs,
+      long pageTimeoutMs,
       long pageSize,
       long pinnedRevision,
       List<KeyValue> keyValues) {
     return kvClient
         .get(fromKey, pageOption(prefix, keysOnly, pinnedRevision, pageSize))
-        .orTimeout(timeoutMs, TimeUnit.MILLISECONDS)
+        .orTimeout(pageTimeoutMs, TimeUnit.MILLISECONDS)
         .thenCompose(
             response -> {
               // Pin every page after the first to the first page's revision for a consistent
@@ -92,14 +103,26 @@ final class EtcdRangePaginator {
 
               ByteSequence nextKey = page.get(page.size() - 1).getKey().concat(NEXT_KEY_SUFFIX);
               return fetchPage(
-                  kvClient, prefix, nextKey, keysOnly, timeoutMs, pageSize, revision, keyValues);
+                  kvClient,
+                  prefix,
+                  nextKey,
+                  keysOnly,
+                  pageTimeoutMs,
+                  pageSize,
+                  revision,
+                  keyValues);
             });
   }
 
   static PaginatedRange listRange(
-      KV kvClient, ByteSequence prefix, boolean keysOnly, long timeoutMs, long pageSize)
+      KV kvClient,
+      ByteSequence prefix,
+      boolean keysOnly,
+      long operationTimeoutMs,
+      long pageTimeoutMs,
+      long pageSize)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return listRangeAsync(kvClient, prefix, keysOnly, timeoutMs, pageSize)
-        .get(timeoutMs, TimeUnit.MILLISECONDS);
+    return listRangeAsync(kvClient, prefix, keysOnly, operationTimeoutMs, pageTimeoutMs, pageSize)
+        .get(operationTimeoutMs, TimeUnit.MILLISECONDS);
   }
 }

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -105,6 +105,9 @@ message EtcdConfig {
   // Initial interval for exponential backoff (ms). The first retry delay is
   // randomized around this value; subsequent intervals grow by a multiplier.
   int32 initial_retry_interval_ms = 15;
+  // Maximum number of keys read per page when paginating range (list) reads.
+  // When 0, a default is applied.
+  int32 list_page_size = 16;
 }
 
 // Configuration for Zookeeper metadata store.

--- a/astra/src/main/proto/astra_configs.proto
+++ b/astra/src/main/proto/astra_configs.proto
@@ -108,6 +108,11 @@ message EtcdConfig {
   // Maximum number of keys read per page when paginating range (list) reads.
   // When 0, a default is applied.
   int32 list_page_size = 16;
+  // Timeout for a single page read when paginating range (list) reads. This
+  // bounds each page independently, separately from the overall operation
+  // timeout that bounds the whole (possibly multi-page) list. When 0, the
+  // operation timeout is used per page.
+  int32 list_page_timeout_ms = 17;
 }
 
 // Configuration for Zookeeper metadata store.

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdMetadataStoreTest.java
@@ -136,6 +136,7 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(3000)
             .setEphemeralNodeMaxRetries(3)
+            .setListPageSize(10000)
             .build();
 
     // Create etcd client
@@ -362,6 +363,7 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(3000)
             .setEphemeralNodeMaxRetries(3)
+            .setListPageSize(10000)
             .build();
 
     EtcdMetadataStore<TestMetadata> newStore = null;
@@ -460,6 +462,7 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(2000) // Short TTL for faster testing
             .setEphemeralNodeMaxRetries(2) // Test retry logic with 2 retries
+            .setListPageSize(10000)
             .build();
 
     ClientBuilder clientBuilder =
@@ -538,6 +541,7 @@ public class EtcdMetadataStoreTest {
             .setRetryTotalDurationMs(5000)
             .setMaxRetryDelayMs(1000)
             .setInitialRetryIntervalMs(100)
+            .setListPageSize(10000)
             .build();
 
     // Create client for failure test
@@ -603,6 +607,7 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(1500) // Short TTL for faster testing
             .setEphemeralNodeMaxRetries(3)
+            .setListPageSize(10000)
             .build();
 
     // Create client for interrupt test
@@ -675,6 +680,7 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(3000)
             .setEphemeralNodeMaxRetries(3)
+            .setListPageSize(10000)
             .build();
 
     // Create client builder for test
@@ -811,6 +817,7 @@ public class EtcdMetadataStoreTest {
             .setNamespace("test")
             .setEphemeralNodeTtlMs(3000)
             .setEphemeralNodeMaxRetries(3)
+            .setListPageSize(500)
             .build();
 
     // A reader whose inbound message size is smaller than the full range response. Before

--- a/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
+++ b/astra/src/test/java/com/slack/astra/metadata/core/EtcdPartitioningMetadataStoreTest.java
@@ -160,6 +160,7 @@ public class EtcdPartitioningMetadataStoreTest {
             .setMaxRetryDelayMs(1000)
             .setInitialRetryIntervalMs(100)
             .setNamespace("test")
+            .setListPageSize(10000)
             .build();
 
     // Build the etcd client
@@ -448,6 +449,7 @@ public class EtcdPartitioningMetadataStoreTest {
             .setMaxRetryDelayMs(1000)
             .setInitialRetryIntervalMs(100)
             .setNamespace("test")
+            .setListPageSize(10000)
             .build();
 
     // Use try-with-resources to ensure proper closing
@@ -637,6 +639,7 @@ public class EtcdPartitioningMetadataStoreTest {
             .setMaxRetryDelayMs(1000)
             .setInitialRetryIntervalMs(100)
             .setNamespace("test")
+            .setListPageSize(500)
             .build();
 
     // Reader with an inbound limit smaller than the full response; discovery failed here before

--- a/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
+++ b/astra/src/test/java/com/slack/astra/testlib/AstraConfigUtil.java
@@ -83,6 +83,7 @@ public class AstraConfigUtil {
             .setRetryTotalDurationMs(60000)
             .setMaxRetryDelayMs(10000)
             .setInitialRetryIntervalMs(2000)
+            .setListPageSize(10000)
             .build();
     AstraConfigs.MetadataStoreConfig metadataStoreConfig =
         AstraConfigs.MetadataStoreConfig.newBuilder()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -81,6 +81,7 @@ metadataStoreConfig:
     retryTotalDurationMs: ${ASTRA_ETCD_RETRY_TOTAL_DURATION_MS:-60000}
     maxRetryDelayMs: ${ASTRA_ETCD_MAX_RETRY_DELAY_MS:-10000}
     initialRetryIntervalMs: ${ASTRA_ETCD_INITIAL_RETRY_INTERVAL_MS:-2000}
+    listPageSize: ${ASTRA_ETCD_LIST_PAGE_SIZE:-10000}
   storeModes:
     DatasetMetadataStore: ${ASTRA_DATASET_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}
     SnapshotMetadataStore: ${ASTRA_SNAPSHOT_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -82,6 +82,7 @@ metadataStoreConfig:
     maxRetryDelayMs: ${ASTRA_ETCD_MAX_RETRY_DELAY_MS:-10000}
     initialRetryIntervalMs: ${ASTRA_ETCD_INITIAL_RETRY_INTERVAL_MS:-2000}
     listPageSize: ${ASTRA_ETCD_LIST_PAGE_SIZE:-10000}
+    listPageTimeoutMs: ${ASTRA_ETCD_LIST_PAGE_TIMEOUT_MS:-15000}
   storeModes:
     DatasetMetadataStore: ${ASTRA_DATASET_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}
     SnapshotMetadataStore: ${ASTRA_SNAPSHOT_METADATA_STORE_MODE:-ZOOKEEPER_CREATES}


### PR DESCRIPTION
###  Summary
At larger scales, the ETCD pagination was timing out. This PR:
- Adds a configurable per-page timeout that is lower than the overall etcd operation timeout
- Makes the page size configurable instead of hardcoded

### Requirements

* [x] I've read and understood the [Contributing Guidelines](CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
